### PR TITLE
Add default fallbacks

### DIFF
--- a/src/ConfirmPrompt.php
+++ b/src/ConfirmPrompt.php
@@ -3,6 +3,8 @@
 namespace Laravel\Prompts;
 
 use Closure;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class ConfirmPrompt extends Prompt
 {
@@ -48,5 +50,18 @@ class ConfirmPrompt extends Prompt
     public function label(): string
     {
         return $this->confirmed ? $this->yes : $this->no;
+    }
+
+    /**
+     * Configure the default fallback behavior.
+     */
+    protected function configureDefaultFallback(): void
+    {
+        self::fallbackUsing(fn (self $prompt) => $this->retryUntilValid(
+            fn () => (new SymfonyStyle(new ArrayInput([]), static::output()))->confirm($prompt->label, $prompt->default),
+            $prompt->required,
+            $prompt->validate,
+            fn ($message) => static::output()->writeln("<error>{$message}</error>"),
+        ));
     }
 }

--- a/src/Note.php
+++ b/src/Note.php
@@ -41,4 +41,12 @@ class Note extends Prompt
     {
         return true;
     }
+
+    /**
+     * Configure the default fallback behavior.
+     */
+    protected function configureDefaultFallback(): void
+    {
+        //
+    }
 }

--- a/src/PasswordPrompt.php
+++ b/src/PasswordPrompt.php
@@ -3,6 +3,8 @@
 namespace Laravel\Prompts;
 
 use Closure;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class PasswordPrompt extends Prompt
 {
@@ -39,5 +41,18 @@ class PasswordPrompt extends Prompt
         }
 
         return $this->addCursor($this->masked(), $this->cursorPosition, $maxWidth);
+    }
+
+    /**
+     * Configure the default fallback behavior.
+     */
+    protected function configureDefaultFallback(): void
+    {
+        self::fallbackUsing(fn (self $prompt) => $this->retryUntilValid(
+            fn () => (new SymfonyStyle(new ArrayInput([]), static::output()))->askHidden($prompt->label) ?? '',
+            $prompt->required,
+            $prompt->validate,
+            fn ($message) => static::output()->writeln("<error>{$message}</error>"),
+        ));
     }
 }

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -4,7 +4,6 @@ namespace Laravel\Prompts;
 
 use Closure;
 use Laravel\Prompts\Output\ConsoleOutput;
-use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
@@ -75,11 +74,13 @@ abstract class Prompt
     {
         $this->capturePreviousNewLines();
 
+        if (! static::hasFallback()) {
+            $this->configureDefaultFallback();
+        }
+
         if (static::shouldFallback()) {
             return $this->fallback();
         }
-
-        $this->checkEnvironment();
 
         try {
             static::terminal()->setTty('-icanon -isig -echo');
@@ -324,16 +325,6 @@ abstract class Prompt
         if (is_string($error) && strlen($error) > 0) {
             $this->state = 'error';
             $this->error = $error;
-        }
-    }
-
-    /**
-     * Check whether the environment can support the prompt.
-     */
-    private function checkEnvironment(): void
-    {
-        if (PHP_OS_FAMILY === 'Windows') {
-            throw new RuntimeException('Prompts is not currently supported on Windows. Please use WSL or configure a fallback.');
         }
     }
 }

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -4,6 +4,8 @@ namespace Laravel\Prompts;
 
 use Closure;
 use Illuminate\Support\Collection;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class SelectPrompt extends Prompt
 {
@@ -137,5 +139,18 @@ class SelectPrompt extends Prompt
         } elseif ($this->highlighted === 0) {
             $this->firstVisible = 0;
         }
+    }
+
+    /**
+     * Configure the default fallback behavior.
+     */
+    protected function configureDefaultFallback(): void
+    {
+        self::fallbackUsing(fn (self $prompt) => $this->retryUntilValid(
+            fn () => (new SymfonyStyle(new ArrayInput([]), static::output()))->choice($prompt->label, $prompt->options, $prompt->default),
+            true,
+            $prompt->validate,
+            fn ($message) => static::output()->writeln("<error>{$message}</error>"),
+        ));
     }
 }

--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -123,4 +123,12 @@ class Spinner extends Prompt
     {
         return true;
     }
+
+    /**
+     * Configure the default fallback behavior.
+     */
+    protected function configureDefaultFallback(): void
+    {
+        //
+    }
 }

--- a/src/TextPrompt.php
+++ b/src/TextPrompt.php
@@ -3,6 +3,8 @@
 namespace Laravel\Prompts;
 
 use Closure;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class TextPrompt extends Prompt
 {
@@ -32,5 +34,18 @@ class TextPrompt extends Prompt
         }
 
         return $this->addCursor($this->value(), $this->cursorPosition, $maxWidth);
+    }
+
+    /**
+     * Configure the default fallback behavior.
+     */
+    protected function configureDefaultFallback(): void
+    {
+        self::fallbackUsing(fn (self $prompt) => $this->retryUntilValid(
+            fn () => (new SymfonyStyle(new ArrayInput([]), static::output()))->ask($prompt->label, $prompt->default ?: null) ?? '',
+            $prompt->required,
+            $prompt->validate,
+            fn ($message) => static::output()->writeln("<error>{$message}</error>"),
+        ));
     }
 }


### PR DESCRIPTION
This PR adds default fallback behavior directly to the Prompts library so that it doesn't _need_ to be implemented by consuming projects and packages.

This will allow us to remove [this code](https://github.com/laravel/installer/blob/master/src/Concerns/ConfiguresPrompts.php) from the Laravel installer.

We could also remove the same code from `laravel/framework`, however, the framework fallback currently uses the updated styling from Nuno.