### PR TITLE
Add a default hint for the `multiselect` prompt

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -38,7 +38,7 @@ function select(string $label, array|Collection $options, int|string $default = 
  * @param  array<int|string>|Collection<int, int|string>  $default
  * @return array<int|string>
  */
-function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, Closure $validate = null, string $hint = ''): array
+function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, Closure $validate = null, string $hint = 'Use the space bar to select options.'): array
 {
     return (new MultiSelectPrompt($label, $options, $default, $scroll, $required, $validate, $hint))->prompt();
 }


### PR DESCRIPTION
This PR uses the `hint` feature introduced in #44 to add a default hint to the `multiselect` prompt, instructing users to use the space bar to select options. I went with the term "space bar" as it is the dominant wording used on [Wikipedia](https://en.wikipedia.org/wiki/Space_bar).

![image](https://github.com/laravel/prompts/assets/4977161/891728e4-fd11-4e72-a783-f23bebd58799)


A few people have raised this issue specifically referring to the multi-select prompt used in the Laravel installer, which will be many people's first exposure to Prompts and Laravel. We could just add this hint to the multi-select prompts in the installer, but ultimately it seemed more user-friendly to make it the default. If someone does not want the hint, they would need to pass an empty string to the `hint` argument.

Fixes #41
Fixes #48 