### PR TITLE
(feat) Add `P` class with static methods

### DIFF
--- a/playground/confirm.php
+++ b/playground/confirm.php
@@ -1,10 +1,10 @@
 <?php
 
-use function Laravel\Prompts\confirm;
+use Laravel\Prompts\P;
 
 require __DIR__.'/../vendor/autoload.php';
 
-$confirmed = confirm(
+$confirmed = P::confirm(
     label: 'Would you like to install dependencies?',
     validate: fn ($value) => match ($value) {
         false => 'You must install dependencies.',

--- a/playground/index.php
+++ b/playground/index.php
@@ -1,24 +1,12 @@
 <?php
 
-use function Laravel\Prompts\alert;
-use function Laravel\Prompts\confirm;
-use function Laravel\Prompts\error;
-use function Laravel\Prompts\intro;
-use function Laravel\Prompts\multiselect;
-use function Laravel\Prompts\note;
-use function Laravel\Prompts\outro;
-use function Laravel\Prompts\password;
-use function Laravel\Prompts\select;
-use function Laravel\Prompts\spin;
-use function Laravel\Prompts\suggest;
-use function Laravel\Prompts\text;
-use function Laravel\Prompts\warning;
+use Laravel\Prompts\P;
 
 require __DIR__.'/../vendor/autoload.php';
 
-intro('Welcome to Laravel');
+P::intro('Welcome to Laravel');
 
-$name = suggest(
+$name = P::suggest(
     label: 'What is your name?',
     placeholder: 'E.g. Taylor Otwell',
     options: [
@@ -38,7 +26,7 @@ $name = suggest(
     },
 );
 
-$path = text(
+$path = P::text(
     label: 'Where should we create your project?',
     placeholder: 'E.g. ./laravel',
     validate: fn ($value) => match (true) {
@@ -48,7 +36,7 @@ $path = text(
     },
 );
 
-$password = password(
+$password = P::password(
     label: 'Provide a password',
     validate: fn ($value) => match (true) {
         ! $value => 'Please enter a password.',
@@ -57,7 +45,7 @@ $password = password(
     },
 );
 
-$type = select(
+$type = P::select(
     label: 'Pick a project type',
     default: 'ts',
     options: [
@@ -66,7 +54,7 @@ $type = select(
     ],
 );
 
-$tools = multiselect(
+$tools = P::multiselect(
     label: 'Select additional tools.',
     default: ['pint', 'eslint'],
     options: [
@@ -81,19 +69,19 @@ $tools = multiselect(
     }
 );
 
-$install = confirm(
+$install = P::confirm(
     label: 'Install dependencies?',
 );
 
 if ($install) {
-    spin(fn () => sleep(3), 'Installing dependencies...');
+    P::spin(fn () => sleep(3), 'Installing dependencies...');
 }
 
-error('Error');
-warning('Warning');
-alert('Alert');
+P::error('Error');
+P::warning('Warning');
+P::alert('Alert');
 
-note(<<<EOT
+P::note(<<<EOT
     Installation complete!
 
     To get started, run:
@@ -102,6 +90,6 @@ note(<<<EOT
         php artisan serve
     EOT);
 
-outro('Happy coding!');
+P::outro('Happy coding!');
 
 var_dump(compact('name', 'path', 'password', 'type', 'tools', 'install'));

--- a/playground/multiselect.php
+++ b/playground/multiselect.php
@@ -1,10 +1,10 @@
 <?php
 
-use function Laravel\Prompts\multiselect;
+use Laravel\Prompts\P;
 
 require __DIR__.'/../vendor/autoload.php';
 
-$permissions = multiselect(
+$permissions = P::multiselect(
     label: 'What permissions should the user have?',
     options: [
         'view' => 'View',

--- a/playground/notes.php
+++ b/playground/notes.php
@@ -1,17 +1,12 @@
 <?php
 
-use function Laravel\Prompts\alert;
-use function Laravel\Prompts\error;
-use function Laravel\Prompts\intro;
-use function Laravel\Prompts\note;
-use function Laravel\Prompts\outro;
-use function Laravel\Prompts\warning;
+use Laravel\Prompts\P;
 
 require __DIR__.'/../vendor/autoload.php';
 
-intro('Intro');
-note('Note');
-warning('Warning');
-error('Error');
-alert('Alert');
-outro('Outro');
+P::intro('Intro');
+P::note('Note');
+P::warning('Warning');
+P::error('Error');
+P::alert('Alert');
+P::outro('Outro');

--- a/playground/password.php
+++ b/playground/password.php
@@ -1,10 +1,10 @@
 <?php
 
-use function Laravel\Prompts\password;
+use Laravel\Prompts\P;
 
 require __DIR__.'/../vendor/autoload.php';
 
-$password = password(
+$password = P::password(
     label: 'Please provide a password',
     placeholder: 'Min 8 characters',
     required: true,

--- a/playground/search.php
+++ b/playground/search.php
@@ -1,10 +1,10 @@
 <?php
 
-use function Laravel\Prompts\search;
+use Laravel\Prompts\P;
 
 require __DIR__.'/../vendor/autoload.php';
 
-$model = search(
+$model = P::search(
     label: 'Which user should receive the email?',
     placeholder: 'Search...',
     options: function ($value) {

--- a/playground/select.php
+++ b/playground/select.php
@@ -1,10 +1,10 @@
 <?php
 
-use function Laravel\Prompts\select;
+use Laravel\Prompts\P;
 
 require __DIR__.'/../vendor/autoload.php';
 
-$role = select(
+$role = P::select(
     label: 'What role should the user have?',
     options: [
         'read-only' => 'Read only',

--- a/playground/spin.php
+++ b/playground/spin.php
@@ -1,10 +1,10 @@
 <?php
 
-use function Laravel\Prompts\spin;
+use Laravel\Prompts\P;
 
 require __DIR__.'/../vendor/autoload.php';
 
-$result = spin(
+$result = P::spin(
     function () {
         sleep(4);
 

--- a/playground/suggest.php
+++ b/playground/suggest.php
@@ -1,10 +1,10 @@
 <?php
 
-use function Laravel\Prompts\suggest;
+use Laravel\Prompts\P;
 
 require __DIR__.'/../vendor/autoload.php';
 
-$model = suggest(
+$model = P::suggest(
     label: 'What model should the policy apply to?',
     placeholder: 'E.g. User',
     options: [

--- a/playground/text.php
+++ b/playground/text.php
@@ -1,10 +1,10 @@
 <?php
 
-use function Laravel\Prompts\text;
+use Laravel\Prompts\P;
 
 require __DIR__.'/../vendor/autoload.php';
 
-$email = text(
+$email = P::text(
     label: 'What is your email address',
     placeholder: 'E.g. taylor@laravel.com',
     validate: fn ($value) => match (true) {

--- a/src/P.php
+++ b/src/P.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Laravel\Prompts;
+
+use Closure;
+use Illuminate\Support\Collection;
+
+class P
+{
+    public static function text(
+        string $label,
+        string $placeholder = '',
+        string $default = '',
+        bool|string $required = false,
+        Closure $validate = null
+    ): string {
+        return (new TextPrompt($label, $placeholder, $default, $required, $validate))->prompt();
+    }
+
+    /**
+     * Prompt the user for input, hiding the value.
+     */
+    public static function password(
+        string $label,
+        string $placeholder = '',
+        bool|string $required = false,
+        Closure $validate = null
+    ): string {
+        return (new PasswordPrompt($label, $placeholder, $required, $validate))->prompt();
+    }
+
+    /**
+     * Prompt the user to select an option.
+     *
+     * @param  array<int|string, string>|Collection<int|string, string>  $options
+     */
+    public static function select(
+        string $label,
+        array|Collection $options,
+        int|string $default = null,
+        int $scroll = 5,
+        Closure $validate = null
+    ): int|string {
+        return (new SelectPrompt($label, $options, $default, $scroll, $validate))->prompt();
+    }
+
+    /**
+     * Prompt the user to select multiple options.
+     *
+     * @param  array<int|string, string>|Collection<int|string, string>  $options
+     * @param  array<int|string>|Collection<int, int|string>  $default
+     * @return array<int|string>
+     */
+    public static function multiselect(
+        string $label,
+        array|Collection $options,
+        array|Collection $default = [],
+        int $scroll = 5,
+        bool|string $required = false,
+        Closure $validate = null
+    ): array {
+        return (new MultiSelectPrompt($label, $options, $default, $scroll, $required, $validate))->prompt();
+    }
+
+    /**
+     * Prompt the user to confirm an action.
+     */
+    public static function confirm(
+        string $label,
+        bool $default = true,
+        string $yes = 'Yes',
+        string $no = 'No',
+        bool|string $required = false,
+        Closure $validate = null
+    ): bool {
+        return (new ConfirmPrompt($label, $default, $yes, $no, $required, $validate))->prompt();
+    }
+
+    /**
+     * Prompt the user for text input with auto-completion.
+     *
+     * @param  array<string>|Collection<int, string>|Closure(string): array<string>  $options
+     */
+    public static function suggest(
+        string $label,
+        array|Collection|Closure $options,
+        string $placeholder = '',
+        string $default = '',
+        int $scroll = 5,
+        bool|string $required = false,
+        Closure $validate = null
+    ): string {
+        return (new SuggestPrompt($label, $options, $placeholder, $default, $scroll, $required, $validate))->prompt();
+    }
+
+    /**
+     * Allow the user to search for an option.
+     *
+     * @param  Closure(string): array<int|string, string>  $options
+     */
+    public static function search(
+        string $label,
+        Closure $options,
+        string $placeholder = '',
+        int $scroll = 5,
+        Closure $validate = null
+    ): int|string {
+        return (new SearchPrompt($label, $options, $placeholder, $scroll, $validate))->prompt();
+    }
+
+    /**
+     * Render a spinner while the given callback is executing.
+     *
+     * @template TReturn of mixed
+     *
+     * @param  \Closure(): TReturn  $callback
+     * @return TReturn
+     */
+    public static function spin(Closure $callback, string $message = ''): mixed
+    {
+        return (new Spinner($message))->spin($callback);
+    }
+
+    /**
+     * Display a note.
+     */
+    public static function note(string $message, string $type = null): void
+    {
+        (new Note($message, $type))->display();
+    }
+
+    /**
+     * Display an error.
+     */
+    public static function error(string $message): void
+    {
+        (new Note($message, 'error'))->display();
+    }
+
+    /**
+     * Display a warning.
+     */
+    public static function warning(string $message): void
+    {
+        (new Note($message, 'warning'))->display();
+    }
+
+    /**
+     * Display an alert.
+     */
+    public static function alert(string $message): void
+    {
+        (new Note($message, 'alert'))->display();
+    }
+
+    /**
+     * Display an introduction.
+     */
+    public static function intro(string $message): void
+    {
+        (new Note($message, 'intro'))->display();
+    }
+
+    /**
+     * Display a closing message.
+     */
+    public static function outro(string $message): void
+    {
+        (new Note($message, 'outro'))->display();
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -8,17 +8,26 @@ use Illuminate\Support\Collection;
 /**
  * Prompt the user for text input.
  */
-function text(string $label, string $placeholder = '', string $default = '', bool|string $required = false, Closure $validate = null): string
-{
-    return (new TextPrompt($label, $placeholder, $default, $required, $validate))->prompt();
+function text(
+    string $label,
+    string $placeholder = '',
+    string $default = '',
+    bool|string $required = false,
+    Closure $validate = null
+): string {
+    return P::text($label, $placeholder, $default, $required, $validate);
 }
 
 /**
  * Prompt the user for input, hiding the value.
  */
-function password(string $label, string $placeholder = '', bool|string $required = false, Closure $validate = null): string
-{
-    return (new PasswordPrompt($label, $placeholder, $required, $validate))->prompt();
+function password(
+    string $label,
+    string $placeholder = '',
+    bool|string $required = false,
+    Closure $validate = null
+): string {
+    return P::password($label, $placeholder, $required, $validate);
 }
 
 /**
@@ -26,9 +35,14 @@ function password(string $label, string $placeholder = '', bool|string $required
  *
  * @param  array<int|string, string>|Collection<int|string, string>  $options
  */
-function select(string $label, array|Collection $options, int|string $default = null, int $scroll = 5, Closure $validate = null): int|string
-{
-    return (new SelectPrompt($label, $options, $default, $scroll, $validate))->prompt();
+function select(
+    string $label,
+    array|Collection $options,
+    int|string $default = null,
+    int $scroll = 5,
+    Closure $validate = null
+): int|string {
+    return P::select($label, $options, $default, $scroll, $validate);
 }
 
 /**
@@ -38,17 +52,29 @@ function select(string $label, array|Collection $options, int|string $default = 
  * @param  array<int|string>|Collection<int, int|string>  $default
  * @return array<int|string>
  */
-function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, Closure $validate = null): array
-{
-    return (new MultiSelectPrompt($label, $options, $default, $scroll, $required, $validate))->prompt();
+function multiselect(
+    string $label,
+    array|Collection $options,
+    array|Collection $default = [],
+    int $scroll = 5,
+    bool|string $required = false,
+    Closure $validate = null
+): array {
+    return P::multiselect($label, $options, $default, $scroll, $required, $validate);
 }
 
 /**
  * Prompt the user to confirm an action.
  */
-function confirm(string $label, bool $default = true, string $yes = 'Yes', string $no = 'No', bool|string $required = false, Closure $validate = null): bool
-{
-    return (new ConfirmPrompt($label, $default, $yes, $no, $required, $validate))->prompt();
+function confirm(
+    string $label,
+    bool $default = true,
+    string $yes = 'Yes',
+    string $no = 'No',
+    bool|string $required = false,
+    Closure $validate = null
+): bool {
+    return P::confirm($label, $default, $yes, $no, $required, $validate);
 }
 
 /**
@@ -56,9 +82,16 @@ function confirm(string $label, bool $default = true, string $yes = 'Yes', strin
  *
  * @param  array<string>|Collection<int, string>|Closure(string): array<string>  $options
  */
-function suggest(string $label, array|Collection|Closure $options, string $placeholder = '', string $default = '', int $scroll = 5, bool|string $required = false, Closure $validate = null): string
-{
-    return (new SuggestPrompt($label, $options, $placeholder, $default, $scroll, $required, $validate))->prompt();
+function suggest(
+    string $label,
+    array|Collection|Closure $options,
+    string $placeholder = '',
+    string $default = '',
+    int $scroll = 5,
+    bool|string $required = false,
+    Closure $validate = null
+): string {
+    return P::suggest($label, $options, $placeholder, $default, $scroll, $required, $validate);
 }
 
 /**
@@ -66,9 +99,14 @@ function suggest(string $label, array|Collection|Closure $options, string $place
  *
  * @param  Closure(string): array<int|string, string>  $options
  */
-function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, Closure $validate = null): int|string
-{
-    return (new SearchPrompt($label, $options, $placeholder, $scroll, $validate))->prompt();
+function search(
+    string $label,
+    Closure $options,
+    string $placeholder = '',
+    int $scroll = 5,
+    Closure $validate = null
+): int|string {
+    return P::search($label, $options, $placeholder, $scroll, $validate);
 }
 
 /**
@@ -81,7 +119,7 @@ function search(string $label, Closure $options, string $placeholder = '', int $
  */
 function spin(Closure $callback, string $message = ''): mixed
 {
-    return (new Spinner($message))->spin($callback);
+    return P::spin($callback, $message);
 }
 
 /**
@@ -89,7 +127,7 @@ function spin(Closure $callback, string $message = ''): mixed
  */
 function note(string $message, string $type = null): void
 {
-    (new Note($message, $type))->display();
+    P::note($message, $type);
 }
 
 /**
@@ -97,7 +135,7 @@ function note(string $message, string $type = null): void
  */
 function error(string $message): void
 {
-    (new Note($message, 'error'))->display();
+    P::error($message);
 }
 
 /**
@@ -105,7 +143,7 @@ function error(string $message): void
  */
 function warning(string $message): void
 {
-    (new Note($message, 'warning'))->display();
+    P::warning($message);
 }
 
 /**
@@ -113,7 +151,7 @@ function warning(string $message): void
  */
 function alert(string $message): void
 {
-    (new Note($message, 'alert'))->display();
+    P::alert($message);
 }
 
 /**
@@ -121,7 +159,7 @@ function alert(string $message): void
  */
 function intro(string $message): void
 {
-    (new Note($message, 'intro'))->display();
+    P::intro($message);
 }
 
 /**
@@ -129,5 +167,5 @@ function intro(string $message): void
  */
 function outro(string $message): void
 {
-    (new Note($message, 'outro'))->display();
+    P::outro($message);
 }

--- a/tests/Feature/ConfirmPromptTest.php
+++ b/tests/Feature/ConfirmPromptTest.php
@@ -1,14 +1,14 @@
 <?php
 
-use function Laravel\Prompts\confirm;
 use Laravel\Prompts\ConfirmPrompt;
 use Laravel\Prompts\Key;
+use Laravel\Prompts\P;
 use Laravel\Prompts\Prompt;
 
 it('confirms', function () {
     Prompt::fake([Key::ENTER]);
 
-    $result = confirm(label: 'Are you sure?');
+    $result = P::confirm(label: 'Are you sure?');
 
     expect($result)->toBeTrue();
 });
@@ -16,7 +16,7 @@ it('confirms', function () {
 test('arrow keys change the value', function () {
     Prompt::fake([Key::DOWN, Key::ENTER]);
 
-    $result = confirm(label: 'Are you sure?');
+    $result = P::confirm(label: 'Are you sure?');
 
     expect($result)->toBeFalse();
 });
@@ -24,7 +24,7 @@ test('arrow keys change the value', function () {
 test('the y selects yes', function () {
     Prompt::fake(['y', Key::ENTER]);
 
-    $result = confirm(label: 'Are you sure?');
+    $result = P::confirm(label: 'Are you sure?');
 
     expect($result)->toBeTrue();
 });
@@ -32,7 +32,7 @@ test('the y selects yes', function () {
 test('the n selects no', function () {
     Prompt::fake(['n', Key::ENTER]);
 
-    $result = confirm(label: 'Are you sure?');
+    $result = P::confirm(label: 'Are you sure?');
 
     expect($result)->toBeFalse();
 });
@@ -40,7 +40,7 @@ test('the n selects no', function () {
 it('accepts a default value', function () {
     Prompt::fake([Key::ENTER]);
 
-    $result = confirm(
+    $result = P::confirm(
         label: 'Are you sure?',
         default: false
     );
@@ -51,7 +51,7 @@ it('accepts a default value', function () {
 it('allows the labels to be changed', function () {
     Prompt::fake([Key::ENTER]);
 
-    $result = confirm(
+    $result = P::confirm(
         label: '¿Estás seguro?',
         yes: 'Sí, por favor',
         no: 'No, gracias'
@@ -66,7 +66,7 @@ it('allows the labels to be changed', function () {
 it('validates', function () {
     Prompt::fake([Key::ENTER, 'y', Key::ENTER]);
 
-    $result = confirm(
+    $result = P::confirm(
         label: 'Would you like to continue?',
         default: false,
         validate: fn ($value) => $value === false ? 'You must choose yes.' : null,
@@ -86,7 +86,7 @@ it('can fall back', function () {
         return true;
     });
 
-    $result = confirm('Would you like to continue?', false);
+    $result = P::confirm('Would you like to continue?', false);
 
     expect($result)->toBeTrue();
 });

--- a/tests/Feature/MultiselectPromptTest.php
+++ b/tests/Feature/MultiselectPromptTest.php
@@ -1,14 +1,14 @@
 <?php
 
 use Laravel\Prompts\Key;
-use function Laravel\Prompts\multiselect;
 use Laravel\Prompts\MultiSelectPrompt;
+use Laravel\Prompts\P;
 use Laravel\Prompts\Prompt;
 
 it('accepts an array of labels', function () {
     Prompt::fake([Key::DOWN, Key::SPACE, Key::DOWN, Key::SPACE, Key::ENTER]);
 
-    $result = multiselect(
+    $result = P::multiselect(
         label: 'What are your favorite colors?',
         options: [
             'Red',
@@ -23,7 +23,7 @@ it('accepts an array of labels', function () {
 it('accepts an array of keys and labels', function () {
     Prompt::fake([Key::DOWN, Key::SPACE, Key::DOWN, Key::SPACE, Key::ENTER]);
 
-    $result = multiselect(
+    $result = P::multiselect(
         label: 'What are your favorite colors?',
         options: [
             'red' => 'Red',
@@ -38,7 +38,7 @@ it('accepts an array of keys and labels', function () {
 it('accepts an associate array with integer keys', function () {
     Prompt::fake([Key::DOWN, Key::SPACE, Key::DOWN, Key::SPACE, Key::ENTER]);
 
-    $result = multiselect(
+    $result = P::multiselect(
         label: 'What are your favorite colors?',
         options: [
             1 => 'Red',
@@ -53,7 +53,7 @@ it('accepts an associate array with integer keys', function () {
 it('accepts default values when the options are labels', function () {
     Prompt::fake([Key::ENTER]);
 
-    $result = multiselect(
+    $result = P::multiselect(
         label: 'What are your favorite colors?',
         options: [
             'Red',
@@ -69,7 +69,7 @@ it('accepts default values when the options are labels', function () {
 it('accepts default values when the options are keys with labels', function () {
     Prompt::fake([Key::ENTER]);
 
-    $result = multiselect(
+    $result = P::multiselect(
         label: 'What are your favorite colors?',
         options: [
             'red' => 'Red',
@@ -85,7 +85,7 @@ it('accepts default values when the options are keys with labels', function () {
 it('accepts collections', function () {
     Prompt::fake([Key::ENTER]);
 
-    $result = multiselect(
+    $result = P::multiselect(
         label: 'What are your favorite colors?',
         options: collect([
             'Red',
@@ -101,7 +101,7 @@ it('accepts collections', function () {
 it('validates', function () {
     Prompt::fake([Key::ENTER, Key::SPACE, Key::ENTER]);
 
-    $result = multiselect(
+    $result = P::multiselect(
         label: 'What are your favorite colors?',
         options: [
             'red' => 'Red',
@@ -125,7 +125,7 @@ it('can fall back', function () {
         return ['Blue'];
     });
 
-    $result = multiselect('What is your favorite color?', [
+    $result = P::multiselect('What is your favorite color?', [
         'Red',
         'Green',
         'Blue',

--- a/tests/Feature/NoteTest.php
+++ b/tests/Feature/NoteTest.php
@@ -1,12 +1,12 @@
 <?php
 
-use function Laravel\Prompts\note;
+use Laravel\Prompts\P;
 use Laravel\Prompts\Prompt;
 
 it('renders a note', function () {
     Prompt::fake();
 
-    note('Hello, World!');
+    P::note('Hello, World!');
 
     Prompt::assertOutputContains('Hello, World!');
 });

--- a/tests/Feature/PasswordPromptTest.php
+++ b/tests/Feature/PasswordPromptTest.php
@@ -1,14 +1,14 @@
 <?php
 
 use Laravel\Prompts\Key;
-use function Laravel\Prompts\password;
+use Laravel\Prompts\P;
 use Laravel\Prompts\PasswordPrompt;
 use Laravel\Prompts\Prompt;
 
 it('returns the input', function () {
     Prompt::fake(['p', 'a', 's', 's', Key::ENTER]);
 
-    $result = password(label: 'What is the password?');
+    $result = P::password(label: 'What is the password?');
 
     expect($result)->toBe('pass');
 });
@@ -16,7 +16,7 @@ it('returns the input', function () {
 it('validates', function () {
     Prompt::fake(['p', 'a', 's', Key::ENTER, 's', Key::ENTER]);
 
-    $result = password(
+    $result = P::password(
         label: 'What is the password',
         validate: fn ($value) => strlen($value) < 4 ? 'Password must be at least 4 characters.' : '',
     );
@@ -29,7 +29,7 @@ it('validates', function () {
 it('cancels', function () {
     Prompt::fake([Key::CTRL_C]);
 
-    password(label: 'What is the password');
+    P::password(label: 'What is the password');
 
     Prompt::assertOutputContains('Cancelled.');
 });
@@ -37,7 +37,7 @@ it('cancels', function () {
 test('the backspace key removes a character', function () {
     Prompt::fake(['p', 'a', 'z', Key::BACKSPACE, 's', 's', Key::ENTER]);
 
-    $result = password(label: 'What is the password?');
+    $result = P::password(label: 'What is the password?');
 
     expect($result)->toBe('pass');
 });
@@ -45,7 +45,7 @@ test('the backspace key removes a character', function () {
 test('the delete key removes a character', function () {
     Prompt::fake(['p', 'a', 'z', Key::LEFT, Key::DELETE, 's', 's', Key::ENTER]);
 
-    $result = password(label: 'What is the password?');
+    $result = P::password(label: 'What is the password?');
 
     expect($result)->toBe('pass');
 });
@@ -59,7 +59,7 @@ it('can fall back', function () {
         return 'result';
     });
 
-    $result = password('What is the password?');
+    $result = P::password('What is the password?');
 
     expect($result)->toBe('result');
 });

--- a/tests/Feature/SearchPromptTest.php
+++ b/tests/Feature/SearchPromptTest.php
@@ -1,14 +1,14 @@
 <?php
 
 use Laravel\Prompts\Key;
+use Laravel\Prompts\P;
 use Laravel\Prompts\Prompt;
-use function Laravel\Prompts\search;
 use Laravel\Prompts\SearchPrompt;
 
 it('accepts a callback', function () {
     Prompt::fake(['u', 'e', Key::DOWN, Key::ENTER]);
 
-    $result = search(
+    $result = P::search(
         label: 'What is your favorite color?',
         options: fn (string $value) => array_filter(
             [
@@ -26,7 +26,7 @@ it('accepts a callback', function () {
 it('returns the value when a list is passed', function () {
     Prompt::fake(['u', 'e', Key::DOWN, Key::ENTER]);
 
-    $result = search(
+    $result = P::search(
         label: 'What is your favorite color?',
         options: fn (string $value) => array_values(array_filter(
             [
@@ -44,7 +44,7 @@ it('returns the value when a list is passed', function () {
 it('returns the key when an associative array is passed', function () {
     Prompt::fake(['u', 'e', Key::DOWN, Key::ENTER]);
 
-    $result = search(
+    $result = P::search(
         label: 'What is your favorite color?',
         options: fn (string $value) => array_filter(
             [
@@ -62,7 +62,7 @@ it('returns the key when an associative array is passed', function () {
 it('validates', function () {
     Prompt::fake([Key::DOWN, Key::ENTER, Key::DOWN, Key::ENTER]);
 
-    $result = search(
+    $result = P::search(
         label: 'What is your favorite color?',
         options: fn () => [
             'red' => 'Red',
@@ -86,7 +86,7 @@ it('can fall back', function () {
         return 'result';
     });
 
-    $result = search(
+    $result = P::search(
         label: 'What is your favorite color?',
         options: fn () => [
             'red' => 'Red',

--- a/tests/Feature/SelectPromptTest.php
+++ b/tests/Feature/SelectPromptTest.php
@@ -1,14 +1,14 @@
 <?php
 
 use Laravel\Prompts\Key;
+use Laravel\Prompts\P;
 use Laravel\Prompts\Prompt;
-use function Laravel\Prompts\select;
 use Laravel\Prompts\SelectPrompt;
 
 it('accepts an array of labels', function () {
     Prompt::fake([Key::DOWN, Key::ENTER]);
 
-    $result = select(
+    $result = P::select(
         label: 'What is your favorite color?',
         options: [
             'Red',
@@ -23,7 +23,7 @@ it('accepts an array of labels', function () {
 it('accepts an array of keys and labels', function () {
     Prompt::fake([Key::DOWN, Key::ENTER]);
 
-    $result = select(
+    $result = P::select(
         label: 'What is your favorite color?',
         options: [
             'red' => 'Red',
@@ -38,7 +38,7 @@ it('accepts an array of keys and labels', function () {
 it('accepts an associate array with integer keys', function () {
     Prompt::fake([Key::DOWN, Key::ENTER]);
 
-    $result = select(
+    $result = P::select(
         label: 'What is your favorite color?',
         options: [
             1 => 'Red',
@@ -53,7 +53,7 @@ it('accepts an associate array with integer keys', function () {
 it('accepts a collection', function () {
     Prompt::fake([Key::DOWN, Key::ENTER]);
 
-    $result = select(
+    $result = P::select(
         label: 'What is your favorite color?',
         options: collect([
             'Red',
@@ -68,7 +68,7 @@ it('accepts a collection', function () {
 it('accepts default values when the options are labels', function () {
     Prompt::fake([Key::ENTER]);
 
-    $result = select(
+    $result = P::select(
         label: 'What is your favorite color?',
         options: [
             'Red',
@@ -84,7 +84,7 @@ it('accepts default values when the options are labels', function () {
 it('accepts default values when the options are keys with labels', function () {
     Prompt::fake([Key::ENTER]);
 
-    $result = select(
+    $result = P::select(
         label: 'What is your favorite color?',
         options: [
             'red' => 'Red',
@@ -100,7 +100,7 @@ it('accepts default values when the options are keys with labels', function () {
 it('validates', function () {
     Prompt::fake([Key::ENTER, Key::DOWN, Key::ENTER]);
 
-    $result = select(
+    $result = P::select(
         label: 'What is your favorite color?',
         options: [
             'red' => 'Red',
@@ -124,7 +124,7 @@ it('can fall back', function () {
         return 'Blue';
     });
 
-    $result = select('What is your favorite color?', [
+    $result = P::select('What is your favorite color?', [
         'Red',
         'Green',
         'Blue',

--- a/tests/Feature/SpinnerTest.php
+++ b/tests/Feature/SpinnerTest.php
@@ -1,12 +1,12 @@
 <?php
 
+use Laravel\Prompts\P;
 use Laravel\Prompts\Prompt;
-use function Laravel\Prompts\spin;
 
 it('renders a spinner while executing a callback and then returns the value', function () {
     Prompt::fake();
 
-    $result = spin(function () {
+    $result = P::spin(function () {
         usleep(1000);
 
         return 'done';

--- a/tests/Feature/SuggestPromptTest.php
+++ b/tests/Feature/SuggestPromptTest.php
@@ -1,14 +1,14 @@
 <?php
 
 use Laravel\Prompts\Key;
+use Laravel\Prompts\P;
 use Laravel\Prompts\Prompt;
-use function Laravel\Prompts\suggest;
 use Laravel\Prompts\SuggestPrompt;
 
 it('accepts any input', function () {
     Prompt::fake(['B', 'l', 'a', 'c', 'k', Key::ENTER]);
 
-    $result = suggest('What is your favorite color?', [
+    $result = P::suggest('What is your favorite color?', [
         'Red',
         'Green',
         'Blue',
@@ -20,7 +20,7 @@ it('accepts any input', function () {
 it('completes the input using the tab key', function () {
     Prompt::fake(['b', Key::TAB, Key::ENTER]);
 
-    $result = suggest('What is your favorite color?', [
+    $result = P::suggest('What is your favorite color?', [
         'Red',
         'Green',
         'Blue',
@@ -32,7 +32,7 @@ it('completes the input using the tab key', function () {
 it('completes the input using the arrow keys', function () {
     Prompt::fake(['b', Key::DOWN, Key::DOWN, Key::DOWN, Key::UP, Key::ENTER]);
 
-    $result = suggest('What is your favorite color?', [
+    $result = P::suggest('What is your favorite color?', [
         'Red',
         'Blue',
         'Black',
@@ -45,7 +45,7 @@ it('completes the input using the arrow keys', function () {
 it('accepts a callback', function () {
     Prompt::fake(['e', 'e', Key::DOWN, Key::ENTER]);
 
-    $result = suggest(
+    $result = P::suggest(
         label: 'What is your favorite color?',
         options: fn (string $value) => array_filter(
             [
@@ -63,7 +63,7 @@ it('accepts a callback', function () {
 it('accepts a collection', function () {
     Prompt::fake(['b', Key::TAB, Key::ENTER]);
 
-    $result = suggest('What is your favorite color?', collect([
+    $result = P::suggest('What is your favorite color?', collect([
         'Red',
         'Green',
         'Blue',
@@ -75,7 +75,7 @@ it('accepts a collection', function () {
 it('validates', function () {
     Prompt::fake([Key::ENTER, 'X', Key::ENTER]);
 
-    $result = suggest(
+    $result = P::suggest(
         label: 'What is your name?',
         options: ['Taylor'],
         validate: fn ($value) => empty($value) ? 'Please enter your name.' : null,
@@ -95,7 +95,7 @@ it('can fall back', function () {
         return 'result';
     });
 
-    $result = suggest('What is your favorite color?', [
+    $result = P::suggest('What is your favorite color?', [
         'Red',
         'Green',
         'Blue',

--- a/tests/Feature/TextPromptTest.php
+++ b/tests/Feature/TextPromptTest.php
@@ -1,14 +1,14 @@
 <?php
 
 use Laravel\Prompts\Key;
+use Laravel\Prompts\P;
 use Laravel\Prompts\Prompt;
-use function Laravel\Prompts\text;
 use Laravel\Prompts\TextPrompt;
 
 it('returns the input', function () {
     Prompt::fake(['J', 'e', 's', 's', Key::ENTER]);
 
-    $result = text(label: 'What is your name?');
+    $result = P::text(label: 'What is your name?');
 
     expect($result)->toBe('Jess');
 });
@@ -16,7 +16,7 @@ it('returns the input', function () {
 it('accepts a default value', function () {
     Prompt::fake([Key::ENTER]);
 
-    $result = text(
+    $result = P::text(
         label: 'What is your name?',
         default: 'Jess'
     );
@@ -27,7 +27,7 @@ it('accepts a default value', function () {
 it('validates', function () {
     Prompt::fake(['J', 'e', 's', Key::ENTER, 's', Key::ENTER]);
 
-    $result = text(
+    $result = P::text(
         label: 'What is your name?',
         validate: fn ($value) => $value !== 'Jess' ? 'Invalid name.' : '',
     );
@@ -40,7 +40,7 @@ it('validates', function () {
 it('cancels', function () {
     Prompt::fake([Key::CTRL_C]);
 
-    text(label: 'What is your name?');
+    P::text(label: 'What is your name?');
 
     Prompt::assertOutputContains('Cancelled.');
 });
@@ -48,7 +48,7 @@ it('cancels', function () {
 test('the backspace key removes a character', function () {
     Prompt::fake(['J', 'e', 'z', Key::BACKSPACE, 's', 's', Key::ENTER]);
 
-    $result = text(label: 'What is your name?');
+    $result = P::text(label: 'What is your name?');
 
     expect($result)->toBe('Jess');
 });
@@ -56,7 +56,7 @@ test('the backspace key removes a character', function () {
 test('the delete key removes a character', function () {
     Prompt::fake(['J', 'e', 'z', Key::LEFT, Key::DELETE, 's', 's', Key::ENTER]);
 
-    $result = text(label: 'What is your name?');
+    $result = P::text(label: 'What is your name?');
 
     expect($result)->toBe('Jess');
 });
@@ -70,7 +70,7 @@ it('can fall back', function () {
         return 'result';
     });
 
-    $result = text('What is your name?');
+    $result = P::text('What is your name?');
 
     expect($result)->toBe('result');
 });


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull-request add a P class, that can be imported to call any function.
It is aligned with [laravel/framework](https://github.com/laravel/framework) where all the string and array helpers functions were migrated to dedicated `Arr` and `Str` classes with static methods.

That change also allows to greatly limit the number of imports in a console command class, where https://github.com/laravel/prompts feature would be used.

**Note:**
The playground and tests files have also been updated to reflect this change.
