### PR TITLE
fix(select): default value not being centered when not visible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.idea
 /vendor
 composer.lock

--- a/playground/select.php
+++ b/playground/select.php
@@ -5,21 +5,41 @@ use function Laravel\Prompts\select;
 require __DIR__.'/../vendor/autoload.php';
 
 $role = select(
-    label: 'What role should the user have?',
+    label: 'Where are you from?',
     options: [
-        'read-only' => 'Read only',
-        'member' => 'Member',
-        'contributor' => 'Contributor',
-        'supervisor' => 'Supervisor',
-        'manager' => 'Manager',
-        'admin' => 'Administrator',
-        'owner' => 'Owner',
+        'argentina' => 'Argentina',
+        'australia' => 'Australia',
+        'belgium' => 'Belgium',
+        'brazil' => 'Brazil',
+        'canada' => 'Canada',
+        'chile' => 'Chile',
+        'china' => 'China',
+        'colombia' => 'Colombia',
+        'egypt' => 'Egypt',
+        'france' => 'France',
+        'germany' => 'Germany',
+        'india' => 'India',
+        'italy' => 'Italy',
+        'japan' => 'Japan',
+        'kenya' => 'Kenya',
+        'mexico' => 'Mexico',
+        'morocco' => 'Morocco',
+        'nigeria' => 'Nigeria',
+        'new-zealand' => 'New Zealand',
+        'portugal' => 'Portugal',
+        'south-africa' => 'South Africa',
+        'south-korea' => 'South Korea',
+        'spain' => 'Spain',
+        'switzerland' => 'Switzerland',
+        'united-kingdom' => 'United Kingdom',
+        'united-states' => 'United States',
     ],
+    default: 'france',
     validate: fn ($value) => match ($value) {
-        'owner' => 'The owner role is already assigned.',
+        'spain' => 'Spain is not available yet.',
         default => null
     },
-    hint: 'The role will determine what the user can do.',
+    hint: 'The country will determine the currency and the timezone of the user.',
 );
 
 var_dump($role);

--- a/src/Concerns/Fallback.php
+++ b/src/Concerns/Fallback.php
@@ -27,6 +27,14 @@ trait Fallback
     }
 
     /**
+     * Disable the fallback implementation.
+     */
+    public static function disableFallback(): void
+    {
+        static::$shouldFallback = false;
+    }
+
+    /**
      * Whether the prompt should fallback to a custom implementation.
      */
     public static function shouldFallback(): bool

--- a/src/Concerns/Fallback.php
+++ b/src/Concerns/Fallback.php
@@ -27,14 +27,6 @@ trait Fallback
     }
 
     /**
-     * Disable the fallback implementation.
-     */
-    public static function disableFallback(): void
-    {
-        static::$shouldFallback = false;
-    }
-
-    /**
      * Whether the prompt should fallback to a custom implementation.
      */
     public static function shouldFallback(): bool

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -45,6 +45,16 @@ class SelectPrompt extends Prompt
             } else {
                 $this->highlighted = array_search($this->default, array_keys($this->options)) ?: 0;
             }
+
+            // If the default is not visible, scroll and center it.
+            // If it's too near the end of the list, we scroll to the end.
+            if($this->highlighted >= $this->scroll){
+                $optionsLeft = count($this->options) - $this->highlighted;
+                $halfScroll = floor($this->scroll / 2);
+                $endOffset = max(0, $halfScroll - $optionsLeft);
+
+                $this->firstVisible = $this->highlighted - $halfScroll - $endOffset;
+            }
         }
 
         $this->on('key', fn ($key) => match ($key) {

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -50,8 +50,17 @@ class SelectPrompt extends Prompt
             // If it's near the end of the list, we just scroll to the end.
             if($this->highlighted >= $this->scroll){
                 $optionsLeft = count($this->options) - $this->highlighted - 1;
-                $halfScroll = (int) floor(($this->scroll - 0.1) / 2);
+                $halfScroll = (int) floor($this->scroll / 2);
                 $endOffset = max(0, $halfScroll - $optionsLeft);
+
+                // If the scroll is even, we need to subtract one more
+                // in order to take the highlighted option into account.
+                // Since when the scroll is odd the halfScroll is floored,
+                // we don't need to do anything.
+                if($this->scroll % 2 === 0){
+                    $endOffset--;
+                }
+
                 $this->firstVisible = $this->highlighted - $halfScroll - $endOffset;
             }
         }

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -50,7 +50,7 @@ class SelectPrompt extends Prompt
             // If it's near the end of the list, we just scroll to the end.
             if($this->highlighted >= $this->scroll){
                 $optionsLeft = count($this->options) - $this->highlighted - 1;
-                $halfScroll = floor(($this->scroll - 0.1) / 2);
+                $halfScroll = (int) floor(($this->scroll - 0.1) / 2);
                 $endOffset = max(0, $halfScroll - $optionsLeft);
                 $this->firstVisible = $this->highlighted - $halfScroll - $endOffset;
             }

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -47,12 +47,11 @@ class SelectPrompt extends Prompt
             }
 
             // If the default is not visible, scroll and center it.
