### PR TITLE
Prompt `hint`

### DIFF
--- a/playground/confirm.php
+++ b/playground/confirm.php
@@ -9,7 +9,8 @@ $confirmed = confirm(
     validate: fn ($value) => match ($value) {
         false => 'You must install dependencies.',
         default => null,
-    }
+    },
+    hint: 'Dependencies are required to run the application.',
 );
 
 var_dump($confirmed);

--- a/playground/multiselect.php
+++ b/playground/multiselect.php
@@ -18,6 +18,7 @@ $permissions = multiselect(
         empty($values) => 'Please select at least one permission.',
         default => null,
     },
+    hint: 'The permissions will determine what the user can do.',
 );
 
 var_dump($permissions);

--- a/playground/password.php
+++ b/playground/password.php
@@ -12,6 +12,7 @@ $password = password(
         strlen($value) < 8 => 'Password should have at least 8 characters.',
         default => null,
     },
+    hint: 'Your password will be encrypted and stored securely.',
 );
 
 var_dump($password);

--- a/playground/search.php
+++ b/playground/search.php
@@ -29,7 +29,8 @@ $model = search(
         if ($value === '0') {
             return 'User 0 is not allowed to receive emails.';
         }
-    }
+    },
+    hint: 'An email will be sent to the user.',
 );
 
 var_dump($model);

--- a/playground/select.php
+++ b/playground/select.php
@@ -18,7 +18,8 @@ $role = select(
     validate: fn ($value) => match ($value) {
         'owner' => 'The owner role is already assigned.',
         default => null
-    }
+    },
+    hint: 'The role will determine what the user can do.',
 );
 
 var_dump($role);

--- a/playground/suggest.php
+++ b/playground/suggest.php
@@ -21,6 +21,7 @@ $model = suggest(
         strlen($value) === 0 => 'Please enter a model name.',
         default => null,
     },
+    hint: 'The model name should be singular.',
 );
 
 var_dump($model);

--- a/playground/text.php
+++ b/playground/text.php
@@ -12,6 +12,7 @@ $email = text(
         ! filter_var($value, FILTER_VALIDATE_EMAIL) => 'Please enter a valid email address.',
         default => null,
     },
+    hint: 'We will never share your email address with anyone else.',
 );
 
 var_dump($email);

--- a/src/ConfirmPrompt.php
+++ b/src/ConfirmPrompt.php
@@ -21,6 +21,7 @@ class ConfirmPrompt extends Prompt
         public string $no = 'No',
         public bool|string $required = false,
         public ?Closure $validate = null,
+        public string $hint = ''
     ) {
         $this->confirmed = $default;
 

--- a/src/MultiSelectPrompt.php
+++ b/src/MultiSelectPrompt.php
@@ -46,6 +46,7 @@ class MultiSelectPrompt extends Prompt
         public int $scroll = 5,
         public bool|string $required = false,
         public ?Closure $validate = null,
+        public string $hint = ''
     ) {
         $this->options = $options instanceof Collection ? $options->all() : $options;
         $this->default = $default instanceof Collection ? $default->all() : $default;

--- a/src/PasswordPrompt.php
+++ b/src/PasswordPrompt.php
@@ -16,6 +16,7 @@ class PasswordPrompt extends Prompt
         public string $placeholder = '',
         public bool|string $required = false,
         public ?Closure $validate = null,
+        public string $hint = ''
     ) {
         $this->trackTypedValue();
     }

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -32,6 +32,7 @@ class SearchPrompt extends Prompt
         public string $placeholder = '',
         public int $scroll = 5,
         public ?Closure $validate = null,
+        public string $hint = ''
     ) {
         $this->trackTypedValue(submit: false);
 

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -30,6 +30,7 @@ class SelectPrompt extends Prompt
         public int|string|null $default = null,
         public int $scroll = 5,
         public ?Closure $validate = null,
+        public string $hint = ''
     ) {
         $this->options = $options instanceof Collection ? $options->all() : $options;
 

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -42,6 +42,7 @@ class SuggestPrompt extends Prompt
         public int $scroll = 5,
         public bool|string $required = false,
         public ?Closure $validate = null,
+        public string $hint = ''
     ) {
         $this->options = $options instanceof Collection ? $options->all() : $options;
 

--- a/src/TextPrompt.php
+++ b/src/TextPrompt.php
@@ -17,6 +17,7 @@ class TextPrompt extends Prompt
         public string $default = '',
         public bool|string $required = false,
         public ?Closure $validate = null,
+        public string $hint = ''
     ) {
         $this->trackTypedValue($default);
     }

