### PR TITLE
Add a `table` renderer

### DIFF
--- a/src/Concerns/Themes.php
+++ b/src/Concerns/Themes.php
@@ -11,6 +11,7 @@ use Laravel\Prompts\SearchPrompt;
 use Laravel\Prompts\SelectPrompt;
 use Laravel\Prompts\Spinner;
 use Laravel\Prompts\SuggestPrompt;
+use Laravel\Prompts\Table;
 use Laravel\Prompts\TextPrompt;
 use Laravel\Prompts\Themes\Default\ConfirmPromptRenderer;
 use Laravel\Prompts\Themes\Default\MultiSelectPromptRenderer;
@@ -20,6 +21,7 @@ use Laravel\Prompts\Themes\Default\SearchPromptRenderer;
 use Laravel\Prompts\Themes\Default\SelectPromptRenderer;
 use Laravel\Prompts\Themes\Default\SpinnerRenderer;
 use Laravel\Prompts\Themes\Default\SuggestPromptRenderer;
+use Laravel\Prompts\Themes\Default\TableRenderer;
 use Laravel\Prompts\Themes\Default\TextPromptRenderer;
 
 trait Themes
@@ -45,6 +47,7 @@ trait Themes
             SuggestPrompt::class => SuggestPromptRenderer::class,
             Spinner::class => SpinnerRenderer::class,
             Note::class => NoteRenderer::class,
+            Table::class => TableRenderer::class,
         ],
     ];
 

--- a/src/Table.php
+++ b/src/Table.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Laravel\Prompts;
+
+use Illuminate\Support\Collection;
+
+class Table extends Prompt
+{
+    /**
+     * Create a new Table instance.
+     *
+     * @param  array<int, string>|Collection<int, string>  $headers
+     * @param  array<int, string>|Collection<int, string>  $rows
+     */
+    public function __construct(public array|Collection $headers, public array|Collection $rows)
+    {
+        $this->headers = $this->headers instanceof Collection ? $this->headers->all() : $this->headers;
+        $this->rows = $this->rows instanceof Collection ? $this->rows->all() : $this->rows;
+    }
+
+    /**
+     * Display the table.
+     */
+    public function display(): void
+    {
+        $this->prompt();
+    }
+
+    /**
+     * Display the table.
+     */
+    public function prompt(): bool
+    {
+        $this->capturePreviousNewLines();
+
+        $this->state = 'submit';
+
+        static::output()->write($this->renderTheme());
+
+        return true;
+    }
+
+    /**
+     * Get the value of the prompt.
+     */
+    public function value(): bool
+    {
+        return true;
+    }
+}

