### PR TITLE
Replace tput command as it's not available on all OSes

### DIFF
--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Prompts;
 
+use Symfony\Component\Console\Terminal as Term;
+
 class Terminal
 {
     /**
@@ -62,7 +64,7 @@ class Terminal
      */
     public function cols(): int
     {
-        return $this->cols ??= (int) shell_exec('tput cols 2>/dev/null');
+        return $this->cols ??= (new Term())->getWidth();
     }
 
     /**
@@ -70,7 +72,7 @@ class Terminal
      */
     public function lines(): int
     {
-        return $this->lines ??= (int) shell_exec('tput lines 2>/dev/null');
+        return $this->lines ??= (new Term())->getHeight();
     }
 
     /**

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Prompts;
 
-use Symfony\Component\Console\Terminal as Term;
+use Symfony\Component\Console\Terminal as SymfonyTerminal;
 
 class Terminal
 {
@@ -64,7 +64,7 @@ class Terminal
      */
     public function cols(): int
     {
-        return $this->cols ??= (new Term())->getWidth();
+        return $this->cols ??= (new SymfonyTerminal())->getWidth();
     }
 
     /**
@@ -72,7 +72,7 @@ class Terminal
      */
     public function lines(): int
     {
-        return $this->lines ??= (new Term())->getHeight();
+        return $this->lines ??= (new SymfonyTerminal())->getHeight();
     }
 
     /**


### PR DESCRIPTION
The `tput` command isn't available by default in the Alpine Linux official PHP docker images (at least) and this throws an `InvalidArgumentException` for truncation length.

This PR replaces the `tput` command with method calls from the Symfony Console `Terminal` class.

`tput` is used in the `Terminal` class to determine the number of rows and columns available, in particular used for truncating line length if available terminal columns are too low.