### PR TITLE
Short Conditional Statements with Constructor Property Promotion

### DIFF
--- a/src/MultiSelectPrompt.php
+++ b/src/MultiSelectPrompt.php
@@ -13,20 +13,6 @@ class MultiSelectPrompt extends Prompt
     public int $highlighted = 0;
 
     /**
-     * The options for the multi-select prompt.
-     *
-     * @var array<int|string, string>
-     */
-    public array $options;
-
-    /**
-     * The default values the multi-select prompt.
-     *
-     * @var array<int|string>
-     */
-    public array $default;
-
-    /**
      * The selected values.
      *
      * @var array<int|string>
@@ -41,8 +27,8 @@ class MultiSelectPrompt extends Prompt
      */
     public function __construct(
         public string $label,
-        array|Collection $options,
-        array|Collection $default = [],
+        public array|Collection $options,
+        public array|Collection $default = [],
         public int $scroll = 5,
         public bool|string $required = false,
         public ?Closure $validate = null,

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -90,15 +90,12 @@ class SearchPrompt extends Prompt
      */
     protected function highlightPrevious(): void
     {
-        if ($this->matches === []) {
-            $this->highlighted = null;
-        } elseif ($this->highlighted === null) {
-            $this->highlighted = count($this->matches) - 1;
-        } elseif ($this->highlighted === 0) {
-            $this->highlighted = null;
-        } else {
-            $this->highlighted = $this->highlighted - 1;
-        }
+        $this->highlighted = match(true){
+            $this->matches === [] => null,
+            $this->highlighted === null => count($this->matches) - 1,
+            $this->highlighted === 0 => null,
+            default => $this->highlighted - 1,
+        };
     }
 
     /**
@@ -106,13 +103,11 @@ class SearchPrompt extends Prompt
      */
     protected function highlightNext(): void
     {
-        if ($this->matches === []) {
-            $this->highlighted = null;
-        } elseif ($this->highlighted === null) {
-            $this->highlighted = 0;
-        } else {
-            $this->highlighted = $this->highlighted === count($this->matches) - 1 ? null : $this->highlighted + 1;
-        }
+        $this->highlighted = match (true) {
+            $this->matches === [] => null,
+            $this->highlighted === null => 0,
+            default => $this->highlighted === count($this->matches) - 1 ? null : $this->highlighted + 1,
+        };
     }
 
     public function searchValue(): string

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -13,20 +13,13 @@ class SelectPrompt extends Prompt
     public int $highlighted = 0;
 
     /**
-     * The options for the select prompt.
-     *
-     * @var array<int|string, string>
-     */
-    public array $options;
-
-    /**
      * Create a new SelectPrompt instance.
      *
      * @param  array<int|string, string>|Collection<int|string, string>  $options
      */
     public function __construct(
         public string $label,
-        array|Collection $options,
+        public array|Collection $options,
         public int|string|null $default = null,
         public int $scroll = 5,
         public ?Closure $validate = null,
@@ -34,11 +27,9 @@ class SelectPrompt extends Prompt
         $this->options = $options instanceof Collection ? $options->all() : $options;
 
         if ($this->default) {
-            if (array_is_list($this->options)) {
-                $this->highlighted = array_search($this->default, $this->options) ?: 0;
-            } else {
-                $this->highlighted = array_search($this->default, array_keys($this->options)) ?: 0;
-            }
+            $haystack = array_is_list($this->options) ? $this->options : array_keys($this->options);
+
+            $this->highlighted = array_search($this->default, $haystack) ?: 0;
         }
 
         $this->on('key', fn ($key) => match ($key) {
@@ -56,9 +47,9 @@ class SelectPrompt extends Prompt
     {
         if (array_is_list($this->options)) {
             return $this->options[$this->highlighted] ?? null;
-        } else {
-            return array_keys($this->options)[$this->highlighted];
         }
+
+        return array_keys($this->options)[$this->highlighted];
     }
 
     /**
@@ -68,9 +59,9 @@ class SelectPrompt extends Prompt
     {
         if (array_is_list($this->options)) {
             return $this->options[$this->highlighted] ?? null;
-        } else {
-            return $this->options[array_keys($this->options)[$this->highlighted]] ?? null;
         }
+
+        return $this->options[array_keys($this->options)[$this->highlighted]] ?? null;
     }
 
     /**

--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -60,15 +60,7 @@ class Spinner extends Prompt
 
             $pid = pcntl_fork();
 
-            if ($pid === 0) {
-                while (true) { // @phpstan-ignore-line
-                    $this->render();
-
-                    $this->count++;
-
-                    usleep($this->interval * 1000);
-                }
-            } else {
+            if ($pid !== 0) {
                 $result = $callback();
                 posix_kill($pid, SIGHUP);
                 $lines = explode(PHP_EOL, $this->prevFrame);
@@ -79,6 +71,14 @@ class Spinner extends Prompt
                 pcntl_signal(SIGINT, SIG_DFL);
 
                 return $result;
+            }
+
+            while (true) { // @phpstan-ignore-line
+                $this->render();
+
+                $this->count++;
+
+                usleep($this->interval * 1000);
             }
         } catch (\Throwable $e) {
             $this->showCursor();

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -16,13 +16,6 @@ class SuggestPrompt extends Prompt
     public ?int $highlighted = null;
 
     /**
-     * The options for the suggest prompt.
-     *
-     * @var array<string>|Closure(string): array<string>
-     */
-    public array|Closure $options;
-
-    /**
      * The cache of matches.
      *
      * @var array<string>|null
@@ -36,7 +29,7 @@ class SuggestPrompt extends Prompt
      */
     public function __construct(
         public string $label,
-        array|Collection|Closure $options,
+        public array|Collection|Closure $options,
         public string $placeholder = '',
         public string $default = '',
         public int $scroll = 5,
@@ -102,15 +95,12 @@ class SuggestPrompt extends Prompt
      */
     protected function highlightPrevious(): void
     {
-        if ($this->matches() === []) {
-            $this->highlighted = null;
-        } elseif ($this->highlighted === null) {
-            $this->highlighted = count($this->matches()) - 1;
-        } elseif ($this->highlighted === 0) {
-            $this->highlighted = null;
-        } else {
-            $this->highlighted = $this->highlighted - 1;
-        }
+        $this->highlighted = match (true) {
+            $this->matches() === [] => null,
+            $this->highlighted === null => count($this->matches()) - 1,
+            $this->highlighted === 0 => null,
+            default => $this->highlighted - 1,
+        };
     }
 
     /**
@@ -118,13 +108,11 @@ class SuggestPrompt extends Prompt
      */
     protected function highlightNext(): void
     {
-        if ($this->matches() === []) {
-            $this->highlighted = null;
-        } elseif ($this->highlighted === null) {
-            $this->highlighted = 0;
-        } else {
-            $this->highlighted = $this->highlighted === count($this->matches()) - 1 ? null : $this->highlighted + 1;
-        }
+        $this->highlighted = match (true) {
+            $this->matches() === [] => null,
+            $this->highlighted === null => 0,
+            default => $this->highlighted === count($this->matches()) - 1 ? null : $this->highlighted + 1,
+        };
     }
 
     /**

--- a/src/Themes/Default/MultiSelectPromptRenderer.php
+++ b/src/Themes/Default/MultiSelectPromptRenderer.php
@@ -57,11 +57,11 @@ class MultiSelectPromptRenderer extends Renderer
                 ->map(fn ($label) => $this->truncate($this->format($label), $prompt->terminal()->cols() - 12))
                 ->map(function ($label, $index) use ($prompt) {
                     $active = $index === $prompt->highlighted;
-                    if (array_is_list($prompt->options)) {
-                        $value = $prompt->options[$index];
-                    } else {
-                        $value = array_keys($prompt->options)[$index];
-                    }
+
+                    $value = array_is_list($prompt->options)
+                        ? $prompt->options[$index]
+                        : array_keys($prompt->options)[$index];
+
                     $selected = in_array($value, $prompt->value());
 
                     if ($prompt->state === 'cancel') {


### PR DESCRIPTION
In this PR, we aim to enhance our codebase by implementing shorter conditional statements using the constructor property promotion feature, a new addition to PHP as of PHP 8.0.

**What's the Goal?**
The goal of this pull request is to leverage the powerful constructor property promotion feature to simplify our codebase and make it more concise, readable, and maintainable. By employing this new PHP feature, we can significantly reduce boilerplate code when initializing object properties through constructor arguments.

**Key Changes:**
1. **Constructor Property Promotion:**
   We will be refactoring existing class constructors to take advantage of the constructor property promotion feature. Instead of manually assigning arguments to properties inside the constructor, we can now directly assign them as constructor parameters, saving us time and effort.

2. **Shorter Conditional Statements:**
   By utilizing constructor property promotion, we can also improve the readability of our code by reducing the need for lengthy conditional statements. With this feature, we can ensure that properties are correctly initialized without the clutter of excessive if-else blocks.

**Why is this Important?**
By adopting constructor property promotion, we can make our code more elegant and straightforward, ultimately leading to increased developer productivity and better code maintenance. This update aligns our codebase with modern PHP practices and embraces the latest features introduced in PHP 8.0.

Thank you for contributing to this important update! Let's make our codebase even better together. Happy coding!