### PR TITLE
fix: Check for non-null return value from fread to handle character z…

### DIFF
--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -24,8 +24,9 @@ class Terminal
      */
     public function read(): string
     {
-        $terminalInput = fread(STDIN, 1024);
-        return $terminalInput !== false ? $terminalInput : '';
+        $input = fread(STDIN, 1024);
+
+        return $input !== false ? $input : '';
     }
 
     /**

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -24,7 +24,8 @@ class Terminal
      */
     public function read(): string
     {
-        return fread(STDIN, 1024) ?: '';
+        $terminalInput = fread(STDIN, 1024);
+        return is_null($terminalInput) ? '' : $terminalInput;
     }
 
     /**

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -25,7 +25,7 @@ class Terminal
     public function read(): string
     {
         $terminalInput = fread(STDIN, 1024);
-        return is_null($terminalInput) ? '' : $terminalInput;
+        return $terminalInput !== false ? $terminalInput : '';
     }
 
     /**


### PR DESCRIPTION
As detailed here #13 the input fails if "0" is typed. 

This is happening because fread(STDIN, 1024) is returning "0" but fread(STDIN, 1024) ?:"" returns "".

