### PR TITLE
Don't allow negativ str_repeats

### DIFF
--- a/src/Themes/Default/Renderer.php
+++ b/src/Themes/Default/Renderer.php
@@ -77,7 +77,7 @@ abstract class Renderer
      */
     public function __toString()
     {
-        return str_repeat(PHP_EOL, 2 - $this->prompt->newLinesWritten())
+        return str_repeat(PHP_EOL, max(2 - $this->prompt->newLinesWritten(), 0))
             .$this->output
             .(in_array($this->prompt->state, ['submit', 'cancel']) ? PHP_EOL : '');
     }


### PR DESCRIPTION
As soon as you manually add a newLine output in combination with Prompts, the command throws an exception.

For example, this example command currently breaks with Prompts.

```php
<?php

namespace App\Console\Commands;

use Illuminate\Console\Command;
use function Laravel\Prompts\note;

class TestCommand extends Command
{
    protected $signature = 'app:test-command';

    public function handle()
    {
        note("1");
        note("2");
        $this->output->newLine();
        note("3");
    }
}

```

In this case, the calculated value for str_repeat becomes negative, which is not allowed as [per the PHP docs](https://www.php.net/manual/en/function.str-repeat.php).

This PR fixes this by only using the values 0 or greater.