### PR TITLE
support multi-byte character sets

### DIFF
--- a/src/Concerns/TypedValue.php
+++ b/src/Concerns/TypedValue.php
@@ -36,14 +36,14 @@ trait TypedValue
         $this->typedValue = $default;
 
         if ($this->typedValue) {
-            $this->cursorPosition = mb_strlen($this->typedValue);
+            $this->cursorPosition = mb_strwidth($this->typedValue);
         }
 
         $this->on('key', function ($key) use ($submit) {
             if ($key[0] === "\e") {
                 match ($key) {
                     Key::LEFT => $this->cursorPosition = max(0, $this->cursorPosition - 1),
-                    Key::RIGHT => $this->cursorPosition = min(mb_strlen($this->typedValue), $this->cursorPosition + 1),
+                    Key::RIGHT => $this->cursorPosition = min(mb_strwidth($this->typedValue), $this->cursorPosition + 1),
                     Key::DELETE => $this->typedValue = mb_substr($this->typedValue, 0, $this->cursorPosition).mb_substr($this->typedValue, $this->cursorPosition + 1),
                     default => null,
                 };
@@ -85,27 +85,27 @@ trait TypedValue
      */
     protected function addCursor(string $value, int $cursorPosition, int $maxWidth): string
     {
-        $offset = $cursorPosition - $maxWidth + ($cursorPosition < mb_strlen($value) ? 2 : 1);
+        $offset = $cursorPosition - $maxWidth + ($cursorPosition < mb_strwidth($value) ? 2 : 1);
         $offset = $offset > 0 ? $offset + 1 : 0;
         $offsetCursorPosition = $cursorPosition - $offset;
 
         $output = $offset > 0 ? $this->dim('…') : '';
         $output .= mb_substr($value, $offset, $offsetCursorPosition);
 
-        if ($cursorPosition > mb_strlen($value) - 1) {
+        if ($cursorPosition > mb_strwidth($value) - 1) {
             return $output.$this->inverse(' ');
         }
 
         $output .= $this->inverse(mb_substr($value, $cursorPosition, 1));
 
-        if ($cursorPosition === mb_strlen($value) - 1) {
+        if ($cursorPosition === mb_strwidth($value) - 1) {
             return $output.' ';
         }
 
         $remainder = mb_substr($value, $cursorPosition + 1);
         $remainingSpace = $maxWidth - $offsetCursorPosition - ($offset ? 2 : 1);
 
-        if (mb_strlen($remainder) <= $remainingSpace) {
+        if (mb_strwidth($remainder) <= $remainingSpace) {
             return $output.$remainder;
         }
 

--- a/src/PasswordPrompt.php
+++ b/src/PasswordPrompt.php
@@ -25,7 +25,7 @@ class PasswordPrompt extends Prompt
      */
     public function masked(): string
     {
-        return str_repeat('•', mb_strlen($this->value()));
+        return str_repeat('•', mb_strwidth($this->value()));
     }
 
     /**

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -148,6 +148,6 @@ class SearchPrompt extends Prompt
             throw new InvalidArgumentException("Length [{$length}] must be greater than zero.");
         }
 
-        return mb_strlen($value) <= $length ? $value : (mb_substr($value, 0, $length - 1).'…');
+        return mb_strwidth($value) <= $length ? $value : (mb_substr($value, 0, $length - 1).'…');
     }
 }

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -148,6 +148,6 @@ class SuggestPrompt extends Prompt
             throw new InvalidArgumentException("Length [{$length}] must be greater than zero.");
         }
 
-        return mb_strlen($value) <= $length ? $value : (mb_substr($value, 0, $length - 1).'…');
+        return mb_strwidth($value) <= $length ? $value : (mb_substr($value, 0, $length - 1).'…');
     }
 }

--- a/src/Themes/Default/Concerns/DrawsBoxes.php
+++ b/src/Themes/Default/Concerns/DrawsBoxes.php
@@ -28,7 +28,7 @@ trait DrawsBoxes
                 ->toArray()
         );
 
-        $topBorder = str_repeat('─', $width - mb_strlen($this->stripEscapeSequences($title)));
+        $topBorder = str_repeat('─', $width - mb_strwidth($this->stripEscapeSequences($title)));
         $bottomBorder = str_repeat('─', $width + 2);
 
         $this->line("{$this->{$color}(' ┌')} {$title} {$this->{$color}($topBorder.'┐')}");
@@ -60,7 +60,7 @@ trait DrawsBoxes
         return max(
             $this->minWidth,
             collect($lines)
-                ->map(fn ($line) => mb_strlen($this->stripEscapeSequences($line)) + $padding)
+                ->map(fn ($line) => mb_strwidth($this->stripEscapeSequences($line)) + $padding)
                 ->max()
         );
     }
@@ -70,7 +70,7 @@ trait DrawsBoxes
      */
     protected function pad(string $text, int $length): string
     {
-        $rightPadding = str_repeat(' ', max(0, $length - mb_strlen($this->stripEscapeSequences($text))));
+        $rightPadding = str_repeat(' ', max(0, $length - mb_strwidth($this->stripEscapeSequences($text))));
 
         return "{$text}{$rightPadding}";
     }

--- a/src/Themes/Default/Renderer.php
+++ b/src/Themes/Default/Renderer.php
@@ -69,7 +69,7 @@ abstract class Renderer
             throw new InvalidArgumentException("Length [{$length}] must be greater than zero.");
         }
 
-        return mb_strlen($value) <= $length ? $value : (mb_substr($value, 0, $length - 1).'…');
+        return mb_strwidth($value) <= $length ? $value : (mb_substr($value, 0, $length - 1).'…');
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds support for multi-byte charaters such as emoji, Japanese and Chines languages.

## Test

```php
use function Laravel\Prompts\confirm;

$confirmed = confirm(
  label: '楽しんでいますか？',
  yes: 'はい',
  no: 'いいえ',
);
var_dump($confirmed);
```