### PR TITLE
Fix display of submitted multiselect selections

### DIFF
--- a/src/Concerns/FakesInputOutput.php
+++ b/src/Concerns/FakesInputOutput.php
@@ -39,10 +39,50 @@ trait FakesInputOutput
      */
     public static function assertOutputContains(string $string): void
     {
+        Assert::assertStringContainsString($string, static::content());
+    }
+
+    /**
+     * Assert that the output doesn't contain the given string.
+     */
+    public static function assertOutputDoesntContain(string $string): void
+    {
+        Assert::assertStringNotContainsString($string, static::content());
+    }
+
+    /**
+     * Assert that the stripped output contains the given string.
+     */
+    public static function assertStrippedOutputContains(string $string): void
+    {
+        Assert::assertStringContainsString($string, static::strippedContent());
+    }
+
+    /**
+     * Assert that the stripped output doesn't contain the given string.
+     */
+    public static function assertStrippedOutputDoesntContain(string $string): void
+    {
+        Assert::assertStringNotContainsString($string, static::strippedContent());
+    }
+
+    /**
+     * Get the buffered console output.
+     */
+    public static function content(): string
+    {
         if (! static::output() instanceof BufferedConsoleOutput) {
-            throw new RuntimeException('Prompt must be faked before asserting output.');
+            throw new RuntimeException('Prompt must be faked before accessing content.');
         }
 
-        Assert::assertStringContainsString($string, static::output()->content());
+        return static::output()->content();
+    }
+
+    /**
+     * Get the buffered console output, stripped of escape sequences.
+     */
+    public static function strippedContent(): string
+    {
+        return preg_replace("/\e\[[0-9;?]*[A-Za-z]/", '', static::content());
     }
 }

--- a/src/MultiSelectPrompt.php
+++ b/src/MultiSelectPrompt.php
@@ -79,7 +79,7 @@ class MultiSelectPrompt extends Prompt
     public function labels(): array
     {
         if (array_is_list($this->options)) {
-            return array_values(array_intersect_key($this->options, $this->values));
+            return array_map(fn ($value) => (string) $value, $this->values);
         }
 
         return array_values(array_intersect_key($this->options, array_flip($this->values)));

--- a/tests/Feature/MultiselectPromptTest.php
+++ b/tests/Feature/MultiselectPromptTest.php
@@ -19,6 +19,10 @@ it('accepts an array of labels', function () {
     );
 
     expect($result)->toBe(['Green', 'Blue']);
+
+    Prompt::assertStrippedOutputDoesntContain('│ Red');
+    Prompt::assertStrippedOutputContains('│ Green');
+    Prompt::assertStrippedOutputContains('│ Blue');
 });
 
 it('accepts an array of keys and labels', function () {


### PR DESCRIPTION
This PR fixes an issue where the "submitted" state of the `multiselect` displayed the user selections incorrectly when using a list array.

Fixes #52