### PR TITLE
Use fallback implementation when `stty` command fails

### DIFF
--- a/src/Concerns/Fallback.php
+++ b/src/Concerns/Fallback.php
@@ -3,6 +3,7 @@
 namespace Laravel\Prompts\Concerns;
 
 use Closure;
+use RuntimeException;
 
 trait Fallback
 {
@@ -49,7 +50,11 @@ trait Fallback
      */
     public function fallback(): mixed
     {
-        $fallback = static::$fallbacks[static::class];
+        $fallback = static::$fallbacks[static::class] ?? null;
+
+        if ($fallback === null) {
+            throw new RuntimeException('No fallback implementation registered for ['.static::class.']');
+        }
 
         return $fallback($this);
     }

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -6,6 +6,7 @@ use Closure;
 use Laravel\Prompts\Output\ConsoleOutput;
 use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 
 abstract class Prompt
 {
@@ -80,12 +81,20 @@ abstract class Prompt
 
         $this->checkEnvironment();
 
+        try {
+            static::terminal()->setTty('-icanon -isig -echo');
+        } catch (Throwable $e) {
+            static::output()->writeln("<comment>{$e->getMessage()}</comment>");
+            static::fallbackWhen(true);
+
+            return $this->fallback();
+        }
+
         register_shutdown_function(function () {
             $this->restoreCursor();
             static::terminal()->restoreTty();
         });
 
-        static::terminal()->setTty('-icanon -isig -echo');
         $this->hideCursor();
         $this->render();
 

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Prompts;
 
+use RuntimeException;
 use Symfony\Component\Console\Terminal as SymfonyTerminal;
 
 class Terminal
@@ -36,9 +37,9 @@ class Terminal
      */
     public function setTty(string $mode): void
     {
-        $this->initialTtyMode ??= (shell_exec('stty -g') ?: null);
+        $this->initialTtyMode ??= $this->exec('stty -g');
 
-        shell_exec("stty $mode");
+        $this->exec("stty $mode");
     }
 
     /**
@@ -47,7 +48,7 @@ class Terminal
     public function restoreTty(): void
     {
         if ($this->initialTtyMode) {
-            shell_exec("stty {$this->initialTtyMode}");
+            $this->exec("stty {$this->initialTtyMode}");
 
             $this->initialTtyMode = null;
         }
@@ -75,5 +76,30 @@ class Terminal
     public function exit(): void
     {
         exit(1);
+    }
+
+    /**
+     * Execute the given command and return the output.
+     */
+    protected function exec(string $command): string
+    {
+        $process = proc_open($command, [
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ], $pipes);
+
+        if (! $process) {
+            throw new RuntimeException('Failed to create process.');
+        }
+
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        $code = proc_close($process);
+
+        if ($code !== 0 || $stdout === false) {
+            throw new RuntimeException(trim($stderr ?: "Unknown error (code: $code)"), $code);
+        }
+
+        return $stdout;
     }
 }


### PR DESCRIPTION
In scenarios where the `fallbackWhen` condition is false, but the `stty` command fails, the prompt will still attempt to render but is unlikely to work correctly.

This has been reported when SSHing into a Linux machine from a Windows terminal, where the environment detection will report a supported environment, but the `stty` command cannot set the appropriate terminal modes. (Note: This may be due to shared hosting permissions rather than Windows - See https://github.com/laravel/prompts/issues/62#issuecomment-1713052440.)

This PR updates Prompts to enable the fallback when the `stty` command fails. I have configured it to still output the `stty` error message in case it can be resolved, but it will only output it once, before the first prompt.

![image](https://github.com/laravel/prompts/assets/4977161/3f25ba10-76b0-4e8b-adbb-1fb8377bb2f2)

I've also improved the error message when no fallback has been registered for users on old Laravel versions or not using Laravel at all. #57 should improve this.

Fixes #62 