### PR TITLE
Add support for alternative arrow keys

### DIFF
--- a/src/Concerns/TypedValue.php
+++ b/src/Concerns/TypedValue.php
@@ -30,8 +30,8 @@ trait TypedValue
         $this->on('key', function ($key) use ($submit) {
             if ($key[0] === "\e") {
                 match ($key) {
-                    Key::LEFT => $this->cursorPosition = max(0, $this->cursorPosition - 1),
-                    Key::RIGHT => $this->cursorPosition = min(mb_strlen($this->typedValue), $this->cursorPosition + 1),
+                    Key::LEFT, Key::LEFT_ARROW => $this->cursorPosition = max(0, $this->cursorPosition - 1),
+                    Key::RIGHT, Key::RIGHT_ARROW => $this->cursorPosition = min(mb_strlen($this->typedValue), $this->cursorPosition + 1),
                     Key::DELETE => $this->typedValue = mb_substr($this->typedValue, 0, $this->cursorPosition).mb_substr($this->typedValue, $this->cursorPosition + 1),
                     default => null,
                 };

--- a/src/ConfirmPrompt.php
+++ b/src/ConfirmPrompt.php
@@ -27,7 +27,7 @@ class ConfirmPrompt extends Prompt
         $this->on('key', fn ($key) => match ($key) {
             'y' => $this->confirmed = true,
             'n' => $this->confirmed = false,
-            Key::TAB, Key::UP, Key::DOWN, Key::LEFT, Key::RIGHT, 'h', 'j', 'k', 'l' => $this->confirmed = ! $this->confirmed,
+            Key::TAB, Key::UP, Key::UP_ARROW, Key::DOWN, Key::DOWN_ARROW, Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, 'h', 'j', 'k', 'l' => $this->confirmed = ! $this->confirmed,
             Key::ENTER => $this->submit(),
             default => null,
         });

--- a/src/Key.php
+++ b/src/Key.php
@@ -12,6 +12,14 @@ class Key
 
     const LEFT = "\e[D";
 
+    const UP_ARROW = "\eOA";
+
+    const DOWN_ARROW = "\eOB";
+
+    const RIGHT_ARROW = "\eOC";
+
+    const LEFT_ARROW = "\eOD";
+
     const DELETE = "\e[3~";
 
     const BACKSPACE = "\177";

--- a/src/MultiSelectPrompt.php
+++ b/src/MultiSelectPrompt.php
@@ -52,8 +52,8 @@ class MultiSelectPrompt extends Prompt
         $this->values = $this->default;
 
         $this->on('key', fn ($key) => match ($key) {
-            Key::UP, Key::LEFT, Key::SHIFT_TAB, 'k', 'h' => $this->highlightPrevious(),
-            Key::DOWN, Key::RIGHT, Key::TAB, 'j', 'l' => $this->highlightNext(),
+            Key::UP, Key::UP_ARROW, Key::LEFT, Key::LEFT_ARROW, Key::SHIFT_TAB, 'k', 'h' => $this->highlightPrevious(),
+            Key::DOWN, Key::DOWN_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::TAB, 'j', 'l' => $this->highlightNext(),
             Key::SPACE => $this->toggleHighlighted(),
             Key::ENTER => $this->submit(),
             default => null,

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -36,10 +36,10 @@ class SearchPrompt extends Prompt
         $this->trackTypedValue(submit: false);
 
         $this->on('key', fn ($key) => match ($key) {
-            Key::UP, Key::SHIFT_TAB => $this->highlightPrevious(),
-            Key::DOWN, Key::TAB => $this->highlightNext(),
+            Key::UP, Key::UP_ARROW, Key::SHIFT_TAB => $this->highlightPrevious(),
+            Key::DOWN, Key::DOWN_ARROW, Key::TAB => $this->highlightNext(),
             Key::ENTER => $this->highlighted !== null ? $this->submit() : $this->search(),
-            Key::LEFT, Key::RIGHT => $this->highlighted = null,
+            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW => $this->highlighted = null,
             default => $this->search(),
         });
     }

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -42,8 +42,8 @@ class SelectPrompt extends Prompt
         }
 
         $this->on('key', fn ($key) => match ($key) {
-            Key::UP, Key::LEFT, Key::SHIFT_TAB, 'k', 'h' => $this->highlightPrevious(),
-            Key::DOWN, Key::RIGHT, Key::TAB, 'j', 'l' => $this->highlightNext(),
+            Key::UP, Key::UP_ARROW, Key::LEFT, Key::LEFT_ARROW, Key::SHIFT_TAB, 'k', 'h' => $this->highlightPrevious(),
+            Key::DOWN, Key::DOWN_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::TAB, 'j', 'l' => $this->highlightNext(),
             Key::ENTER => $this->submit(),
             default => null,
         });

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -46,10 +46,10 @@ class SuggestPrompt extends Prompt
         $this->options = $options instanceof Collection ? $options->all() : $options;
 
         $this->on('key', fn ($key) => match ($key) {
-            Key::UP, Key::SHIFT_TAB => $this->highlightPrevious(),
-            Key::DOWN, Key::TAB => $this->highlightNext(),
+            Key::UP, Key::UP_ARROW, Key::SHIFT_TAB => $this->highlightPrevious(),
+            Key::DOWN, Key::DOWN_ARROW, Key::TAB => $this->highlightNext(),
             Key::ENTER => $this->selectHighlighted(),
-            Key::LEFT, Key::RIGHT => $this->highlighted = null,
+            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW => $this->highlighted = null,
             default => (function () {
                 $this->highlighted = null;
                 $this->matches = null;


### PR DESCRIPTION
This PR adds support for alternative arrow key codes used in some scenarios.

Specifically, something called ["Single Shift Three" (SS3)](https://en.wikipedia.org/wiki/ANSI_escape_code#Fe_Escape_sequences). This [Stack Exchange post](https://vi.stackexchange.com/a/15328) does a pretty good job of explaining it, but essentially there are two escape sequences that can represent the directional keys.

Example from `infocmp`:

```
cuu1=\E[A
kcuu1=\EOA
```

And `man termcap`:

```
   cursor_up              cuu1                    up               up one line
   key_up                 kcuu1                   ku               up-arrow key
```

I'm not entirely sure what common scenarios would cause `\EOA` to be sent, but at least one user has reported this on 1 of 3 Macs with iTerm, and they've confirmed this fix.

Coming up with new names was a bit tricky, especially without renaming anything existing :woman_shrugging: 

Fixes #31 