### PR TITLE
Make adjusted `scroll` value available in prompt constructor

### DIFF
--- a/src/Concerns/ReducesScrollingToFitTerminal.php
+++ b/src/Concerns/ReducesScrollingToFitTerminal.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Prompts\Concerns;
+
+use Laravel\Prompts\Themes\Contracts\Scrolling;
+
+trait ReducesScrollingToFitTerminal
+{
+    /**
+     * Reduce the scroll property to fit the terminal height.
+     */
+    protected function reduceScrollingToFitTerminal(): void
+    {
+        $reservedLines = ($renderer = $this->getRenderer()) instanceof Scrolling ? $renderer->reservedLines() : 0;
+
+        $this->scroll = min($this->scroll, $this->terminal()->lines() - $reservedLines);
+    }
+}

--- a/src/MultiSelectPrompt.php
+++ b/src/MultiSelectPrompt.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Collection;
 
 class MultiSelectPrompt extends Prompt
 {
+    use Concerns\ReducesScrollingToFitTerminal;
+
     /**
      * The index of the highlighted option.
      */
@@ -56,6 +58,8 @@ class MultiSelectPrompt extends Prompt
         $this->options = $options instanceof Collection ? $options->all() : $options;
         $this->default = $default instanceof Collection ? $default->all() : $default;
         $this->values = $this->default;
+
+        $this->reduceScrollingToFitTerminal();
 
         $this->on('key', fn ($key) => match ($key) {
             Key::UP, Key::UP_ARROW, Key::LEFT, Key::LEFT_ARROW, Key::SHIFT_TAB, 'k', 'h' => $this->highlightPrevious(),

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -6,6 +6,7 @@ use Closure;
 
 class SearchPrompt extends Prompt
 {
+    use Concerns\ReducesScrollingToFitTerminal;
     use Concerns\Truncation;
     use Concerns\TypedValue;
 
@@ -40,6 +41,8 @@ class SearchPrompt extends Prompt
         public string $hint = ''
     ) {
         $this->trackTypedValue(submit: false);
+
+        $this->reduceScrollingToFitTerminal();
 
         $this->on('key', fn ($key) => match ($key) {
             Key::UP, Key::UP_ARROW, Key::SHIFT_TAB => $this->highlightPrevious(),

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Collection;
 
 class SelectPrompt extends Prompt
 {
+    use Concerns\ReducesScrollingToFitTerminal;
+
     /**
      * The index of the highlighted option.
      */
@@ -38,6 +40,8 @@ class SelectPrompt extends Prompt
         public string $hint = ''
     ) {
         $this->options = $options instanceof Collection ? $options->all() : $options;
+
+        $this->reduceScrollingToFitTerminal();
 
         if ($this->default) {
             if (array_is_list($this->options)) {

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 
 class SuggestPrompt extends Prompt
 {
+    use Concerns\ReducesScrollingToFitTerminal;
     use Concerns\Truncation;
     use Concerns\TypedValue;
 
@@ -50,6 +51,8 @@ class SuggestPrompt extends Prompt
         public string $hint = ''
     ) {
         $this->options = $options instanceof Collection ? $options->all() : $options;
+
+        $this->reduceScrollingToFitTerminal();
 
         $this->on('key', fn ($key) => match ($key) {
             Key::UP, Key::UP_ARROW, Key::SHIFT_TAB => $this->highlightPrevious(),

--- a/src/Themes/Contracts/Scrolling.php
+++ b/src/Themes/Contracts/Scrolling.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laravel\Prompts\Themes\Contracts;
+
+interface Scrolling
+{
+    /**
+     * The number of lines to reserve outside of the scrollable area.
+     */
+    public function reservedLines(): int;
+}

--- a/src/Themes/Default/MultiSelectPromptRenderer.php
+++ b/src/Themes/Default/MultiSelectPromptRenderer.php
@@ -3,8 +3,9 @@
 namespace Laravel\Prompts\Themes\Default;
 
 use Laravel\Prompts\MultiSelectPrompt;
+use Laravel\Prompts\Themes\Contracts\Scrolling;
 
-class MultiSelectPromptRenderer extends Renderer
+class MultiSelectPromptRenderer extends Renderer implements Scrolling
 {
     use Concerns\DrawsBoxes;
     use Concerns\DrawsScrollbars;
@@ -14,8 +15,6 @@ class MultiSelectPromptRenderer extends Renderer
      */
     public function __invoke(MultiSelectPrompt $prompt): string
     {
-        $prompt->scroll = min($prompt->scroll, $prompt->terminal()->lines() - 5);
-
         return match ($prompt->state) {
             'submit' => $this
                 ->box(
@@ -108,5 +107,13 @@ class MultiSelectPromptRenderer extends Renderer
             fn ($label) => $this->truncate($label, $prompt->terminal()->cols() - 6),
             $prompt->labels()
         ));
+    }
+
+    /**
+     * The number of lines to reserve outside of the scrollable area.
+     */
+    public function reservedLines(): int
+    {
+        return 5;
     }
 }

--- a/src/Themes/Default/Renderer.php
+++ b/src/Themes/Default/Renderer.php
@@ -9,8 +9,8 @@ use RuntimeException;
 
 abstract class Renderer
 {
-    use Truncation;
     use Colors;
+    use Truncation;
 
     /**
      * The output to be rendered.

--- a/src/Themes/Default/SearchPromptRenderer.php
+++ b/src/Themes/Default/SearchPromptRenderer.php
@@ -3,8 +3,9 @@
 namespace Laravel\Prompts\Themes\Default;
 
 use Laravel\Prompts\SearchPrompt;
+use Laravel\Prompts\Themes\Contracts\Scrolling;
 
-class SearchPromptRenderer extends Renderer
+class SearchPromptRenderer extends Renderer implements Scrolling
 {
     use Concerns\DrawsBoxes;
     use Concerns\DrawsScrollbars;
@@ -14,7 +15,6 @@ class SearchPromptRenderer extends Renderer
      */
     public function __invoke(SearchPrompt $prompt): string
     {
-        $prompt->scroll = min($prompt->scroll, $prompt->terminal()->lines() - 7);
         $maxWidth = $prompt->terminal()->cols() - 6;
 
         return match ($prompt->state) {
@@ -122,5 +122,13 @@ class SearchPromptRenderer extends Renderer
             count($prompt->matches()),
             min($this->longest($prompt->matches(), padding: 4), $prompt->terminal()->cols() - 6)
         )->implode(PHP_EOL);
+    }
+
+    /**
+     * The number of lines to reserve outside of the scrollable area.
+     */
+    public function reservedLines(): int
+    {
+        return 7;
     }
 }

--- a/src/Themes/Default/SelectPromptRenderer.php
+++ b/src/Themes/Default/SelectPromptRenderer.php
@@ -3,8 +3,9 @@
 namespace Laravel\Prompts\Themes\Default;
 
 use Laravel\Prompts\SelectPrompt;
+use Laravel\Prompts\Themes\Contracts\Scrolling;
 
-class SelectPromptRenderer extends Renderer
+class SelectPromptRenderer extends Renderer implements Scrolling
 {
     use Concerns\DrawsBoxes;
     use Concerns\DrawsScrollbars;
@@ -14,7 +15,6 @@ class SelectPromptRenderer extends Renderer
      */
     public function __invoke(SelectPrompt $prompt): string
     {
-        $prompt->scroll = min($prompt->scroll, $prompt->terminal()->lines() - 5);
         $maxWidth = $prompt->terminal()->cols() - 6;
 
         return match ($prompt->state) {
@@ -82,5 +82,13 @@ class SelectPromptRenderer extends Renderer
             min($this->longest($prompt->options, padding: 6), $prompt->terminal()->cols() - 6),
             $prompt->state === 'cancel' ? 'dim' : 'cyan'
         )->implode(PHP_EOL);
+    }
+
+    /**
+     * The number of lines to reserve outside of the scrollable area.
+     */
+    public function reservedLines(): int
+    {
+        return 5;
     }
 }

--- a/src/Themes/Default/SuggestPromptRenderer.php
+++ b/src/Themes/Default/SuggestPromptRenderer.php
@@ -3,8 +3,9 @@
 namespace Laravel\Prompts\Themes\Default;
 
 use Laravel\Prompts\SuggestPrompt;
+use Laravel\Prompts\Themes\Contracts\Scrolling;
 
-class SuggestPromptRenderer extends Renderer
+class SuggestPromptRenderer extends Renderer implements Scrolling
 {
     use Concerns\DrawsBoxes;
     use Concerns\DrawsScrollbars;
@@ -14,7 +15,6 @@ class SuggestPromptRenderer extends Renderer
      */
     public function __invoke(SuggestPrompt $prompt): string
     {
-        $prompt->scroll = min($prompt->scroll, $prompt->terminal()->lines() - 7);
         $maxWidth = $prompt->terminal()->cols() - 6;
 
         return match ($prompt->state) {
@@ -110,5 +110,13 @@ class SuggestPromptRenderer extends Renderer
             min($this->longest($prompt->matches(), padding: 4), $prompt->terminal()->cols() - 6),
             $prompt->state === 'cancel' ? 'dim' : 'cyan'
         )->implode(PHP_EOL);
+    }
+
+    /**
+     * The number of lines to reserve outside of the scrollable area.
+     */
+    public function reservedLines(): int
+    {
+        return 7;
     }
 }


### PR DESCRIPTION
This PR moves the responsibility of reducing the prompt's configured scroll height to the prompt itself rather than the renderer.

This supports #59 by allowing it to reference the amended `$scroll` value when determining how far down the list should be scrolled when a default value is passed that is beyond the scrollable area.