### PR TITLE
Display count of selected items when scrolling

### DIFF
--- a/src/Themes/Default/Concerns/DrawsBoxes.php
+++ b/src/Themes/Default/Concerns/DrawsBoxes.php
@@ -18,6 +18,7 @@ trait DrawsBoxes
         string $body,
         string $footer = '',
         string $color = 'gray',
+        string $info = '',
     ): self {
         $this->minWidth = min($this->minWidth, Prompt::terminal()->cols() - 6);
 
@@ -31,8 +32,6 @@ trait DrawsBoxes
         );
 
         $topBorder = str_repeat('─', $width - mb_strwidth($this->stripEscapeSequences($title)));
-        $bottomBorder = str_repeat('─', $width + 2);
-
         $this->line("{$this->{$color}(' ┌')} {$title} {$this->{$color}($topBorder.'┐')}");
 
         $bodyLines->each(function ($line) use ($width, $color) {
@@ -40,14 +39,16 @@ trait DrawsBoxes
         });
 
         if ($footerLines->isNotEmpty()) {
-            $this->line($this->{$color}(' ├'.$bottomBorder.'┤'));
+            $this->line($this->{$color}(' ├'.str_repeat('─', $width + 2).'┤'));
 
             $footerLines->each(function ($line) use ($width, $color) {
                 $this->line("{$this->{$color}(' │')} {$this->pad($line, $width)} {$this->{$color}('│')}");
             });
         }
 
-        $this->line($this->{$color}(' └'.$bottomBorder.'┘'));
+        $this->line($this->{$color}(' └'.str_repeat(
+            '─', $info ? ($width - mb_strwidth($this->stripEscapeSequences($info))) : ($width + 2)
+        ).($info ? " {$info} " : '').'┘'));
 
         return $this;
     }

--- a/src/Themes/Default/MultiSelectPromptRenderer.php
+++ b/src/Themes/Default/MultiSelectPromptRenderer.php
@@ -35,6 +35,7 @@ class MultiSelectPromptRenderer extends Renderer implements Scrolling
                     $this->truncate($prompt->label, $prompt->terminal()->cols() - 6),
                     $this->renderOptions($prompt),
                     color: 'yellow',
+                    info: count($prompt->options) > $prompt->scroll ? (count($prompt->value()).' selected') : '',
                 )
                 ->warning($this->truncate($prompt->error, $prompt->terminal()->cols() - 5)),
 
@@ -42,6 +43,7 @@ class MultiSelectPromptRenderer extends Renderer implements Scrolling
                 ->box(
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $this->renderOptions($prompt),
+                    info: count($prompt->options) > $prompt->scroll ? (count($prompt->value()).' selected') : '',
                 )
                 ->when(
                     $prompt->hint,


### PR DESCRIPTION
This PR updates the `multiselect` prompt to display the number of selected items when the list is scrollable so that it's clear when other selected items aren't currently visible. 

![image](https://github.com/laravel/prompts/assets/4977161/c7693227-54c4-40e2-84ed-0fac6ef7e23b)

This is especially helpful when a `multiselect` has default values that may not all appear at the top of a list. The functionality from this PR will also be potentially helpful for #58.

I've opted not to include the count when the list doesn't contain enough items to scroll. E.g:

![image](https://github.com/laravel/prompts/assets/4977161/8580a87a-4dbc-4ee3-a2fa-2b1387c06e10)