### PR TITLE
Fix required validation on `suggest` prompt

### DIFF
--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -45,8 +45,6 @@ class SuggestPrompt extends Prompt
     ) {
         $this->options = $options instanceof Collection ? $options->all() : $options;
 
-        $this->trackTypedValue($default);
-
         $this->on('key', fn ($key) => match ($key) {
             Key::UP, Key::SHIFT_TAB => $this->highlightPrevious(),
             Key::DOWN, Key::TAB => $this->highlightNext(),
@@ -57,6 +55,8 @@ class SuggestPrompt extends Prompt
                 $this->matches = null;
             })(),
         });
+
+        $this->trackTypedValue($default);
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue where validation occurs prematurely in the `suggest` prompt when the user selects one of the suggested values. This is most obvious when the `suggest` prompt is marked as `required` and the user selects a suggested value without typing anything to narrow the suggestions.

This is because there are two listeners for the "Enter" key - one in the `SuggestPrompt` class that sets the selected value if one has been highlighted and one in the `TypedValue` trait that submits the entered or selected value. This PR solves this by registering the "suggest-specific" key listeners first. 

An alternative approach would be to pass the `submit: false` argument to the `trackTypedValue` method and handle the submit behaviour directly in `SuggestPrompt` instead.

Fixes #21