-            // If it's too near the end of the list, we scroll to the end.
+            // If it's near the end of the list, we just scroll to the end.
             if($this->highlighted >= $this->scroll){
-                $optionsLeft = count($this->options) - $this->highlighted;
+                $optionsLeft = count($this->options) - $this->highlighted - 1;
                 $halfScroll = floor($this->scroll / 2);
                 $endOffset = max(0, $halfScroll - $optionsLeft);
-
                 $this->firstVisible = $this->highlighted - $halfScroll - $endOffset;
             }
         }

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -50,7 +50,7 @@ class SelectPrompt extends Prompt
             // If it's near the end of the list, we just scroll to the end.
             if($this->highlighted >= $this->scroll){
                 $optionsLeft = count($this->options) - $this->highlighted - 1;
-                $halfScroll = floor($this->scroll / 2);
+                $halfScroll = floor(($this->scroll - 0.1) / 2);
                 $endOffset = max(0, $halfScroll - $optionsLeft);
                 $this->firstVisible = $this->highlighted - $halfScroll - $endOffset;
             }

--- a/tests/Feature/SelectPromptTest.php
+++ b/tests/Feature/SelectPromptTest.php
@@ -132,4 +132,61 @@ it('can fall back', function () {
     ]);
 
     expect($result)->toBe('Blue');
+
+    Prompt::disableFallback();
+});
+
+it('centers the default value when it\'s not visible', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = select(
+        label: 'What is your favorite color?',
+        options: [
+            'Red',
+            'Green',
+            'Blue',
+            'Yellow',
+            'Orange',
+            'Purple',
+            'Pink',
+            'Brown',
+            'Black',
+        ],
+        default: 'Purple',
+        scroll: 3
+    );
+
+    expect($result)->toBe('Purple');
+
+    Prompt::assertOutputContains('Orange');
+    Prompt::assertOutputContains('Purple');
+    Prompt::assertOutputContains('Pink');
+});
+
+it('scrolls to the bottom when the default value is near the end', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = select(
+        label: 'What is your favorite color?',
+        options: [
+            'Red',
+            'Green',
+            'Blue',
+            'Yellow',
+            'Orange',
+            'Purple',
+            'Pink',
+            'Brown',
+            'Black',
+        ],
+        default: 'Brown'
+    );
+
+    expect($result)->toBe('Brown');
+
+    Prompt::assertOutputContains('Orange');
+    Prompt::assertOutputContains('Purple');
+    Prompt::assertOutputContains('Pink');
+    Prompt::assertOutputContains('Brown');
+    Prompt::assertOutputContains('Black');
 });

--- a/tests/Feature/SelectPromptTest.php
+++ b/tests/Feature/SelectPromptTest.php
@@ -132,8 +132,6 @@ it('can fall back', function () {
     ]);
 
     expect($result)->toBe('Blue');
-
-    Prompt::disableFallback();
 });
 
 it('centers the default value when it\'s not visible', function () {

--- a/tests/Feature/SelectPromptTest.php
+++ b/tests/Feature/SelectPromptTest.php
@@ -163,7 +163,7 @@ it('centers the default value when it\'s not visible', function () {
     Prompt::assertOutputContains('Pink');
 });
 
-it('scrolls to the bottom when the default value is near the end', function () {
+it('scrolls to the bottom when the default value is near the end', function (int $scroll, array $outputContains) {
     Prompt::fake([Key::ENTER]);
 
     $result = select(
@@ -179,14 +179,35 @@ it('scrolls to the bottom when the default value is near the end', function () {
             'Brown',
             'Black',
         ],
-        default: 'Brown'
+        default: 'Brown',
+        scroll: $scroll
     );
 
     expect($result)->toBe('Brown');
 
-    Prompt::assertOutputContains('Orange');
-    Prompt::assertOutputContains('Purple');
-    Prompt::assertOutputContains('Pink');
-    Prompt::assertOutputContains('Brown');
-    Prompt::assertOutputContains('Black');
-});
+    foreach ($outputContains as $output) {
+        Prompt::assertOutputContains($output);
+    }
+})->with([
+    'odd' => [
+        'scroll' => 5,
+        'outputContains' => [
+            'Orange',
+            'Purple',
+            'Pink',
+            'Brown',
+            'Black',
+        ]
+    ],
+    'even' => [
+        'scroll' => 6,
+        'outputContains' => [
+            'Yellow',
+            'Orange',
+            'Purple',
+            'Pink',
+            'Brown',
+            'Black',
+        ]
+    ],
+]);


### PR DESCRIPTION
When you have a `select` prompt and set a default value outside the first x values (where x is defined by the `scroll` parameter), you don't see it. 

It's even worst when you scroll down the list, since you'll never see what is currently selected, it'll remain outside of the displayed values until the end, when it loops back to the top.

This PR fixes this by centering the "view" (the displayed values) on the default item.

I had to modify the `select.php` playground in order to reflect this change.

### Before: 

https://github.com/laravel/prompts/assets/15825155/7f7a6954-27af-43e0-8ff0-f4b21f675643

### After: 

https://github.com/laravel/prompts/assets/15825155/f1036fb2-42bb-4be6-b543-0f245d0441d0

...and when the default value is near the bottom of the list (in this example with a scroll 10):

https://github.com/laravel/prompts/assets/15825155/2405c665-d6c8-4c3f-a485-deba20272995