### PR TITLE
Add Page-Up and Page-Down key for list prompt

### DIFF
--- a/src/Key.php
+++ b/src/Key.php
@@ -12,6 +12,10 @@ class Key
 
     const LEFT = "\e[D";
 
+    const PAGE_UP = "\e[5~";
+
+    const PAGE_DOWN = "\e[6~";
+
     const UP_ARROW = "\eOA";
 
     const DOWN_ARROW = "\eOB";

--- a/src/MultiSelectPrompt.php
+++ b/src/MultiSelectPrompt.php
@@ -64,6 +64,8 @@ class MultiSelectPrompt extends Prompt
         $this->on('key', fn ($key) => match ($key) {
             Key::UP, Key::UP_ARROW, Key::LEFT, Key::LEFT_ARROW, Key::SHIFT_TAB, 'k', 'h' => $this->highlightPrevious(),
             Key::DOWN, Key::DOWN_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::TAB, 'j', 'l' => $this->highlightNext(),
+            Key::PAGE_UP => $this->highlightPreviousPage(),
+            Key::PAGE_DOWN => $this->highlightNextPage(),
             Key::SPACE => $this->toggleHighlighted(),
             Key::ENTER => $this->submit(),
             default => null,
@@ -149,6 +151,38 @@ class MultiSelectPrompt extends Prompt
             $this->firstVisible++;
         } elseif ($this->highlighted === 0) {
             $this->firstVisible = 0;
+        }
+    }
+
+    /**
+     * Highlight the previous page entry, or wrap around to the last entry.
+     */
+    protected function highlightPreviousPage(): void
+    {
+        $this->highlighted = $this->highlighted === 0 ? count($this->options) - 1 : max($this->highlighted - $this->scroll, 0);
+
+        if ($this->highlighted === count($this->options) - 1) {
+            $this->firstVisible = count($this->options) - min($this->scroll, count($this->options));
+        } elseif ($this->highlighted === 0) {
+            $this->firstVisible = 0;
+        } elseif ($this->highlighted < $this->firstVisible) {
+            $this->firstVisible = max($this->firstVisible - $this->scroll, 0);
+        }
+    }
+
+    /**
+     * Highlight the next page entry, or wrap around to the first entry.
+     */
+    protected function highlightNextPage(): void
+    {
+        $this->highlighted = $this->highlighted === count($this->options) - 1 ? 0 : min($this->highlighted + $this->scroll, count($this->options) - 1);
+
+        if ($this->highlighted === 0) {
+            $this->firstVisible = 0;
+        } elseif ($this->highlighted === count($this->options) - 1) {
+            $this->firstVisible = count($this->options) - min($this->scroll, count($this->options));
+        } elseif ($this->highlighted > $this->firstVisible + $this->scroll - 1) {
+            $this->firstVisible = min($this->firstVisible + $this->scroll, count($this->options) - $this->scroll);
         }
     }
 

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -47,6 +47,8 @@ class SearchPrompt extends Prompt
         $this->on('key', fn ($key) => match ($key) {
             Key::UP, Key::UP_ARROW, Key::SHIFT_TAB => $this->highlightPrevious(),
             Key::DOWN, Key::DOWN_ARROW, Key::TAB => $this->highlightNext(),
+            Key::PAGE_UP => $this->highlightPreviousPage(),
+            Key::PAGE_DOWN => $this->highlightNextPage(),
             Key::ENTER => $this->highlighted !== null ? $this->submit() : $this->search(),
             Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW => $this->highlighted = null,
             default => $this->search(),
@@ -146,6 +148,54 @@ class SearchPrompt extends Prompt
             $this->firstVisible++;
         } elseif ($this->highlighted === 0 || $this->highlighted === null) {
             $this->firstVisible = 0;
+        }
+    }
+
+    /**
+     * Highlight the previous page entry, or wrap around to the last entry.
+     */
+    protected function highlightPreviousPage(): void
+    {
+        if ($this->matches === []) {
+            $this->highlighted = null;
+        } elseif ($this->highlighted === null) {
+            $this->highlighted = count($this->matches) - 1;
+        } elseif ($this->highlighted === 0) {
+            $this->highlighted = null;
+        } else {
+            $this->highlighted = max($this->highlighted - $this->scroll, 0);
+        }
+
+        if ($this->highlighted === count($this->matches) - 1) {
+            $this->firstVisible = count($this->matches) - min($this->scroll, count($this->matches));
+        } elseif ($this->highlighted === 0 || $this->highlighted === null) {
+            $this->firstVisible = 0;
+        } elseif ($this->highlighted < $this->firstVisible) {
+            $this->firstVisible = max($this->firstVisible - $this->scroll, 0);
+        }
+    }
+
+    /**
+     * Highlight the next page entry, or wrap around to the first entry.
+     */
+    protected function highlightNextPage(): void
+    {
+        if ($this->matches === []) {
+            $this->highlighted = null;
+        } elseif ($this->highlighted === null) {
+            $this->highlighted = 0;
+        } elseif ($this->highlighted === count($this->matches) - 1) {
+            $this->highlighted = null;
+        } else {
+            $this->highlighted = min($this->highlighted + $this->scroll, count($this->matches) - 1);
+        }
+
+        if ($this->highlighted === 0 || $this->highlighted === null) {
+            $this->firstVisible = 0;
+        } elseif ($this->highlighted === count($this->matches) - 1) {
+            $this->firstVisible = count($this->matches) - min($this->scroll, count($this->matches));
+        } elseif ($this->highlighted > $this->firstVisible + $this->scroll - 1) {
+            $this->firstVisible = min($this->firstVisible + $this->scroll, count($this->matches) - $this->scroll);
         }
     }
 

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -72,6 +72,8 @@ class SelectPrompt extends Prompt
         $this->on('key', fn ($key) => match ($key) {
             Key::UP, Key::UP_ARROW, Key::LEFT, Key::LEFT_ARROW, Key::SHIFT_TAB, 'k', 'h' => $this->highlightPrevious(),
             Key::DOWN, Key::DOWN_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::TAB, 'j', 'l' => $this->highlightNext(),
+            Key::PAGE_UP => $this->highlightPreviousPage(),
+            Key::PAGE_DOWN => $this->highlightNextPage(),
             Key::ENTER => $this->submit(),
             default => null,
         });