--- a/src/Themes/Default/TableRenderer.php
+++ b/src/Themes/Default/TableRenderer.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Laravel\Prompts\Themes\Default;
+
+use Laravel\Prompts\Output\BufferedConsoleOutput;
+use Laravel\Prompts\Table;
+use Symfony\Component\Console\Helper\Table as SymfonyTable;
+use Symfony\Component\Console\Helper\TableStyle;
+
+class TableRenderer extends Renderer
+{
+    /**
+     * Render the table.
+     */
+    public function __invoke(Table $table): string
+    {
+        $tableStyle = (new TableStyle())
+            ->setHorizontalBorderChars('─')
+            ->setVerticalBorderChars(' │', '│')
+            ->setCrossingChars('┼', ' ┌', '┬', '─┐', '─┤', '─┘', '┴', ' └', ' ├')
+            ->setCellHeaderFormat($this->dim('%s'))
+            ->setBorderFormat($this->dim('%s'));
+
+        $buffered = new BufferedConsoleOutput();
+
+        (new SymfonyTable($buffered))
+            ->setHeaders($table->headers)
+            ->setRows($table->rows)
+            ->setStyle($tableStyle)
+            ->render();
+
+        collect(explode(PHP_EOL, $buffered->content()))
+            ->filter(fn ($line) => $line !== '')
+            ->each(fn ($line) => $this->line($line));
+
+        return $this;
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -139,3 +139,11 @@ function outro(string $message): void
 {
     (new Note($message, 'outro'))->display();
 }
+
+/**
+ * Display a table.
+ */
+function table(array|Collection $headers, array|Collection $rows): void
+{
+    (new Table($headers, $rows))->display();
+}

--- a/tests/Feature/TableTest.php
+++ b/tests/Feature/TableTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Laravel\Prompts\Prompt;
+
+use function Laravel\Prompts\table;
+
+it('renders a table', function ($headers, $rows) {
+    Prompt::fake();
+
+    table($headers, $rows);
+
+    Prompt::assertStrippedOutputContains('┌────────────────────┬───────────────────┐');
+    Prompt::assertStrippedOutputContains('│ Name               │ Twitter           │');
+    Prompt::assertStrippedOutputContains('├────────────────────┼───────────────────┤');
+    Prompt::assertStrippedOutputContains('│ Taylor Otwell      │ @taylorotwell     │');
+    Prompt::assertStrippedOutputContains('│ Dries Vints        │ @driesvints       │');
+    Prompt::assertStrippedOutputContains('│ James Brooks       │ @jbrooksuk        │');
+    Prompt::assertStrippedOutputContains('│ Nuno Maduro        │ @enunomaduro      │');
+    Prompt::assertStrippedOutputContains('│ Mior Muhammad Zaki │ @crynobone        │');
+    Prompt::assertStrippedOutputContains('│ Jess Archer        │ @jessarchercodes  │');
+    Prompt::assertStrippedOutputContains('│ Guus Leeuw         │ @phpguus          │');
+    Prompt::assertStrippedOutputContains('│ Tim MacDonald      │ @timacdonald87    │');
+    Prompt::assertStrippedOutputContains('│ Joe Dixon          │ @_joedixon        │');
+    Prompt::assertStrippedOutputContains('└────────────────────┴───────────────────┘');
+})->with([
+    [
+        ['Name', 'Twitter'],
+        [
+            ['Taylor Otwell', '@taylorotwell'],
+            ['Dries Vints', '@driesvints'],
+            ['James Brooks', '@jbrooksuk'],
+            ['Nuno Maduro', '@enunomaduro'],
+            ['Mior Muhammad Zaki', '@crynobone'],
+            ['Jess Archer', '@jessarchercodes'],
+            ['Guus Leeuw', '@phpguus'],
+            ['Tim MacDonald', '@timacdonald87'],
+            ['Joe Dixon', '@_joedixon'],
+        ],
+    ],
+    [
+        collect(['Name', 'Twitter']),
+        collect([
+            ['Taylor Otwell', '@taylorotwell'],
+            ['Dries Vints', '@driesvints'],
+            ['James Brooks', '@jbrooksuk'],
+            ['Nuno Maduro', '@enunomaduro'],
+            ['Mior Muhammad Zaki', '@crynobone'],
+            ['Jess Archer', '@jessarchercodes'],
+            ['Guus Leeuw', '@phpguus'],
+            ['Tim MacDonald', '@timacdonald87'],
+            ['Joe Dixon', '@_joedixon'],
+        ]),
+    ],
+]);


### PR DESCRIPTION
This PR adds a table helper that renders a table matching the style of the rest of the package components.

I'm not sure if adding more non-interactive output is on the roadmap for the package, but I've had many use cases for this and it's nice that the output is cohesive.

It's a simple wrapper for the existing Symfony console table component:

```php
table(
    ['Name', 'Twitter'],
    [
        ['Taylor Otwell', '@taylorotwell'],
        ['Dries Vints', '@driesvints'],
        ['James Brooks', '@jbrooksuk'],
        ['Nuno Maduro', '@enunomaduro'],
        ['Mior Muhammad Zaki', '@crynobone'],
        ['Jess Archer', '@jessarchercodes'],
        ['Guus Leeuw', '@phpguus'],
        ['Tim MacDonald', '@timacdonald87'],
        ['Joe Dixon', '@_joedixon'],
    ],
);
```
In context it looks like this (I played with both `cyan` and `dim` for the table headers and thought `dim` looked better in the end):

<img width="601" alt="CleanShot 2023-09-13 at 20 43 10@2x" src="https://github.com/laravel/prompts/assets/2702148/3f8cc1cf-3716-4d0c-9b40-31cf5a800169">
