### PR TITLE
added null type hints

### DIFF
--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -134,7 +134,7 @@ class SearchPrompt extends Prompt
     /**
      * Get the selected label.
      */
-    public function label(): string
+    public function label(): ?string
     {
         return $this->matches[array_keys($this->matches)[$this->highlighted]] ?? null;
     }

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -52,7 +52,7 @@ class SelectPrompt extends Prompt
     /**
      * Get the selected value.
      */
-    public function value(): int|string
+    public function value(): int|string|null
     {
         if (array_is_list($this->options)) {
             return $this->options[$this->highlighted] ?? null;
@@ -64,7 +64,7 @@ class SelectPrompt extends Prompt
     /**
      * Get the selected label.
      */
-    public function label(): string
+    public function label(): ?string
     {
         if (array_is_list($this->options)) {
             return $this->options[$this->highlighted] ?? null;


### PR DESCRIPTION
There are only three places where null can be  returned and it was not specified as the return type hint. This PR fixes that.