### PR TITLE
Prevent C0 control codes

### DIFF
--- a/src/Concerns/TypedValue.php
+++ b/src/Concerns/TypedValue.php
@@ -17,18 +17,6 @@ trait TypedValue
     protected int $cursorPosition = 0;
 
     /**
-     * Keys to ignore
-     *
-     * @var array<string>
-     */
-    protected array $ignore = [
-        Key::ENTER,
-        Key::TAB,
-        Key::CTRL_C,
-        Key::CTRL_D,
-    ];
-
-    /**
      * Track the value as the user types.
      */
     protected function trackTypedValue(string $default = '', bool $submit = true): void
@@ -64,7 +52,7 @@ trait TypedValue
 
                     $this->typedValue = mb_substr($this->typedValue, 0, $this->cursorPosition - 1).mb_substr($this->typedValue, $this->cursorPosition);
                     $this->cursorPosition--;
-                } elseif (! in_array($key, $this->ignore)) {
+                } elseif (ord($key) >= 32) {
                     $this->typedValue = mb_substr($this->typedValue, 0, $this->cursorPosition).$key.mb_substr($this->typedValue, $this->cursorPosition);
                     $this->cursorPosition++;
                 }

--- a/src/Key.php
+++ b/src/Key.php
@@ -25,6 +25,4 @@ class Key
     const SHIFT_TAB = "\e[Z";
 
     const CTRL_C = "\x03";
-
-    const CTRL_D = "\x04";
 }


### PR DESCRIPTION
This PR fixes an issue where pressing keys like `Ctrl+A`, `Ctrl+B`, etc. while in a text field would capture non-printable control codes.

In addition to returning these codes, it would also impact the box drawing because the characters would be counted for padding but not visually take up any space:

![image](https://github.com/laravel/prompts/assets/4977161/963bc31f-7b7e-46ac-bc80-1f5af7faee6b)

I previously maintained an ignore list to deal with the most common ones, but now that I better understand the problem, we can safely exclude any characters with an ordinal code point less than 32.

See https://en.wikipedia.org/wiki/C0_and_C1_control_codes and https://en.wikipedia.org/wiki/List_of_Unicode_characters

There are other potentially problematic control codes in the C1 range and elsewhere, but they're not easy to input in everyday use with the keyboard.