### PR TITLE
[10.x] `spin`: Ensure process termination on `$callback()` failure

### DIFF
--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -55,6 +55,8 @@ class Spinner extends Prompt
             exit();
         });
 
+        $pid = 0;
+
         try {
             $this->render();
 

--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -82,6 +82,7 @@ class Spinner extends Prompt
             }
         } catch (\Throwable $e) {
             $this->showCursor();
+            posix_kill($pid, SIGHUP);
             pcntl_async_signals($originalAsync);
             pcntl_signal(SIGINT, SIG_DFL);
 


### PR DESCRIPTION
When executing the `spin` function, if an error is thrown within the `$callback()` function, PHP currently displays the error in the terminal but doesn't terminate the process. This pull request introduces a change to ensure that the process is terminated in the event of a failure within the `callback()` function.

### Example:

```php
$result = spin(
    function () {
        sleep(-1);  // This will fail, causing an exception to be caught, and preventing the posix_kill function from being called

        return 'Callback return';
    },
    'Installing dependencies...',
);