--- a/src/Themes/Default/Concerns/DrawsBoxes.php
+++ b/src/Themes/Default/Concerns/DrawsBoxes.php
@@ -10,6 +10,8 @@ trait DrawsBoxes
 
     /**
      * Draw a box.
+     *
+     * @return $this
      */
     protected function box(
         string $title,

--- a/src/Themes/Default/ConfirmPromptRenderer.php
+++ b/src/Themes/Default/ConfirmPromptRenderer.php
@@ -41,8 +41,11 @@ class ConfirmPromptRenderer extends Renderer
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $this->renderOptions($prompt),
                 )
-                ->hint($prompt->hint)
-                ->newLine(), // Space for errors
+                ->when(
+                    $prompt->hint,
+                    fn () => $this->hint($prompt->hint),
+                    fn () => $this->newLine() // Space for errors
+                ),
         };
     }
 

--- a/src/Themes/Default/ConfirmPromptRenderer.php
+++ b/src/Themes/Default/ConfirmPromptRenderer.php
@@ -41,6 +41,7 @@ class ConfirmPromptRenderer extends Renderer
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $this->renderOptions($prompt),
                 )
+                ->hint($prompt->hint)
                 ->newLine(), // Space for errors
         };
     }

--- a/src/Themes/Default/MultiSelectPromptRenderer.php
+++ b/src/Themes/Default/MultiSelectPromptRenderer.php
@@ -42,8 +42,11 @@ class MultiSelectPromptRenderer extends Renderer
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $this->renderOptions($prompt),
                 )
-                ->hint($prompt->hint)
-                ->newLine(), // Space for errors
+                ->when(
+                    $prompt->hint,
+                    fn () => $this->hint($prompt->hint),
+                    fn () => $this->newLine() // Space for errors
+                ),
         };
     }
 

--- a/src/Themes/Default/MultiSelectPromptRenderer.php
+++ b/src/Themes/Default/MultiSelectPromptRenderer.php
@@ -42,6 +42,7 @@ class MultiSelectPromptRenderer extends Renderer
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $this->renderOptions($prompt),
                 )
+                ->hint($prompt->hint)
                 ->newLine(), // Space for errors
         };
     }

--- a/src/Themes/Default/PasswordPromptRenderer.php
+++ b/src/Themes/Default/PasswordPromptRenderer.php
@@ -43,6 +43,7 @@ class PasswordPromptRenderer extends Renderer
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $prompt->maskedWithCursor($maxWidth),
                 )
+                ->hint($prompt->hint)
                 ->newLine(), // Space for errors
         };
     }

--- a/src/Themes/Default/PasswordPromptRenderer.php
+++ b/src/Themes/Default/PasswordPromptRenderer.php
@@ -43,8 +43,11 @@ class PasswordPromptRenderer extends Renderer
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $prompt->maskedWithCursor($maxWidth),
                 )
-                ->hint($prompt->hint)
-                ->newLine(), // Space for errors
+                ->when(
+                    $prompt->hint,
+                    fn () => $this->hint($prompt->hint),
+                    fn () => $this->newLine() // Space for errors
+                ),
         };
     }
 }

--- a/src/Themes/Default/Renderer.php
+++ b/src/Themes/Default/Renderer.php
@@ -62,6 +62,18 @@ abstract class Renderer
     }
 
     /**
+     * Render an hint message.
+     */
+    protected function hint(string $message): self
+    {
+        if ($message === '') {
+            return $this;
+        }
+
+        return $this->line($this->gray("  {$message}"));
+    }
+
+    /**
      * Render the output with a blank line above and below.
      */
     public function __toString()

