### PR TITLE
Support Laravel 9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - '*.x'
-      - l9
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,8 +20,9 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.1, 8.2]
+        laravel: [9, 10]
 
-    name: PHP ${{ matrix.php }}
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
     steps:
       - name: Checkout code
@@ -41,7 +42,9 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+          command: |
+            composer require "illuminate/collections=^${{ matrix.laravel }}" --no-update
+            composer update --prefer-stable --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: vendor/bin/pest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - '*.x'
+      - l9
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "ext-mbstring": "*",
-        "illuminate/collections": "^10.0",
+        "illuminate/collections": "^9.0|^10.0",
         "symfony/console": "^6.2"
     },
     "require-dev": {


### PR DESCRIPTION
Many packages in the Laravel ecosystem still support Laravel 9 (Livewire, Inertia, Filament, many Spatie packages with commands), and it would be great if they could make use of prompts to enhance their UX.

I have ensured that GitHub actions runs tests using Laravel 9, and they appear to be passing. Please let me know if I've made an oversight here and there is a reason why it's not currently supported.