### PR TITLE
Support more readline keys

### DIFF
--- a/src/Concerns/TypedValue.php
+++ b/src/Concerns/TypedValue.php
@@ -70,6 +70,11 @@ trait TypedValue
                     $regex = "/{$symbols}(?!{$symbols})/";
                     $left = mb_substr($this->typedValue, 0, $this->cursorPosition);
                     $words = preg_split($regex, $left, -1, PREG_SPLIT_OFFSET_CAPTURE | PREG_SPLIT_NO_EMPTY);
+
+                    if (! $words) {
+                        return;
+                    }
+
                     $lastWordPosition = end($words)[1];
                     $left = mb_substr($left, 0, $lastWordPosition);
                     $right = mb_substr($this->typedValue, $this->cursorPosition);

--- a/src/Concerns/TypedValue.php
+++ b/src/Concerns/TypedValue.php
@@ -30,7 +30,7 @@ trait TypedValue
         $this->on('key', function ($key) use ($submit) {
             if ($key[0] === "\e" || in_array($key, [Key::CTRL_B, Key::CTRL_F])) {
                 match ($key) {
-                    Key::LEFT, Key::LEFT_ARROW , Key::CTRL_B => $this->cursorPosition = max(0, $this->cursorPosition - 1),
+                    Key::LEFT, Key::LEFT_ARROW, Key::CTRL_B => $this->cursorPosition = max(0, $this->cursorPosition - 1),
                     Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_F => $this->cursorPosition = min(mb_strlen($this->typedValue), $this->cursorPosition + 1),
                     Key::DELETE => $this->typedValue = mb_substr($this->typedValue, 0, $this->cursorPosition).mb_substr($this->typedValue, $this->cursorPosition + 1),
                     default => null,

--- a/src/Concerns/TypedValue.php
+++ b/src/Concerns/TypedValue.php
@@ -54,33 +54,6 @@ trait TypedValue
 
                     $this->typedValue = mb_substr($this->typedValue, 0, $this->cursorPosition - 1).mb_substr($this->typedValue, $this->cursorPosition);
                     $this->cursorPosition--;
-                } elseif ($key === Key::CTRL_U) {
-                    if ($this->cursorPosition === 0) {
-                        return;
-                    }
-
-                    $this->typedValue = mb_substr($this->typedValue, $this->cursorPosition);
-                    $this->cursorPosition = 0;
-                } elseif ($key === Key::CTRL_W) {
-                    if ($this->cursorPosition === 0) {
-                        return;
-                    }
-
-                    $symbols = '[!@#%^&*()-=[\]{};:\'",.<>?\/\s]';
-                    $regex = "/{$symbols}(?!{$symbols})/";
-                    $left = mb_substr($this->typedValue, 0, $this->cursorPosition);
-                    $words = preg_split($regex, $left, -1, PREG_SPLIT_OFFSET_CAPTURE | PREG_SPLIT_NO_EMPTY);
-
-                    if (! $words) {
-                        return;
-                    }
-
-                    $lastWordPosition = end($words)[1];
-                    $left = mb_substr($left, 0, $lastWordPosition);
-                    $right = mb_substr($this->typedValue, $this->cursorPosition);
-
-                    $this->typedValue = $left.$right;
-                    $this->cursorPosition = mb_strlen($left);
                 } elseif (ord($key) >= 32) {
                     $this->typedValue = mb_substr($this->typedValue, 0, $this->cursorPosition).$key.mb_substr($this->typedValue, $this->cursorPosition);
                     $this->cursorPosition++;

--- a/src/Key.php
+++ b/src/Key.php
@@ -51,8 +51,4 @@ class Key
     const CTRL_A = "\x01";
 
     const CTRL_E = "\x05";
-
-    const CTRL_U = "\x15";
-
-    const CTRL_W = "\x17";
 }

--- a/src/Key.php
+++ b/src/Key.php
@@ -32,6 +32,10 @@ class Key
 
     const SHIFT_TAB = "\e[Z";
 
+    const HOME = "\e[1~";
+
+    const END = "\e[4~";
+
     const CTRL_C = "\x03";
 
     const CTRL_P = "\x10";
@@ -43,4 +47,12 @@ class Key
     const CTRL_B = "\x02";
 
     const CTRL_H = "\x08";
+
+    const CTRL_A = "\x01";
+
+    const CTRL_E = "\x05";
+
+    const CTRL_U = "\x15";
+
+    const CTRL_W = "\x17";
 }

--- a/src/Key.php
+++ b/src/Key.php
@@ -36,19 +36,43 @@ class Key
 
     const END = "\e[4~";
 
+    /**
+     * Cancel/SIGINT
+     */
     const CTRL_C = "\x03";
 
+    /**
+     * Previous/Up
+     */
     const CTRL_P = "\x10";
 
+    /**
+     * Next/Down
+     */
     const CTRL_N = "\x0E";
 
+    /**
+     * Forward/Right
+     */
     const CTRL_F = "\x06";
 
+    /**
+     * Back/Left
+     */
     const CTRL_B = "\x02";
 
+    /**
+     * Backspace
+     */
     const CTRL_H = "\x08";
 
+    /**
+     * Home
+     */
     const CTRL_A = "\x01";
 
+    /**
+     * End
+     */
     const CTRL_E = "\x05";
 }

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -48,7 +48,7 @@ class SearchPrompt extends Prompt
             Key::UP, Key::UP_ARROW, Key::SHIFT_TAB, Key::CTRL_P => $this->highlightPrevious(),
             Key::DOWN, Key::DOWN_ARROW, Key::TAB, Key::CTRL_N => $this->highlightNext(),
             Key::ENTER => $this->highlighted !== null ? $this->submit() : $this->search(),
-            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::CTRL_A, Key::CTRL_E => $this->highlighted = null,
+            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::HOME, KEY::END, Key::CTRL_A, Key::CTRL_E => $this->highlighted = null,
             default => $this->search(),
         });
     }

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -48,7 +48,7 @@ class SearchPrompt extends Prompt
             Key::UP, Key::UP_ARROW, Key::SHIFT_TAB, Key::CTRL_P => $this->highlightPrevious(),
             Key::DOWN, Key::DOWN_ARROW, Key::TAB, Key::CTRL_N => $this->highlightNext(),
             Key::ENTER => $this->highlighted !== null ? $this->submit() : $this->search(),
