### PR TITLE
Add `multisearch` prompt

### DIFF
--- a/playground/multisearch.php
+++ b/playground/multisearch.php
@@ -16,7 +16,7 @@ $models = multisearch(
         usleep(100 * 1000);
 
         $min = min(strlen($value)-1, 10);
-        $max = max(10, 20 - strlen($value));
+        $max = max(9, 20 - strlen($value));
 
         if ($max - $min < 0) {
             return [];
@@ -25,7 +25,7 @@ $models = multisearch(
         $data = [];
 
         foreach (range($min, $max) as $id) {
-            $data["id-$id"] = "User $id";
+            $data["user-$id"] = "User $id";
         }
 
         return $data;
@@ -40,4 +40,4 @@ $models = multisearch(
 
 var_dump($models);
 
-echo str_repeat(PHP_EOL, 6);
+// echo str_repeat(PHP_EOL, 5);

--- a/playground/multisearch.php
+++ b/playground/multisearch.php
@@ -1,0 +1,43 @@
+<?php
+
+use function Laravel\Prompts\multisearch;
+
+require __DIR__.'/../vendor/autoload.php';
+
+$models = multisearch(
+    label: 'Which users should receive the email?',
+    placeholder: 'Search...',
+    returnKeys: true,
+    options: function ($value) {
+        if (strlen($value) === 0) {
+            return [];
+        }
+
+        usleep(100 * 1000);
+
+        $min = min(strlen($value)-1, 10);
+        $max = max(10, 20 - strlen($value));
+
+        if ($max - $min < 0) {
+            return [];
+        }
+
+        $data = [];
+
+        foreach (range($min, $max) as $id) {
+            $data["id-$id"] = "User $id";
+        }
+
+        return $data;
+    },
+    validate: function ($values) {
+        if (in_array('id-1', $values)) {
+            return 'User 1 cannot receive emails';
+        }
+    },
+    required: true,
+);
+
+var_dump($models);
+
+echo str_repeat(PHP_EOL, 6);

--- a/playground/multisearch.php
+++ b/playground/multisearch.php
@@ -7,7 +7,6 @@ require __DIR__.'/../vendor/autoload.php';
 $models = multisearch(
     label: 'Which users should receive the email?',
     placeholder: 'Search...',
-    returnKeys: true,
     options: function ($value) {
         if (strlen($value) === 0) {
             return [];

--- a/playground/multisearch.php
+++ b/playground/multisearch.php
@@ -38,5 +38,3 @@ $models = multisearch(
 );
 
 var_dump($models);
-
-// echo str_repeat(PHP_EOL, 5);

--- a/playground/multisearch.php
+++ b/playground/multisearch.php
@@ -4,37 +4,40 @@ use function Laravel\Prompts\multisearch;
 
 require __DIR__.'/../vendor/autoload.php';
 
-$models = multisearch(
+$users = collect([
+    'taylor' => 'Taylor Otwell',
+    'dries' => 'Dries Vints',
+    'james' => 'James Brooks',
+    'nuno' => 'Nuno Maduro',
+    'mior' => 'Mior Muhammad Zaki',
+    'jess' => 'Jess Archer',
+    'guus' => 'Guus Leeuw',
+    'tim' => 'Tim MacDonald',
+    'joe' => 'Joe Dixon',
+]);
+
+$selected = multisearch(
     label: 'Which users should receive the email?',
     placeholder: 'Search...',
-    options: function ($value) {
+    options: function ($value) use ($users) {
+        // Comment to show all results by default.
         if (strlen($value) === 0) {
             return [];
         }
 
-        usleep(100 * 1000);
+        usleep(100 * 1000); // Simulate a DB query.
 
-        $min = min(strlen($value)-1, 10);
-        $max = max(9, 20 - strlen($value));
-
-        if ($max - $min < 0) {
-            return [];
-        }
-
-        $data = [];
-
-        foreach (range($min, $max) as $id) {
-            $data["user-$id"] = "User $id";
-        }
-
-        return $data;
-    },
-    validate: function ($values) {
-        if (in_array('id-1', $values)) {
-            return 'User 1 cannot receive emails';
-        }
+        return $users->when(
+            strlen($value),
+            fn ($users) => $users->filter(fn ($name) => str_contains(strtolower($name), strtolower($value)))
+        )->all();
     },
     required: true,
+    validate: function ($values) {
+        if (in_array('jess', $values)) {
+            return 'Jess cannot receive emails';
+        }
+    },
 );
 
-var_dump($models);
+var_dump($selected);

--- a/src/Concerns/Themes.php
+++ b/src/Concerns/Themes.php
@@ -4,6 +4,7 @@ namespace Laravel\Prompts\Concerns;
 
 use InvalidArgumentException;
 use Laravel\Prompts\ConfirmPrompt;
+use Laravel\Prompts\MultiSearchPrompt;
 use Laravel\Prompts\MultiSelectPrompt;
 use Laravel\Prompts\Note;
 use Laravel\Prompts\PasswordPrompt;
@@ -13,6 +14,7 @@ use Laravel\Prompts\Spinner;
 use Laravel\Prompts\SuggestPrompt;
 use Laravel\Prompts\TextPrompt;
 use Laravel\Prompts\Themes\Default\ConfirmPromptRenderer;
+use Laravel\Prompts\Themes\Default\MultiSearchPromptRenderer;
 use Laravel\Prompts\Themes\Default\MultiSelectPromptRenderer;
 use Laravel\Prompts\Themes\Default\NoteRenderer;
 use Laravel\Prompts\Themes\Default\PasswordPromptRenderer;
@@ -42,6 +44,7 @@ trait Themes
             MultiSelectPrompt::class => MultiSelectPromptRenderer::class,
             ConfirmPrompt::class => ConfirmPromptRenderer::class,
             SearchPrompt::class => SearchPromptRenderer::class,
+            MultiSearchPrompt::class => MultiSearchPromptRenderer::class,
             SuggestPrompt::class => SuggestPromptRenderer::class,
             Spinner::class => SpinnerRenderer::class,
             Note::class => NoteRenderer::class,

--- a/src/Concerns/TypedValue.php
+++ b/src/Concerns/TypedValue.php
@@ -19,7 +19,7 @@ trait TypedValue
     /**
      * Track the value as the user types.
      */
-    protected function trackTypedValue(string $default = '', bool $submit = true, ?callable $allowKey = null): void
+    protected function trackTypedValue(string $default = '', bool $submit = true, callable $ignore = null): void
     {
         $this->typedValue = $default;
 
@@ -27,9 +27,9 @@ trait TypedValue
             $this->cursorPosition = mb_strlen($this->typedValue);
         }
 
-        $this->on('key', function ($key) use ($submit, $allowKey) {
+        $this->on('key', function ($key) use ($submit, $ignore) {
             if ($key[0] === "\e") {
-                if ($allowKey !== null && !($allowKey)($key)) {
+                if ($ignore !== null && $ignore($key)) {
                     return;
                 }
 
@@ -45,7 +45,7 @@ trait TypedValue
 
             // Keys may be buffered.
             foreach (mb_str_split($key) as $key) {
-                if ($allowKey !== null && !($allowKey)($key)) {
+                if ($ignore !== null && $ignore($key)) {
                     return;
                 }
 

--- a/src/MultiSearchPrompt.php
+++ b/src/MultiSearchPrompt.php
@@ -36,7 +36,7 @@ class MultiSearchPrompt extends Prompt
 
     /**
      * The selected values.
-     * 
+     *
      * @var array<int|string, string>
      */
     public array $values = [];
@@ -44,6 +44,7 @@ class MultiSearchPrompt extends Prompt
     /**
      * Create a new MultiSearchPrompt instance.
      *
+     * @param  array<int|string, string>|Collection<int|string, string>  $default
      * @param  Closure(string): array<int|string, string>  $options
      */
     public function __construct(
@@ -59,7 +60,7 @@ class MultiSearchPrompt extends Prompt
     ) {
         $this->default = $default instanceof Collection ? $default->all() : $default;
         $this->values = $this->default;
-        
+
         $this->trackTypedValue(submit: false, allowKey: fn ($key) => $key !== Key::SPACE || $this->highlighted === null);
 
         $this->on('key', fn ($key) => match ($key) {
@@ -207,13 +208,11 @@ class MultiSearchPrompt extends Prompt
 
     /**
      * Get the selected value.
+     *
+     * @return array<int|string>
      */
     public function value(): array
     {
-        if ($this->values === null) {
-            return null;
-        }
-
         return $this->returnKeys
             ? array_keys($this->values)
             : $this->values;

--- a/src/MultiSearchPrompt.php
+++ b/src/MultiSearchPrompt.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace Laravel\Prompts;
+
+use Closure;
+use Illuminate\Support\Collection;
+
+class MultiSearchPrompt extends Prompt
+{
+    use Concerns\Truncation;
+    use Concerns\TypedValue;
+
+    /**
+     * The index of the highlighted option.
+     */
+    public ?int $highlighted = null;
+
+    /**
+     * The index of the first visible option.
+     */
+    public int $firstVisible = 0;
+
+    /**
+     * The cached matches.
+     *
+     * @var array<int|string, string>|null
+     */
+    protected ?array $matches = null;
+
+    /**
+     * The default values the multi-search prompt.
+     *
+     * @var array<int|string, string>
+     */
+    public array $default;
+
+    /**
+     * The selected values.
+     * 
+     * @var array<int|string, string>
+     */
+    public array $values = [];
+
+    /**
+     * Create a new MultiSearchPrompt instance.
+     *
+     * @param  Closure(string): array<int|string, string>  $options
+     */
+    public function __construct(
+        public string $label,
+        public Closure $options,
+        public bool $returnKeys = true,
+        array|Collection $default = [],
+        public string $placeholder = '',
+        public int $scroll = 5,
+        public bool|string $required = false,
+        public ?Closure $validate = null,
+        public string $hint = '',
+    ) {
+        $this->default = $default instanceof Collection ? $default->all() : $default;
+        $this->values = $this->default;
+        
+        $this->trackTypedValue(submit: false, allowKey: fn ($key) => $key !== Key::SPACE || $this->highlighted === null);
+
+        $this->on('key', fn ($key) => match ($key) {
+            Key::UP, Key::UP_ARROW, Key::SHIFT_TAB => $this->highlightPrevious(),
+            Key::DOWN, Key::DOWN_ARROW, Key::TAB => $this->highlightNext(),
+            Key::SPACE => $this->highlighted !== null ? $this->toggleHighlighted() : null,
+            Key::ENTER => $this->submit(),
+            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW => $this->highlighted = null,
+            default => $this->search(),
+        });
+    }
+
+    /**
+     * Perform the search.
+     */
+    protected function search(): void
+    {
+        $this->state = 'searching';
+        $this->highlighted = null;
+        $this->render();
+        $this->matches = null;
+        $this->firstVisible = 0;
+        $this->state = 'active';
+    }
+
+    /**
+     * Get the entered value with a virtual cursor.
+     */
+    public function valueWithCursor(int $maxWidth): string
+    {
+        if ($this->highlighted !== null) {
+            return $this->typedValue === ''
+                ? $this->dim($this->truncate($this->placeholder, $maxWidth))
+                : $this->truncate($this->typedValue, $maxWidth);
+        }
+
+        if ($this->typedValue === '') {
+            return $this->dim($this->addCursor($this->placeholder, 0, $maxWidth));
+        }
+
+        return $this->addCursor($this->typedValue, $this->cursorPosition, $maxWidth);
+    }
+
+    /**
+     * Get options that match the input.
+     *
+     * @return array<string>
+     */
+    public function matches(): array
+    {
+        if (is_array($this->matches)) {
+            return $this->matches;
+        }
+
+        if (strlen($this->typedValue) === 0) {
+            return $this->matches = $this->values;
+        }
+
+        return $this->matches = ($this->options)($this->typedValue);
+    }
+
+    /**
+     * The currently visible matches
+     *
+     * @return array<string>
+     */
+    public function visible(): array
+    {
+        return array_slice($this->matches(), $this->firstVisible, $this->scroll, preserve_keys: true);
+    }
+
+    /**
+     * Highlight the previous entry, or wrap around to the last entry.
+     */
+    protected function highlightPrevious(): void
+    {
+        if ($this->matches === []) {
+            $this->highlighted = null;
+        } elseif ($this->highlighted === null) {
+            $this->highlighted = count($this->matches) - 1;
+        } elseif ($this->highlighted === 0) {
+            $this->highlighted = null;
+        } else {
+            $this->highlighted = $this->highlighted - 1;
+        }
+
+        if ($this->highlighted < $this->firstVisible) {
+            $this->firstVisible--;
+        } elseif ($this->highlighted === count($this->matches) - 1) {
+            $this->firstVisible = count($this->matches) - min($this->scroll, count($this->matches));
+        }
+    }
+
+    /**
+     * Highlight the next entry, or wrap around to the first entry.
+     */
+    protected function highlightNext(): void
+    {
+        if ($this->matches === []) {
+            $this->highlighted = null;
+        } elseif ($this->highlighted === null) {
+            $this->highlighted = 0;
+        } else {
+            $this->highlighted = $this->highlighted === count($this->matches) - 1 ? null : $this->highlighted + 1;
+        }
+
+        if ($this->highlighted > $this->firstVisible + $this->scroll - 1) {
+            $this->firstVisible++;
+        } elseif ($this->highlighted === 0 || $this->highlighted === null) {
+            $this->firstVisible = 0;
+        }
+    }
+
+    /**
+     * Toggle the highlighted entry.
+     */
+    protected function toggleHighlighted(): void
+    {
+        if ($this->returnKeys) {
+            $key = array_keys($this->matches)[$this->highlighted];
+
+            if (array_key_exists($key, $this->values)) {
+                unset($this->values[$key]);
+            } else {
+                $this->values[$key] = $this->matches[$key];
+            }
+        } else {
+            $value = $this->matches[$this->highlighted];
+
+            if (in_array($value, $this->values)) {
+                $this->values = array_filter($this->values, fn ($v) => $v !== $value);
+            } else {
+                $this->values[] = $value;
+            }
+        }
+    }
+
+    /**
+     * Get the current search query.
+     */
+    public function searchValue(): string
+    {
+        return $this->typedValue;
+    }
+
+    /**
+     * Get the selected value.
+     */
+    public function value(): array
+    {
+        if ($this->values === null) {
+            return null;
+        }
+
+        return $this->returnKeys
+            ? array_keys($this->values)
+            : $this->values;
+    }
+
+    /**
+     * Get the selected labels.
+     *
+     * @return array<string>
+     */
+    public function labels(): array
+    {
+        return array_values($this->values);
+    }
+}

--- a/src/MultiSearchPrompt.php
+++ b/src/MultiSearchPrompt.php
@@ -3,7 +3,6 @@
 namespace Laravel\Prompts;
 
 use Closure;
-use Illuminate\Support\Collection;
 
 class MultiSearchPrompt extends Prompt
 {
@@ -29,13 +28,6 @@ class MultiSearchPrompt extends Prompt
     protected ?array $matches = null;
 
     /**
-     * The default values the multi-search prompt.
-     *
-     * @var array<int|string, string>
-     */
-    public array $default;
-
-    /**
      * The selected values.
      *
      * @var array<int|string, string>
@@ -45,23 +37,18 @@ class MultiSearchPrompt extends Prompt
     /**
      * Create a new MultiSearchPrompt instance.
      *
-     * @param  array<int|string, string>|Collection<int|string, string>  $default
      * @param  Closure(string): array<int|string, string>  $options
      */
     public function __construct(
         public string $label,
         public Closure $options,
         public bool $returnKeys = true,
-        array|Collection $default = [],
         public string $placeholder = '',
         public int $scroll = 5,
         public bool|string $required = false,
         public ?Closure $validate = null,
         public string $hint = '',
     ) {
-        $this->default = $default instanceof Collection ? $default->all() : $default;
-        $this->values = $this->default;
-
         $this->trackTypedValue(submit: false, ignore: fn ($key) => $key === Key::SPACE && $this->highlighted !== null);
 
         $this->reduceScrollingToFitTerminal();

--- a/src/MultiSearchPrompt.php
+++ b/src/MultiSearchPrompt.php
@@ -42,7 +42,6 @@ class MultiSearchPrompt extends Prompt
     public function __construct(
         public string $label,
         public Closure $options,
-        public bool $returnKeys = true,
         public string $placeholder = '',
         public int $scroll = 5,
         public bool|string $required = false,
@@ -174,22 +173,18 @@ class MultiSearchPrompt extends Prompt
      */
     protected function toggleHighlighted(): void
     {
-        if ($this->returnKeys) {
-            $key = array_keys($this->matches)[$this->highlighted];
-
-            if (array_key_exists($key, $this->values)) {
-                unset($this->values[$key]);
-            } else {
-                $this->values[$key] = $this->matches[$key];
-            }
+        if (array_is_list($this->matches)) {
+            $label = $this->matches[$this->highlighted];
+            $key = $label;
         } else {
-            $value = $this->matches[$this->highlighted];
+            $key = array_keys($this->matches)[$this->highlighted];
+            $label = $this->matches[$key];
+        }
 
-            if (in_array($value, $this->values)) {
-                $this->values = array_filter($this->values, fn ($v) => $v !== $value);
-            } else {
-                $this->values[] = $value;
-            }
+        if (array_key_exists($key, $this->values)) {
+            unset($this->values[$key]);
+        } else {
+            $this->values[$key] = $label;
         }
     }
 
@@ -208,9 +203,7 @@ class MultiSearchPrompt extends Prompt
      */
     public function value(): array
     {
-        return $this->returnKeys
-            ? array_keys($this->values)
-            : $this->values;
+        return array_keys($this->values);
     }
 
     /**

--- a/src/MultiSearchPrompt.php
+++ b/src/MultiSearchPrompt.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 
 class MultiSearchPrompt extends Prompt
 {
+    use Concerns\ReducesScrollingToFitTerminal;
     use Concerns\Truncation;
     use Concerns\TypedValue;
 
@@ -62,6 +63,8 @@ class MultiSearchPrompt extends Prompt
         $this->values = $this->default;
 
         $this->trackTypedValue(submit: false, allowKey: fn ($key) => $key !== Key::SPACE || $this->highlighted === null);
+
+        $this->reduceScrollingToFitTerminal();
 
         $this->on('key', fn ($key) => match ($key) {
             Key::UP, Key::UP_ARROW, Key::SHIFT_TAB => $this->highlightPrevious(),

--- a/src/MultiSearchPrompt.php
+++ b/src/MultiSearchPrompt.php
@@ -62,7 +62,7 @@ class MultiSearchPrompt extends Prompt
         $this->default = $default instanceof Collection ? $default->all() : $default;
         $this->values = $this->default;
 
-        $this->trackTypedValue(submit: false, allowKey: fn ($key) => $key !== Key::SPACE || $this->highlighted === null);
+        $this->trackTypedValue(submit: false, ignore: fn ($key) => $key === Key::SPACE && $this->highlighted !== null);
 
         $this->reduceScrollingToFitTerminal();
 

--- a/src/MultiSearchPrompt.php
+++ b/src/MultiSearchPrompt.php
@@ -106,7 +106,12 @@ class MultiSearchPrompt extends Prompt
         }
 
         if (strlen($this->typedValue) === 0) {
-            return $this->matches = $this->values;
+            $matches = ($this->options)($this->typedValue);
+
+            return $this->matches = [
+                ...array_diff($this->values, $matches),
+                ...$matches,
+            ];
         }
 
         return $this->matches = ($this->options)($this->typedValue);

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -62,6 +62,7 @@ class SearchPrompt extends Prompt
         $this->highlighted = null;
         $this->render();
         $this->matches = null;
+        $this->firstVisible = 0;
         $this->state = 'active';
     }
 

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -62,6 +62,7 @@ class SuggestPrompt extends Prompt
             default => (function () {
                 $this->highlighted = null;
                 $this->matches = null;
+                $this->firstVisible = 0;
             })(),
         });
 

--- a/src/Themes/Default/MultiSearchPromptRenderer.php
+++ b/src/Themes/Default/MultiSearchPromptRenderer.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Laravel\Prompts\Themes\Default;
+
+use Laravel\Prompts\MultiSearchPrompt;
+
+class MultiSearchPromptRenderer extends Renderer
+{
+    use Concerns\DrawsBoxes;
+    use Concerns\DrawsScrollbars;
+
+    /**
+     * Render the suggest prompt.
+     */
+    public function __invoke(MultiSearchPrompt $prompt): string
+    {
+        $prompt->scroll = min($prompt->scroll, $prompt->terminal()->lines() - 7);
+        $maxWidth = $prompt->terminal()->cols() - 6;
+
+        return match ($prompt->state) {
+            'submit' => $this
+                ->box(
+                    $this->dim($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
+                    $this->renderSelectedOptions($prompt)
+                ),
+
+            'cancel' => $this
+                ->box(
+                    $this->dim($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
+                    $this->strikethrough($this->dim($this->truncate($prompt->searchValue() ?: $prompt->placeholder, $maxWidth))),
+                    color: 'red',
+                )
+                ->error('Cancelled'),
+
+            'error' => $this
+                ->box(
+                    $this->truncate($prompt->label, $prompt->terminal()->cols() - 6),
+                    $prompt->valueWithCursor($maxWidth),
+                    $this->renderOptions($prompt),
+                    color: 'yellow',
+                )
+                ->warning($this->truncate($prompt->error, $prompt->terminal()->cols() - 5)),
+
+            'searching' => $this
+                ->box(
+                    $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
+                    $this->valueWithCursorAndSearchIcon($prompt, $maxWidth),
+                    $this->renderOptions($prompt),
+                )
+                ->hint($prompt->hint),
+
+            default => $this
+                ->box(
+                    $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
+                    $prompt->valueWithCursor($maxWidth),
+                    $this->renderOptions($prompt),
+                )
+                ->when(
+                    $prompt->hint,
+                    fn () => $this->hint($prompt->hint),
+                    fn () => $this->newLine() // Space for errors
+                )
+                ->spaceForDropdown($prompt)
+                ->newLine(), // Space for errors
+        };
+    }
+
+    /**
+     * Render the value with the cursor and a search icon.
+     */
+    protected function valueWithCursorAndSearchIcon(MultiSearchPrompt $prompt, int $maxWidth): string
+    {
+        return preg_replace(
+            '/\s$/',
+            $this->cyan('…'),
+            $this->pad($prompt->valueWithCursor($maxWidth - 1).'  ', min($this->longest($prompt->matches(), padding: 2), $maxWidth))
+        );
+    }
+
+    /**
+     * Render a spacer to prevent jumping when the suggestions are displayed.
+     */
+    protected function spaceForDropdown(MultiSearchPrompt $prompt): self
+    {
+        if ($prompt->searchValue() !== '') {
+            return $this;
+        }
+
+        $this->newLine(max(
+            0,
+            min($prompt->scroll, $prompt->terminal()->lines() - 7) - count($prompt->matches()),
+        ));
+
+        if ($prompt->matches() === []) {
+            $this->newLine();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Render the options.
+     */
+    protected function renderOptions(MultiSearchPrompt $prompt): string
+    {
+        if ($prompt->searchValue() !== '' && empty($prompt->matches())) {
+            return $this->gray('  '.($prompt->state === 'searching' ? 'Searching...' : 'No results.'));
+        }
+
+        return $this->scrollbar(
+            collect($prompt->visible())
+                ->map(fn ($label) => $this->truncate($label, $prompt->terminal()->cols() - 10))
+                ->map(function ($label, $key) use ($prompt) {
+                    $index = array_search($key, array_keys($prompt->matches()));
+                    $active = $index === $prompt->highlighted;
+                    $matches = $prompt->matches();
+
+                    if ($prompt->returnKeys) {
+                        $value = array_keys($matches)[$index];
+                    } else {
+                        $value = $matches[$index];
+                    }
+                    $selected = in_array($value, $prompt->value());
+
+                    return match (true) {
+                        $active && $selected => "{$this->cyan('› ◼')} {$label}  ",
+                        $active => "{$this->cyan('›')} ◻ {$label}  ",
+                        $selected => "  {$this->cyan('◼')} {$this->dim($label)}  ",
+                        default => "  {$this->dim('◻')} {$this->dim($label)}  ",
+                    };
+                }),
+            $prompt->firstVisible,
+            $prompt->scroll,
+            count($prompt->matches()),
+            min($this->longest($prompt->matches(), padding: 4), $prompt->terminal()->cols() - 6)
+        )->implode(PHP_EOL);
+    }
+
+    /**
+     * Render the selected options.
+     */
+    protected function renderSelectedOptions(MultiSearchPrompt $prompt): string
+    {
+        if (count($prompt->labels()) === 0) {
+            return $this->gray('None');
+        }
+
+        return implode("\n", array_map(
+            fn ($label) => $this->truncate($label, $prompt->terminal()->cols() - 6),
+            $prompt->labels()
+        ));
+    }
+}

--- a/src/Themes/Default/MultiSearchPromptRenderer.php
+++ b/src/Themes/Default/MultiSearchPromptRenderer.php
@@ -21,7 +21,8 @@ class MultiSearchPromptRenderer extends Renderer
             'submit' => $this
                 ->box(
                     $this->dim($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
-                    $this->renderSelectedOptions($prompt)
+                    $this->renderSelectedOptions($prompt),
+                    info: $this->getInfoText($prompt, false),
                 ),
 
             'cancel' => $this
@@ -38,6 +39,7 @@ class MultiSearchPromptRenderer extends Renderer
                     $prompt->valueWithCursor($maxWidth),
                     $this->renderOptions($prompt),
                     color: 'yellow',
+                    info: $this->getInfoText($prompt),
                 )
                 ->warning($this->truncate($prompt->error, $prompt->terminal()->cols() - 5)),
 
@@ -46,6 +48,7 @@ class MultiSearchPromptRenderer extends Renderer
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $this->valueWithCursorAndSearchIcon($prompt, $maxWidth),
                     $this->renderOptions($prompt),
+                    info: $this->getInfoText($prompt),
                 )
                 ->hint($prompt->hint),
 
@@ -54,6 +57,7 @@ class MultiSearchPromptRenderer extends Renderer
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $prompt->valueWithCursor($maxWidth),
                     $this->renderOptions($prompt),
+                    info: $this->getInfoText($prompt),
                 )
                 ->when(
                     $prompt->hint,
@@ -149,5 +153,30 @@ class MultiSearchPromptRenderer extends Renderer
             fn ($label) => $this->truncate($label, $prompt->terminal()->cols() - 6),
             $prompt->labels()
         ));
+    }
+
+    /**
+     * Render the info text.
+     */
+    protected function getInfoText(MultiSearchPrompt $prompt, bool $includeHidden = true): string {
+        $info = count($prompt->value()) . ' selected';
+
+        if ($includeHidden) {
+            $countHidden = count($prompt->value()) - collect($prompt->matches())
+                ->filter(function ($label, $key) use ($prompt) {
+                    if ($prompt->returnKeys) {
+                        $value = $key;
+                    } else {
+                        $value = $label;
+                    }
+
+                    return in_array($value, $prompt->value());
+                })
+                ->count();
+
+            $info .= " ($countHidden hidden)";
+        }
+
+        return $info;
     }
 }

--- a/src/Themes/Default/MultiSearchPromptRenderer.php
+++ b/src/Themes/Default/MultiSearchPromptRenderer.php
@@ -115,14 +115,9 @@ class MultiSearchPromptRenderer extends Renderer implements Scrolling
                 ->map(function ($label, $key) use ($prompt) {
                     $index = array_search($key, array_keys($prompt->matches()));
                     $active = $index === $prompt->highlighted;
-                    $matches = $prompt->matches();
-
-                    if ($prompt->returnKeys) {
-                        $value = array_keys($matches)[$index];
-                    } else {
-                        $value = $matches[$index];
-                    }
-                    $selected = in_array($value, $prompt->value());
+                    $selected = array_is_list($prompt->visible())
+                        ? in_array($label, $prompt->value())
+                        : in_array($key, $prompt->value());
 
                     return match (true) {
                         $active && $selected => "{$this->cyan('› ◼')} {$label}  ",
@@ -161,7 +156,7 @@ class MultiSearchPromptRenderer extends Renderer implements Scrolling
         $info = count($prompt->value()).' selected';
 
         $hiddenCount = count($prompt->value()) - collect($prompt->matches())
-            ->filter(fn ($label, $key) => in_array($prompt->returnKeys ? $key : $label, $prompt->value()))
+            ->filter(fn ($label, $key) => in_array(array_is_list($prompt->matches()) ? $label : $key, $prompt->value()))
             ->count();
 
         if ($hiddenCount > 0) {

--- a/src/Themes/Default/MultiSearchPromptRenderer.php
+++ b/src/Themes/Default/MultiSearchPromptRenderer.php
@@ -3,8 +3,9 @@
 namespace Laravel\Prompts\Themes\Default;
 
 use Laravel\Prompts\MultiSearchPrompt;
+use Laravel\Prompts\Themes\Contracts\Scrolling;
 
-class MultiSearchPromptRenderer extends Renderer
+class MultiSearchPromptRenderer extends Renderer implements Scrolling
 {
     use Concerns\DrawsBoxes;
     use Concerns\DrawsScrollbars;
@@ -14,7 +15,6 @@ class MultiSearchPromptRenderer extends Renderer
      */
     public function __invoke(MultiSearchPrompt $prompt): string
     {
-        $prompt->scroll = min($prompt->scroll, $prompt->terminal()->lines() - 7);
         $maxWidth = $prompt->terminal()->cols() - 6;
 
         return match ($prompt->state) {
@@ -178,5 +178,13 @@ class MultiSearchPromptRenderer extends Renderer
         }
 
         return $info;
+    }
+
+    /**
+     * The number of lines to reserve outside of the scrollable area.
+     */
+    public function reservedLines(): int
+    {
+        return 7;
     }
 }

--- a/src/Themes/Default/MultiSearchPromptRenderer.php
+++ b/src/Themes/Default/MultiSearchPromptRenderer.php
@@ -156,23 +156,16 @@ class MultiSearchPromptRenderer extends Renderer implements Scrolling
     /**
      * Render the info text.
      */
-    protected function getInfoText(MultiSearchPrompt $prompt, bool $includeHidden = true): string {
-        $info = count($prompt->value()) . ' selected';
+    protected function getInfoText(MultiSearchPrompt $prompt): string
+    {
+        $info = count($prompt->value()).' selected';
 
-        if ($includeHidden) {
-            $countHidden = count($prompt->value()) - collect($prompt->matches())
-                ->filter(function ($label, $key) use ($prompt) {
-                    if ($prompt->returnKeys) {
-                        $value = $key;
-                    } else {
-                        $value = $label;
-                    }
+        $hiddenCount = count($prompt->value()) - collect($prompt->matches())
+            ->filter(fn ($label, $key) => in_array($prompt->returnKeys ? $key : $label, $prompt->value()))
+            ->count();
 
-                    return in_array($value, $prompt->value());
-                })
-                ->count();
-
-            $info .= " ($countHidden hidden)";
+        if ($hiddenCount > 0) {
+            $info .= " ($hiddenCount hidden)";
         }
 
         return $info;

--- a/src/Themes/Default/MultiSearchPromptRenderer.php
+++ b/src/Themes/Default/MultiSearchPromptRenderer.php
@@ -22,7 +22,6 @@ class MultiSearchPromptRenderer extends Renderer implements Scrolling
                 ->box(
                     $this->dim($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $this->renderSelectedOptions($prompt),
-                    info: $this->getInfoText($prompt, false),
                 ),
 
             'cancel' => $this

--- a/src/Themes/Default/MultiSearchPromptRenderer.php
+++ b/src/Themes/Default/MultiSearchPromptRenderer.php
@@ -65,7 +65,6 @@ class MultiSearchPromptRenderer extends Renderer implements Scrolling
                     fn () => $this->newLine() // Space for errors
                 )
                 ->spaceForDropdown($prompt)
-                ->newLine(), // Space for errors
         };
     }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -75,6 +75,7 @@ function search(string $label, Closure $options, string $placeholder = '', int $
  * Allow the user to search for multiple option.
  *
  * @param  Closure(string): array<int|string, string>  $options
+ * @param  array<int|string, string>|Collection<int|string, string>  $default
  * @return array<int|string>
  */
 function multisearch(string $label, Closure $options, bool $returnKeys = true, array|Collection $default = [], string $placeholder = '', int $scroll = 5, bool|string $required = false, Closure $validate = null, string $hint = 'Use the space bar to select options.'): array

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -72,6 +72,17 @@ function search(string $label, Closure $options, string $placeholder = '', int $
 }
 
 /**
+ * Allow the user to search for multiple option.
+ *
+ * @param  Closure(string): array<int|string, string>  $options
+ * @return array<int|string>
+ */
+function multisearch(string $label, Closure $options, bool $returnKeys = true, array|Collection $default = [], string $placeholder = '', int $scroll = 5, bool|string $required = false, Closure $validate = null, string $hint = 'Use the space bar to select options.'): array
+{
+    return (new MultiSearchPrompt($label, $options, $returnKeys, $default, $placeholder, $scroll, $required, $validate, $hint))->prompt();
+}
+
+/**
  * Render a spinner while the given callback is executing.
  *
  * @template TReturn of mixed

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -77,9 +77,9 @@ function search(string $label, Closure $options, string $placeholder = '', int $
  * @param  Closure(string): array<int|string, string>  $options
  * @return array<int|string>
  */
-function multisearch(string $label, Closure $options, bool $returnKeys = true, string $placeholder = '', int $scroll = 5, bool|string $required = false, Closure $validate = null, string $hint = 'Use the space bar to select options.'): array
+function multisearch(string $label, Closure $options, string $placeholder = '', int $scroll = 5, bool|string $required = false, Closure $validate = null, string $hint = 'Use the space bar to select options.'): array
 {
-    return (new MultiSearchPrompt($label, $options, $returnKeys, $placeholder, $scroll, $required, $validate, $hint))->prompt();
+    return (new MultiSearchPrompt($label, $options, $placeholder, $scroll, $required, $validate, $hint))->prompt();
 }
 
 /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -75,12 +75,11 @@ function search(string $label, Closure $options, string $placeholder = '', int $
  * Allow the user to search for multiple option.
  *
  * @param  Closure(string): array<int|string, string>  $options
- * @param  array<int|string, string>|Collection<int|string, string>  $default
  * @return array<int|string>
  */
-function multisearch(string $label, Closure $options, bool $returnKeys = true, array|Collection $default = [], string $placeholder = '', int $scroll = 5, bool|string $required = false, Closure $validate = null, string $hint = 'Use the space bar to select options.'): array
+function multisearch(string $label, Closure $options, bool $returnKeys = true, string $placeholder = '', int $scroll = 5, bool|string $required = false, Closure $validate = null, string $hint = 'Use the space bar to select options.'): array
 {
-    return (new MultiSearchPrompt($label, $options, $returnKeys, $default, $placeholder, $scroll, $required, $validate, $hint))->prompt();
+    return (new MultiSearchPrompt($label, $options, $returnKeys, $placeholder, $scroll, $required, $validate, $hint))->prompt();
 }
 
 /**

--- a/tests/Feature/MultiSearchPromptTest.php
+++ b/tests/Feature/MultiSearchPromptTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use Laravel\Prompts\Key;
+use Laravel\Prompts\MultiSearchPrompt;
+use Laravel\Prompts\Prompt;
+
+use function Laravel\Prompts\multisearch;
+
+it('accepts a callback', function () {
+    Prompt::fake([
+        'u', 'e', Key::DOWN, Key::SPACE, // Select Blue
+        Key::BACKSPACE, Key::BACKSPACE, // Clear search
+        'e', 'n', Key::DOWN, Key::SPACE, // Select Green
+        Key::ENTER // Confirm selection
+    ]);
+
+    $result = multisearch(
+        label: 'What are your favorite colors?',
+        options: fn (string $value) => array_filter(
+            [
+                'red' => 'Red',
+                'green' => 'Green',
+                'blue' => 'Blue',
+            ],
+            fn ($option) => str_contains(strtolower($option), strtolower($value)),
+        ),
+    );
+
+    expect($result)->toBe(['blue', 'green']);
+    
+
+    Prompt::assertStrippedOutputDoesntContain('│ Red');
+    Prompt::assertStrippedOutputContains('│ Green');
+    Prompt::assertStrippedOutputContains('│ Blue');
+});
+
+it('returns the value when return key flag is false', function () {
+    Prompt::fake(['u', 'e', Key::DOWN, Key::SPACE, Key::ENTER]);
+
+    $result = multisearch(
+        label: 'What are your favorite colors?',
+        options: fn (string $value) => array_values(array_filter(
+            [
+                'red' => 'Red',
+                'green' => 'Green',
+                'blue' => 'Blue',
+            ],
+            fn ($option) => str_contains(strtolower($option), strtolower($value)),
+        )),
+        returnKeys: false
+    );
+
+    expect($result)->toBe(['Blue']);
+});
+
+it('accepts default values when the options are keys with labels', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = multisearch(
+        label: 'What are your favorite colors?',
+        options: fn () => [
+            'red' => 'Red',
+            'green' => 'Green',
+            'blue' => 'Blue',
+        ],
+        default: [
+            'green' => 'Green'
+        ]
+    );
+
+    expect($result)->toBe(['green']);
+});
+
+it('validates', function () {
+    Prompt::fake(['a', Key::DOWN, Key::SPACE, Key::ENTER, Key::DOWN, Key::SPACE, Key::ENTER]);
+
+    $result = multisearch(
+        label: 'What are your favorite colors?',
+        options: fn () => [
+            'red' => 'Red',
+            'green' => 'Green',
+            'blue' => 'Blue',
+        ],
+        validate: fn ($value) => !in_array('green', $value) ? 'Please choose green.' : null
+    );
+
+    expect($result)->toBe(['red', 'green']);
+
+    Prompt::assertOutputContains('Please choose green.');
+});
+
+it('can fall back', function () {
+    Prompt::fallbackWhen(true);
+
+    MultiSearchPrompt::fallbackUsing(function (MultiSearchPrompt $prompt) {
+        expect($prompt->label)->toBe('What are your favorite colors?');
+
+        return ['result'];
+    });
+
+    $result = multisearch(
+        label: 'What are your favorite colors?',
+        options: fn () => [
+            'red' => 'Red',
+            'green' => 'Green',
+            'blue' => 'Blue',
+        ],
+    );
+
+    expect($result)->toBe(['result']);
+});

--- a/tests/Feature/MultiSearchPromptTest.php
+++ b/tests/Feature/MultiSearchPromptTest.php
@@ -92,20 +92,19 @@ it("maintains selections when the search value and results are empty", function 
     expect($result)->toBe(['blue', 'green']);
 });
 
-it('returns the value when return key flag is false', function () {
+it('returns the value when the options are a list', function () {
     Prompt::fake(['u', 'e', Key::DOWN, Key::SPACE, Key::ENTER]);
 
     $result = multisearch(
         label: 'What are your favorite colors?',
-        options: fn (string $value) => array_values(array_filter(
-            [
-                'red' => 'Red',
-                'green' => 'Green',
-                'blue' => 'Blue',
-            ],
-            fn ($option) => str_contains(strtolower($option), strtolower($value)),
-        )),
-        returnKeys: false
+        options: fn ($value) => collect([
+            'Red',
+            'Green',
+            'Blue',
+        ])->when(
+            strlen($value),
+            fn ($vendor) => $vendor->filter(fn ($label) => str_contains(strtolower($label), strtolower($value)))
+        )->values()->all(),
     );
 
     expect($result)->toBe(['Blue']);

--- a/tests/Feature/MultiSearchPromptTest.php
+++ b/tests/Feature/MultiSearchPromptTest.php
@@ -6,32 +6,90 @@ use Laravel\Prompts\Prompt;
 
 use function Laravel\Prompts\multisearch;
 
-it('accepts a callback', function () {
+it('allows unfiltered results', function () {
+    Prompt::fake([Key::DOWN, Key::DOWN, Key::SPACE, Key::DOWN, Key::SPACE, Key::ENTER]);
+
+    $result = multisearch(
+        label: 'What are your favorite colors?',
+        placeholder: 'Search...',
+        options: fn ($value) => collect([
+            'red' => 'Red',
+            'green' => 'Green',
+            'blue' => 'Blue',
+        ])->when(
+            strlen($value),
+            fn ($vendor) => $vendor->filter(fn ($label) => str_contains(strtolower($label), strtolower($value)))
+        )->all(),
+    );
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌ What are your favorite colors? ──────────────────────────────┐
+         │ Search...                                                    │
+         ├──────────────────────────────────────────────────────────────┤
+         │   ◻ Red                                                      │
+         │   ◻ Green                                                    │
+         │   ◻ Blue                                                     │
+         └────────────────────────────────────────────────── 0 selected ┘
+        OUTPUT);
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌ What are your favorite colors? ──────────────────────────────┐
+         │ Green                                                        │
+         │ Blue                                                         │
+         └──────────────────────────────────────────────────────────────┘
+        OUTPUT);
+
+    expect($result)->toBe(['green', 'blue']);
+});
+
+it("maintains selections when the search value and results are empty", function () {
     Prompt::fake([
         'u', 'e', Key::DOWN, Key::SPACE, // Select Blue
         Key::BACKSPACE, Key::BACKSPACE, // Clear search
         'e', 'n', Key::DOWN, Key::SPACE, // Select Green
-        Key::ENTER // Confirm selection
+        Key::BACKSPACE, Key::BACKSPACE, // Clear search
+        Key::ENTER, // Confirm selection
     ]);
 
     $result = multisearch(
         label: 'What are your favorite colors?',
-        options: fn (string $value) => array_filter(
-            [
+        placeholder: 'Search...',
+        options: function ($value) {
+            if (strlen($value) === 0) {
+                return [];
+            }
+
+            return collect([
                 'red' => 'Red',
                 'green' => 'Green',
                 'blue' => 'Blue',
-            ],
-            fn ($option) => str_contains(strtolower($option), strtolower($value)),
-        ),
+            ])->filter(fn ($label) => str_contains(strtolower($label), strtolower($value)))->all();
+        },
     );
 
-    expect($result)->toBe(['blue', 'green']);
-    
+    Prompt::assertStrippedOutputContains(<<<OUTPUT
+         ┌ What are your favorite colors? ──────────────────────────────┐
+         │ Search...                                                    │
+         └────────────────────────────────────────────────── 0 selected ┘
+        OUTPUT);
 
-    Prompt::assertStrippedOutputDoesntContain('│ Red');
-    Prompt::assertStrippedOutputContains('│ Green');
-    Prompt::assertStrippedOutputContains('│ Blue');
+    Prompt::assertStrippedOutputContains(<<<OUTPUT
+         │ Search...                                                    │
+         ├──────────────────────────────────────────────────────────────┤
+         │   ◼ Blue                                                     │
+         │   ◼ Green                                                    │
+         └────────────────────────────────────────────────── 2 selected ┘
+          Use the space bar to select options.
+        OUTPUT);
+
+    Prompt::assertStrippedOutputContains(<<<OUTPUT
+         ┌ What are your favorite colors? ──────────────────────────────┐
+         │ Blue                                                         │
+         │ Green                                                        │
+         └──────────────────────────────────────────────────────────────┘
+        OUTPUT);
+
+    expect($result)->toBe(['blue', 'green']);
 });
 
 it('returns the value when return key flag is false', function () {

--- a/tests/Feature/MultiSearchPromptTest.php
+++ b/tests/Feature/MultiSearchPromptTest.php
@@ -59,14 +59,14 @@ it('supports default results', function ($options, $expected) {
             'blue' => 'Blue',
         ])->when(
             strlen($value),
-            fn ($vendor) => $vendor->filter(fn ($label) => str_contains(strtolower($label), strtolower($value)))
+            fn ($colors) => $colors->filter(fn ($label) => str_contains(strtolower($label), strtolower($value)))
         )->all(),
         ['green', 'blue'],
     ],
     'list' => [
         fn ($value) => collect(['Red', 'Green', 'Blue'])->when(
             strlen($value),
-            fn ($vendor) => $vendor->filter(fn ($label) => str_contains(strtolower($label), strtolower($value)))
+            fn ($colors) => $colors->filter(fn ($label) => str_contains(strtolower($label), strtolower($value)))
         )->values()->all(),
         ['Green', 'Blue'],
     ],

--- a/tests/Feature/MultiSearchPromptTest.php
+++ b/tests/Feature/MultiSearchPromptTest.php
@@ -53,24 +53,6 @@ it('returns the value when return key flag is false', function () {
     expect($result)->toBe(['Blue']);
 });
 
-it('accepts default values when the options are keys with labels', function () {
-    Prompt::fake([Key::ENTER]);
-
-    $result = multisearch(
-        label: 'What are your favorite colors?',
-        options: fn () => [
-            'red' => 'Red',
-            'green' => 'Green',
-            'blue' => 'Blue',
-        ],
-        default: [
-            'green' => 'Green'
-        ]
-    );
-
-    expect($result)->toBe(['green']);
-});
-
 it('validates', function () {
     Prompt::fake(['a', Key::DOWN, Key::SPACE, Key::ENTER, Key::DOWN, Key::SPACE, Key::ENTER]);
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hi there,

We have been using this package a lot at work, but we've run into one issue: sometimes we need to combine a `search` and a `multiselect` prompt.

Imagine the following scenario: The role association for a user is currently handled via console commands and consists of two steps: First one needs to search for a domain for which roles should be attached to a user, afterward one has to select none, one, or multiple roles related to the domain to attach to a user.

This results into the following prompts:
- `search` prompt for selecting the user that should be modified
- `search` prompt for a domain
- `multiselect` prompt for specific roles within that domain with preselected roles that have already been given to the user

The `search` for a domain and the `multiselect` for roles might also be in a while loop, as one might want to add multiple roles on different domains.

Introducing: the `multisearch` prompt. This prompt allows searching for entries and selecting multiple of them, confirming everything with `enter`. When no search prompt has been entered, all currently selected entries are shown and can be deselected.

While working on the prompt, I noticed a bug which I have addressed in a separate commit: The scroll position is not being changed when updating a search. This might cause the list of entries to seem empty, if the list of entries is smaller than the current first visible index. You can still scroll, but it seems unintuitive.