--- a/src/Themes/Default/Renderer.php
+++ b/src/Themes/Default/Renderer.php
@@ -70,6 +70,8 @@ abstract class Renderer
             return $this;
         }
 
+        $message = $this->truncate($message, $this->prompt->terminal()->cols() - 6);
+
         return $this->line($this->gray("  {$message}"));
     }
 

--- a/src/Themes/Default/Renderer.php
+++ b/src/Themes/Default/Renderer.php
@@ -76,6 +76,22 @@ abstract class Renderer
     }
 
     /**
+     * Apply the callback if the given "value" is truthy.
+     *
+     * @return $this
+     */
+    protected function when(mixed $value, callable $callback, callable $default = null): self
+    {
+        if ($value) {
+            $callback($this);
+        } elseif ($default) {
+            $default($this);
+        }
+
+        return $this;
+    }
+
+    /**
      * Render the output with a blank line above and below.
      */
     public function __toString()

--- a/src/Themes/Default/SearchPromptRenderer.php
+++ b/src/Themes/Default/SearchPromptRenderer.php
@@ -53,6 +53,7 @@ class SearchPromptRenderer extends Renderer
                     $prompt->valueWithCursor($maxWidth),
                     $this->renderOptions($prompt),
                 )
+                ->hint($prompt->hint)
                 ->spaceForDropdown($prompt)
                 ->newLine(), // Space for errors
         };

--- a/src/Themes/Default/SearchPromptRenderer.php
+++ b/src/Themes/Default/SearchPromptRenderer.php
@@ -53,8 +53,12 @@ class SearchPromptRenderer extends Renderer
                     $prompt->valueWithCursor($maxWidth),
                     $this->renderOptions($prompt),
                 )
+                ->when(
+                    $prompt->hint,
+                    fn () => $this->hint($prompt->hint),
+                    fn () => $this->newLine() // Space for errors
+                )
                 ->spaceForDropdown($prompt)
-                ->newLine(), // Space for errors
         };
     }
 
@@ -78,8 +82,6 @@ class SearchPromptRenderer extends Renderer
         if ($prompt->searchValue() !== '') {
             return $this;
         }
-
-        $this->hint($prompt->hint);
 
         $this->newLine(max(
             0,

--- a/src/Themes/Default/SearchPromptRenderer.php
+++ b/src/Themes/Default/SearchPromptRenderer.php
@@ -53,7 +53,6 @@ class SearchPromptRenderer extends Renderer
                     $prompt->valueWithCursor($maxWidth),
                     $this->renderOptions($prompt),
                 )
-                ->hint($prompt->hint)
                 ->spaceForDropdown($prompt)
                 ->newLine(), // Space for errors
         };
@@ -79,6 +78,8 @@ class SearchPromptRenderer extends Renderer
         if ($prompt->searchValue() !== '') {
             return $this;
         }
+
+        $this->hint($prompt->hint);
 
         $this->newLine(max(
             0,

--- a/src/Themes/Default/SearchPromptRenderer.php
+++ b/src/Themes/Default/SearchPromptRenderer.php
@@ -45,7 +45,8 @@ class SearchPromptRenderer extends Renderer
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $this->valueWithCursorAndSearchIcon($prompt, $maxWidth),
                     $this->renderOptions($prompt),
-                ),
+                )
+                ->hint($prompt->hint),
 
             default => $this
                 ->box(

--- a/src/Themes/Default/SelectPromptRenderer.php
+++ b/src/Themes/Default/SelectPromptRenderer.php
@@ -44,8 +44,11 @@ class SelectPromptRenderer extends Renderer
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $this->renderOptions($prompt),
                 )
-                ->hint($prompt->hint)
-                ->newLine(), // Space for errors
+                ->when(
+                    $prompt->hint,
+                    fn () => $this->hint($prompt->hint),
+                    fn () => $this->newLine() // Space for errors
+                ),
         };
     }
 

--- a/src/Themes/Default/SelectPromptRenderer.php
+++ b/src/Themes/Default/SelectPromptRenderer.php
@@ -44,6 +44,7 @@ class SelectPromptRenderer extends Renderer
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $this->renderOptions($prompt),
                 )
