### PR TITLE
Improve errors on unsupported environments

### DIFF
--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -4,6 +4,7 @@ namespace Laravel\Prompts;
 
 use Closure;
 use Laravel\Prompts\Output\ConsoleOutput;
+use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class Prompt
@@ -76,6 +77,8 @@ abstract class Prompt
         if (static::shouldFallback()) {
             return $this->fallback();
         }
+
+        $this->checkEnvironment();
 
         register_shutdown_function(function () {
             $this->restoreCursor();
@@ -300,6 +303,16 @@ abstract class Prompt
         if (is_string($error) && strlen($error) > 0) {
             $this->state = 'error';
             $this->error = $error;
+        }
+    }
+
+    /**
+     * Check whether the environment can support the prompt.
+     */
+    private function checkEnvironment(): void
+    {
+        if (PHP_OS_FAMILY === 'Windows') {
+            throw new RuntimeException('Prompts is not currently supported on Windows. Please use WSL or configure a fallback.');
         }
     }
 }

--- a/src/Themes/Default/Renderer.php
+++ b/src/Themes/Default/Renderer.php
@@ -5,6 +5,7 @@ namespace Laravel\Prompts\Themes\Default;
 use InvalidArgumentException;
 use Laravel\Prompts\Concerns\Colors;
 use Laravel\Prompts\Prompt;
+use RuntimeException;
 
 abstract class Renderer
 {
@@ -20,7 +21,7 @@ abstract class Renderer
      */
     public function __construct(protected Prompt $prompt)
     {
-        //
+        $this->checkTerminalSize($prompt);
     }
 
     /**
@@ -79,5 +80,20 @@ abstract class Renderer
         return str_repeat(PHP_EOL, 2 - $this->prompt->newLinesWritten())
             .$this->output
             .(in_array($this->prompt->state, ['submit', 'cancel']) ? PHP_EOL : '');
+    }
+
+    /**
+     * Check that the terminal is large enough to render the prompt.
+     */
+    private function checkTerminalSize(Prompt $prompt): void
+    {
+        $required = 8;
+        $actual = $prompt->terminal()->lines();
+
+        if ($actual < $required) {
+            throw new RuntimeException(
+                "The terminal height must be at least [$required] lines but is currently [$actual]. Please increase the height or reduce the font size."
+            );
+        }
     }
 }


### PR DESCRIPTION
This PR improves the error messaging in the following unsupported scenarios:

* When running Windows outside of WSL without a fallback. This error should only be seen when using Prompts without a Laravel version that includes https://github.com/laravel/framework/pull/46772. Currently, a cryptic error occurs when trying to run the `stty` command.
* When the terminal height is less than eight lines the prompts will not render correctly. [Traditional terminal standards](https://en.wikipedia.org/wiki/VT100) have a minimum height of 24 lines which is still a common default in modern terminal applications. Still, it's possible to have fewer lines, especially in a terminal "drawer" in an IDE. VSCode's terminal is 11 lines by default, but this can be reduced by increasing the font size or shrinking the drawer height.

  ![image](https://github.com/laravel/prompts/assets/4977161/4b4e6d68-739c-4492-af13-614ba6974949)

Fixes #3
Fixes #8