@@ -136,6 +138,39 @@ class SelectPrompt extends Prompt
             $this->firstVisible++;
         } elseif ($this->highlighted === 0) {
             $this->firstVisible = 0;
+        }
+    }
+
+    /**
+     * Highlight the previous page entry, or wrap around to the last entry.
+     */
+    protected function highlightPreviousPage(): void
+    {
+        $this->highlighted = $this->highlighted === 0 ? count($this->options) - 1 : max($this->highlighted - $this->scroll, 0);
+
+        if ($this->highlighted === count($this->options) - 1) {
+            $this->firstVisible = count($this->options) - min($this->scroll, count($this->options));
+        } elseif ($this->highlighted === 0) {
+            $this->firstVisible = 0;
+            // 2 3
+        } elseif ($this->highlighted < $this->firstVisible) {
+            $this->firstVisible = max($this->firstVisible - $this->scroll, 0);
+        }
+    }
+
+    /**
+     * Highlight the next page entry, or wrap around to the first entry.
+     */
+    protected function highlightNextPage(): void
+    {
+        $this->highlighted = $this->highlighted === count($this->options) - 1 ? 0 : min($this->highlighted + $this->scroll, count($this->options) - 1);
+
+        if ($this->highlighted === 0) {
+            $this->firstVisible = 0;
+        } elseif ($this->highlighted === count($this->options) - 1) {
+            $this->firstVisible = count($this->options) - min($this->scroll, count($this->options));
+        } elseif ($this->highlighted > $this->firstVisible + $this->scroll - 1) {
+            $this->firstVisible = min($this->firstVisible + $this->scroll, count($this->options) - $this->scroll);
         }
     }
 }

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -57,6 +57,8 @@ class SuggestPrompt extends Prompt
         $this->on('key', fn ($key) => match ($key) {
             Key::UP, Key::UP_ARROW, Key::SHIFT_TAB => $this->highlightPrevious(),
             Key::DOWN, Key::DOWN_ARROW, Key::TAB => $this->highlightNext(),
+            Key::PAGE_UP => $this->highlightPreviousPage(),
+            Key::PAGE_DOWN => $this->highlightNextPage(),
             Key::ENTER => $this->selectHighlighted(),
             Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW => $this->highlighted = null,
             default => (function () {
@@ -155,6 +157,54 @@ class SuggestPrompt extends Prompt
             $this->firstVisible++;
         } elseif ($this->highlighted === 0 || $this->highlighted === null) {
             $this->firstVisible = 0;
+        }
+    }
+
+    /**
+     * Highlight the previous page entry, or wrap around to the last entry.
+     */
+    protected function highlightPreviousPage(): void
+    {
+        if ($this->matches === []) {
+            $this->highlighted = null;
+        } elseif ($this->highlighted === null) {
+            $this->highlighted = count($this->matches) - 1;
+        } elseif ($this->highlighted === 0) {
+            $this->highlighted = null;
+        } else {
+            $this->highlighted = max($this->highlighted - $this->scroll, 0);
+        }
+
+        if ($this->highlighted === count($this->matches) - 1) {
+            $this->firstVisible = count($this->matches) - min($this->scroll, count($this->matches));
+        } elseif ($this->highlighted === 0 || $this->highlighted === null) {
+            $this->firstVisible = 0;
+        } elseif ($this->highlighted < $this->firstVisible) {
+            $this->firstVisible = max($this->firstVisible - $this->scroll, 0);
+        }
+    }
+
+    /**
+     * Highlight the next page entry, or wrap around to the first entry.
+     */
+    protected function highlightNextPage(): void
+    {
+        if ($this->matches === []) {
+            $this->highlighted = null;
+        } elseif ($this->highlighted === null) {
+            $this->highlighted = 0;
+        } elseif ($this->highlighted === count($this->matches) - 1) {
+            $this->highlighted = null;
+        } else {
+            $this->highlighted = min($this->highlighted + $this->scroll, count($this->matches) - 1);
+        }
+
+        if ($this->highlighted === 0 || $this->highlighted === null) {
+            $this->firstVisible = 0;
+        } elseif ($this->highlighted === count($this->matches) - 1) {
+            $this->firstVisible = count($this->matches) - min($this->scroll, count($this->matches));
+        } elseif ($this->highlighted > $this->firstVisible + $this->scroll - 1) {
+            $this->firstVisible = min($this->firstVisible + $this->scroll, count($this->matches) - $this->scroll);
         }
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR allows list-related prompts to support page-turning display using the Page-Up and Page-Down keys.

![record](https://github.com/laravel/prompts/assets/20330940/5b037d6f-ac86-49a7-8745-8b4f98fe76a2)