-            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F => $this->highlighted = null,
+            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::CTRL_A, Key::CTRL_E => $this->highlighted = null,
             default => $this->search(),
         });
     }

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -48,7 +48,7 @@ class SearchPrompt extends Prompt
             Key::UP, Key::UP_ARROW, Key::SHIFT_TAB, Key::CTRL_P => $this->highlightPrevious(),
             Key::DOWN, Key::DOWN_ARROW, Key::TAB, Key::CTRL_N => $this->highlightNext(),
             Key::ENTER => $this->highlighted !== null ? $this->submit() : $this->search(),
-            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::HOME, KEY::END, Key::CTRL_A, Key::CTRL_E => $this->highlighted = null,
+            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::HOME, Key::END, Key::CTRL_A, Key::CTRL_E => $this->highlighted = null,
             default => $this->search(),
         });
     }

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -58,7 +58,7 @@ class SuggestPrompt extends Prompt
             Key::UP, Key::UP_ARROW, Key::SHIFT_TAB, Key::CTRL_P => $this->highlightPrevious(),
             Key::DOWN, Key::DOWN_ARROW, Key::TAB, Key::CTRL_N => $this->highlightNext(),
             Key::ENTER => $this->selectHighlighted(),
-            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::HOME, KEY::END, Key::CTRL_A, Key::CTRL_E => $this->highlighted = null,
+            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::HOME, Key::END, Key::CTRL_A, Key::CTRL_E => $this->highlighted = null,
             default => (function () {
                 $this->highlighted = null;
                 $this->matches = null;

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -58,7 +58,7 @@ class SuggestPrompt extends Prompt
             Key::UP, Key::UP_ARROW, Key::SHIFT_TAB, Key::CTRL_P => $this->highlightPrevious(),
             Key::DOWN, Key::DOWN_ARROW, Key::TAB, Key::CTRL_N => $this->highlightNext(),
             Key::ENTER => $this->selectHighlighted(),
-            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::CTRL_A, Key::CTRL_E => $this->highlighted = null,
+            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::HOME, KEY::END, Key::CTRL_A, Key::CTRL_E => $this->highlighted = null,
             default => (function () {
                 $this->highlighted = null;
                 $this->matches = null;

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -58,7 +58,7 @@ class SuggestPrompt extends Prompt
             Key::UP, Key::UP_ARROW, Key::SHIFT_TAB, Key::CTRL_P => $this->highlightPrevious(),
             Key::DOWN, Key::DOWN_ARROW, Key::TAB, Key::CTRL_N => $this->highlightNext(),
             Key::ENTER => $this->selectHighlighted(),
-            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F => $this->highlighted = null,
+            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::CTRL_A, Key::CTRL_E => $this->highlighted = null,
             default => (function () {
                 $this->highlighted = null;
                 $this->matches = null;

--- a/tests/Feature/TextPromptTest.php
+++ b/tests/Feature/TextPromptTest.php
@@ -83,3 +83,27 @@ test('support emacs style key binding', function () {
 
     expect($result)->toBe('Jess');
 });
+
+test('move to the beginning and end of line', function () {
+    Prompt::fake(['e', 's', Key::HOME, 'J', KEY::END, 's', Key::ENTER]);
+
+    $result = text(label: 'What is your name?');
+
+    expect($result)->toBe('Jess');
+});
+
+test('cut text to the beginning of line', function () {
+    Prompt::fake(['z', 'z', 'J', Key::LEFT, Key::CTRL_U, Key::RIGHT, 'e', 's', 's', Key::ENTER]);
+
+    $result = text(label: 'What is your name?');
+
+    expect($result)->toBe('Jess');
+});
+
+test('cut previous word', function () {
+    Prompt::fake(['z', ' ', 'z', 'z', 'J', Key::LEFT, Key::CTRL_W, Key::CTRL_W, Key::RIGHT, 'e', 's', 's', Key::ENTER]);
+
+    $result = text(label: 'What is your name?');
+
+    expect($result)->toBe('Jess');
+});

--- a/tests/Feature/TextPromptTest.php
+++ b/tests/Feature/TextPromptTest.php
@@ -91,19 +91,3 @@ test('move to the beginning and end of line', function () {
 
     expect($result)->toBe('Jess');
 });
-
-test('cut text to the beginning of line', function () {
-    Prompt::fake(['z', 'z', 'J', Key::LEFT, Key::CTRL_U, Key::RIGHT, 'e', 's', 's', Key::ENTER]);
-
-    $result = text(label: 'What is your name?');
-
-    expect($result)->toBe('Jess');
-});
-
-test('cut previous word', function () {
-    Prompt::fake(['z', ' ', 'z', 'z', 'J', Key::LEFT, Key::CTRL_W, Key::CTRL_W, Key::RIGHT, 'e', 's', 's', Key::ENTER]);
-
-    $result = text(label: 'What is your name?');
-
-    expect($result)->toBe('Jess');
-});


### PR DESCRIPTION
With this PR, we can use:
- `CTRL_A`, `HOME`: move to the beginning of line
- `CTRL_E`, `END`: move to the end of line

see: <https://github.com/laravel/prompts/pull/67#pullrequestreview-1623516659>