+                ->hint($prompt->hint)
                 ->newLine(), // Space for errors
         };
     }

--- a/src/Themes/Default/SuggestPromptRenderer.php
+++ b/src/Themes/Default/SuggestPromptRenderer.php
@@ -46,6 +46,7 @@ class SuggestPromptRenderer extends Renderer
                     $this->valueWithCursorAndArrow($prompt, $maxWidth),
                     $this->renderOptions($prompt),
                 )
+                ->hint($prompt->hint)
                 ->spaceForDropdown($prompt)
                 ->newLine(), // Space for errors
         };

--- a/src/Themes/Default/SuggestPromptRenderer.php
+++ b/src/Themes/Default/SuggestPromptRenderer.php
@@ -46,7 +46,6 @@ class SuggestPromptRenderer extends Renderer
                     $this->valueWithCursorAndArrow($prompt, $maxWidth),
                     $this->renderOptions($prompt),
                 )
-                ->hint($prompt->hint)
                 ->spaceForDropdown($prompt)
                 ->newLine(), // Space for errors
         };
@@ -73,6 +72,8 @@ class SuggestPromptRenderer extends Renderer
      */
     protected function spaceForDropdown(SuggestPrompt $prompt): self
     {
+        $this->hint($prompt->hint);
+
         if ($prompt->value() === '' && $prompt->highlighted === null) {
             $this->newLine(min(
                 count($prompt->matches()),

--- a/src/Themes/Default/SuggestPromptRenderer.php
+++ b/src/Themes/Default/SuggestPromptRenderer.php
@@ -46,8 +46,12 @@ class SuggestPromptRenderer extends Renderer
                     $this->valueWithCursorAndArrow($prompt, $maxWidth),
                     $this->renderOptions($prompt),
                 )
-                ->spaceForDropdown($prompt)
-                ->newLine(), // Space for errors
+                ->when(
+                    $prompt->hint,
+                    fn () => $this->hint($prompt->hint),
+                    fn () => $this->newLine() // Space for errors
+                )
+                ->spaceForDropdown($prompt),
         };
     }
 
@@ -72,8 +76,6 @@ class SuggestPromptRenderer extends Renderer
      */
     protected function spaceForDropdown(SuggestPrompt $prompt): self
     {
-        $this->hint($prompt->hint);
-
         if ($prompt->value() === '' && $prompt->highlighted === null) {
             $this->newLine(min(
                 count($prompt->matches()),

--- a/src/Themes/Default/TextPromptRenderer.php
+++ b/src/Themes/Default/TextPromptRenderer.php
@@ -43,6 +43,7 @@ class TextPromptRenderer extends Renderer
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $prompt->valueWithCursor($maxWidth),
                 )
+                ->hint($prompt->hint)
                 ->newLine(), // Space for errors
         };
     }

--- a/src/Themes/Default/TextPromptRenderer.php
+++ b/src/Themes/Default/TextPromptRenderer.php
@@ -43,8 +43,11 @@ class TextPromptRenderer extends Renderer
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $prompt->valueWithCursor($maxWidth),
                 )
-                ->hint($prompt->hint)
-                ->newLine(), // Space for errors
+                ->when(
+                    $prompt->hint,
+                    fn () => $this->hint($prompt->hint),
+                    fn () => $this->newLine() // Space for errors
+                )
         };
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -8,17 +8,17 @@ use Illuminate\Support\Collection;
 /**
  * Prompt the user for text input.
  */
-function text(string $label, string $placeholder = '', string $default = '', bool|string $required = false, Closure $validate = null): string
+function text(string $label, string $placeholder = '', string $default = '', bool|string $required = false, Closure $validate = null, string $hint = ''): string
 {
-    return (new TextPrompt($label, $placeholder, $default, $required, $validate))->prompt();
+    return (new TextPrompt($label, $placeholder, $default, $required, $validate, $hint))->prompt();
 }
 
 /**
  * Prompt the user for input, hiding the value.
  */
