### PR TITLE
Fix output of escape characters when using `NullOutput` interface

### DIFF
--- a/src/Concerns/Cursor.php
+++ b/src/Concerns/Cursor.php
@@ -14,7 +14,7 @@ trait Cursor
      */
     public function hideCursor(): void
     {
-        $this->terminal()->write("\e[?25l");
+        static::writeDirectly("\e[?25l");
 
         static::$cursorHidden = true;
     }
@@ -24,7 +24,7 @@ trait Cursor
      */
     public function showCursor(): void
     {
-        $this->terminal()->write("\e[?25h");
+        static::writeDirectly("\e[?25h");
 
         static::$cursorHidden = false;
     }
@@ -58,6 +58,6 @@ trait Cursor
             $sequence .= "\e[{$y}B"; // Down
         }
 
-        $this->terminal()->write($sequence);
+        static::writeDirectly($sequence);
     }
 }

--- a/src/Concerns/Erase.php
+++ b/src/Concerns/Erase.php
@@ -18,7 +18,7 @@ trait Erase
             $clear .= "\e[G";
         }
 
-        $this->terminal()->write($clear);
+        static::writeDirectly($clear);
     }
 
     /**
@@ -26,6 +26,6 @@ trait Erase
      */
     public function eraseDown(): void
     {
-        $this->terminal()->write("\e[J");
+        static::writeDirectly("\e[J");
     }
 }

--- a/src/Output/ConsoleOutput.php
+++ b/src/Output/ConsoleOutput.php
@@ -38,4 +38,12 @@ class ConsoleOutput extends SymfonyConsoleOutput
             $this->newLinesWritten = $trailingNewLines;
         }
     }
+
+    /**
+     * Write output directly, bypassing newline capture.
+     */
+    public function writeDirectly(string $message): void
+    {
+        parent::doWrite($message, false);
+    }
 }

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -142,6 +142,18 @@ abstract class Prompt
     }
 
     /**
+     * Write output directly, bypassing newline capture.
+     */
+    protected static function writeDirectly(string $message): void
+    {
+        match (true) {
+            method_exists(static::output(), 'writeDirectly') => static::output()->writeDirectly($message),
+            method_exists(static::output(), 'getOutput') => static::output()->getOutput()->write($message),
+            default => static::output()->write($message),
+        };
+    }
+
+    /**
      * Get the terminal instance.
      */
     public static function terminal(): Terminal

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -32,14 +32,6 @@ class Terminal
     }
 
     /**
-     * Write data to the terminal.
-     */
-    public function write(string $data): void
-    {
-        fwrite(STDOUT, $data);
-    }
-
-    /**
      * Set the TTY mode.
      */
     public function setTty(string $mode): void


### PR DESCRIPTION
This PR fixes an issue when the output interface has been set to a `NullOutput` instance (e.g. when using the `callSilent` method in Laravel).

Currently, cursor manipulation and erase escape sequences are written directly to STDOUT because they interfere with the trailing newline calculation. However, when a `NullOutput` instance is used, the escape sequences are still output while the rest of the output is dropped.

When using Laravel's `OutputStyle`, we can bypass its newline calculation by writing directly to the underlying `OutputInterface` using the `getOutput` method.

When used without Laravel, I've added a `writeDirectly` method to the `ConsoleOutput` class that bypasses the calculation.

This partially solves #22, but a framework PR is required to completely solve it.