### PR TITLE
Spin with `then` Method

### DIFF
--- a/playground/spin.php
+++ b/playground/spin.php
@@ -17,4 +17,29 @@ echo PHP_EOL;
 
 var_dump($result);
 
-echo str_repeat(PHP_EOL, 6);
+spin(
+    function () {
+        sleep(2);
+    },
+    'Starting process...',
+)->then(
+    function () {
+        sleep(2);
+    },
+    'Installing dependencies...',
+)->then(
+    function () {
+        sleep(2);
+    },
+    'Preparing environment...',
+)->then(
+    function () {
+        sleep(2);
+    },
+    'Finishing up...',
+)->then(
+    function () {
+        sleep(1);
+    },
+    'Done!',
+);

--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -33,7 +33,7 @@ class Spinner extends Prompt
     /**
      * Render the spinner and execute the callback.
      *
-     * @template TReturn of mixed
+     * @template TReturn of mixed|self|Spinner
      *
      * @param  \Closure(): TReturn  $callback
      * @return TReturn
@@ -78,6 +78,10 @@ class Spinner extends Prompt
                 pcntl_async_signals($originalAsync);
                 pcntl_signal(SIGINT, SIG_DFL);
 
+                if (! $result) {
+                    return $this; // @phpstan-ignore-line
+                }
+
                 return $result;
             }
         } catch (\Throwable $e) {
@@ -87,6 +91,23 @@ class Spinner extends Prompt
 
             throw $e;
         }
+    }
+
+    /**
+     * Render spinners sequentially executing the callback.
+     *
+     * @template TReturn of mixed|self|Spinner
+     *
+     * @param \Closure(): TReturn $callback
+     * @param string $message
+     * @return Spinner
+     * @throws \Throwable
+     */
+    public function then(Closure $callback, string $message = ''): self
+    {
+        (new self($message))->spin($callback);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
According to [this issue](https://github.com/laravel/prompts/issues/51), I had the idea of suggesting an additional resource for `spin`, evaluating the result of the callback return. **When the callback is evaluated to false (none, null, false), we can chain the `then` method in sequence to create a fluent interface**, as demonstrated below:

![CleanShot 2023-08-16 at 12 24 45](https://github.com/laravel/prompts/assets/60591772/e58a010f-d140-4e4c-8071-9db4925f361c)