-function password(string $label, string $placeholder = '', bool|string $required = false, Closure $validate = null): string
+function password(string $label, string $placeholder = '', bool|string $required = false, Closure $validate = null, string $hint = ''): string
 {
-    return (new PasswordPrompt($label, $placeholder, $required, $validate))->prompt();
+    return (new PasswordPrompt($label, $placeholder, $required, $validate, $hint))->prompt();
 }
 
 /**
@@ -26,9 +26,9 @@ function password(string $label, string $placeholder = '', bool|string $required
  *
  * @param  array<int|string, string>|Collection<int|string, string>  $options
  */
-function select(string $label, array|Collection $options, int|string $default = null, int $scroll = 5, Closure $validate = null): int|string
+function select(string $label, array|Collection $options, int|string $default = null, int $scroll = 5, Closure $validate = null, string $hint = ''): int|string
 {
-    return (new SelectPrompt($label, $options, $default, $scroll, $validate))->prompt();
+    return (new SelectPrompt($label, $options, $default, $scroll, $validate, $hint))->prompt();
 }
 
 /**
@@ -38,17 +38,17 @@ function select(string $label, array|Collection $options, int|string $default = 
  * @param  array<int|string>|Collection<int, int|string>  $default
  * @return array<int|string>
  */
-function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, Closure $validate = null): array
+function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, Closure $validate = null, string $hint = ''): array
 {
-    return (new MultiSelectPrompt($label, $options, $default, $scroll, $required, $validate))->prompt();
+    return (new MultiSelectPrompt($label, $options, $default, $scroll, $required, $validate, $hint))->prompt();
 }
 
 /**
  * Prompt the user to confirm an action.
  */
-function confirm(string $label, bool $default = true, string $yes = 'Yes', string $no = 'No', bool|string $required = false, Closure $validate = null): bool
+function confirm(string $label, bool $default = true, string $yes = 'Yes', string $no = 'No', bool|string $required = false, Closure $validate = null, string $hint = ''): bool
 {
-    return (new ConfirmPrompt($label, $default, $yes, $no, $required, $validate))->prompt();
+    return (new ConfirmPrompt($label, $default, $yes, $no, $required, $validate, $hint))->prompt();
 }
 
 /**
@@ -56,9 +56,9 @@ function confirm(string $label, bool $default = true, string $yes = 'Yes', strin
  *
  * @param  array<string>|Collection<int, string>|Closure(string): array<string>  $options
  */
-function suggest(string $label, array|Collection|Closure $options, string $placeholder = '', string $default = '', int $scroll = 5, bool|string $required = false, Closure $validate = null): string
+function suggest(string $label, array|Collection|Closure $options, string $placeholder = '', string $default = '', int $scroll = 5, bool|string $required = false, Closure $validate = null, string $hint = ''): string
 {
-    return (new SuggestPrompt($label, $options, $placeholder, $default, $scroll, $required, $validate))->prompt();
+    return (new SuggestPrompt($label, $options, $placeholder, $default, $scroll, $required, $validate, $hint))->prompt();
 }
 
 /**
@@ -66,9 +66,9 @@ function suggest(string $label, array|Collection|Closure $options, string $place
  *
  * @param  Closure(string): array<int|string, string>  $options
  */
-function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, Closure $validate = null): int|string
+function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, Closure $validate = null, string $hint = ''): int|string
 {
-    return (new SearchPrompt($label, $options, $placeholder, $scroll, $validate))->prompt();
+    return (new SearchPrompt($label, $options, $placeholder, $scroll, $validate, $hint))->prompt();
 }
 
 /**


### PR DESCRIPTION
Considering the stylization of the prompt that reminds us of the idea we have in HTML where the typed value is inserted in an input, this PR aims to add `hits` to the inputs: small blocks of text that allow us to give hints, similar to what we do in HTML:

![CleanShot 2023-08-08 at 8 28 16](https://github.com/laravel/prompts/assets/60591772/6d81c50f-0715-43b9-99e8-c2b3a5c435e6)

Notes: 
- The hints will be visible as truncated, following the prompt rules.
- The hints will be visible as long as an error message, alert or validation error does not occur.
- The hints is available for all prompt types.