### PR TITLE
[0.2.x] Add non-interactive mode

### DIFF
--- a/src/Concerns/FakesInputOutput.php
+++ b/src/Concerns/FakesInputOutput.php
@@ -16,6 +16,9 @@ trait FakesInputOutput
      */
     public static function fake(array $keys = []): void
     {
+        // Force interactive mode when testing because we will be mocking the terminal.
+        static::interactive();
+
         $mock = \Mockery::mock(Terminal::class);
 
         $mock->shouldReceive('write')->byDefault();

--- a/src/Concerns/Interactivity.php
+++ b/src/Concerns/Interactivity.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Laravel\Prompts\Concerns;
+
+use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
+
+trait Interactivity
+{
+    /**
+     * Whether to render the prompt interactively.
+     */
+    protected static bool $interactive;
+
+    /**
+     * Set interactive mode.
+     */
+    public static function interactive(bool $interactive = true): void
+    {
+        static::$interactive = $interactive;
+    }
+
+    /**
+     * Return the default value if it passes validation.
+     */
+    protected function default(): mixed
+    {
+        $default = $this->value();
+
+        $this->validate($default);
+
+        if ($this->state === 'error') {
+            throw new NonInteractiveValidationException($this->error);
+        }
+
+        return $default;
+    }
+}

--- a/src/Exceptions/NonInteractiveValidationException.php
+++ b/src/Exceptions/NonInteractiveValidationException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Prompts\Exceptions;
+
+use RuntimeException;
+
+class NonInteractiveValidationException extends RuntimeException
+{
+    //
+}

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -16,6 +16,7 @@ abstract class Prompt
     use Concerns\Events;
     use Concerns\FakesInputOutput;
     use Concerns\Fallback;
+    use Concerns\Interactivity;
     use Concerns\Themes;
 
     /**
@@ -73,6 +74,12 @@ abstract class Prompt
      */
     public function prompt(): mixed
     {
+        static::$interactive ??= stream_isatty(STDIN);
+
+        if (! static::$interactive) {
+            return $this->default();
+        }
+
         $this->capturePreviousNewLines();
 
         if (static::shouldFallback()) {

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -311,7 +311,7 @@ abstract class Prompt
     {
         $this->validated = true;
 
-        if (($this->required ?? false) && ($value === '' || $value === [] || $value === false)) {
+        if (($this->required ?? false) && ($value === '' || $value === [] || $value === false || $value === null)) {
             $this->state = 'error';
             $this->error = is_string($this->required) ? $this->required : 'Required.';
 

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -3,7 +3,6 @@
 namespace Laravel\Prompts;
 
 use Closure;
-use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 
 class SearchPrompt extends Prompt
 {
@@ -20,6 +19,11 @@ class SearchPrompt extends Prompt
      * The index of the first visible option.
      */
     public int $firstVisible = 0;
+
+    /**
+     * Whether user input is required.
+     */
+    public bool|string $required = true;
 
     /**
      * The cached matches.
@@ -178,13 +182,5 @@ class SearchPrompt extends Prompt
     public function label(): ?string
     {
         return $this->matches[array_keys($this->matches)[$this->highlighted]] ?? null;
-    }
-
-    /**
-     * Fail when non-interactive.
-     */
-    protected function default(): mixed
-    {
-        throw new NonInteractiveValidationException('Required.');
     }
 }

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -3,6 +3,7 @@
 namespace Laravel\Prompts;
 
 use Closure;
+use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 
 class SearchPrompt extends Prompt
 {
@@ -177,5 +178,13 @@ class SearchPrompt extends Prompt
     public function label(): ?string
     {
         return $this->matches[array_keys($this->matches)[$this->highlighted]] ?? null;
+    }
+
+    /**
+     * Fail when non-interactive.
+     */
+    protected function default(): mixed
+    {
+        throw new NonInteractiveValidationException('Required.');
     }
 }

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -4,6 +4,7 @@ namespace Laravel\Prompts;
 
 use Closure;
 use Illuminate\Support\Collection;
+use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 
 class SelectPrompt extends Prompt
 {
@@ -137,5 +138,17 @@ class SelectPrompt extends Prompt
         } elseif ($this->highlighted === 0) {
             $this->firstVisible = 0;
         }
+    }
+
+    /**
+     * Return the default value if it passes validation.
+     */
+    protected function default(): mixed
+    {
+        if ($this->default === null) {
+            throw new NonInteractiveValidationException('Required.');
+        }
+
+        return parent::default();
     }
 }

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -4,7 +4,6 @@ namespace Laravel\Prompts;
 
 use Closure;
 use Illuminate\Support\Collection;
-use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 
 class SelectPrompt extends Prompt
 {
@@ -26,6 +25,11 @@ class SelectPrompt extends Prompt
      * @var array<int|string, string>
      */
     public array $options;
+
+    /**
+     * Whether user input is required.
+     */
+    public bool|string $required = true;
 
     /**
      * Create a new SelectPrompt instance.
@@ -83,6 +87,10 @@ class SelectPrompt extends Prompt
      */
     public function value(): int|string|null
     {
+        if (static::$interactive === false) {
+            return $this->default;
+        }
+
         if (array_is_list($this->options)) {
             return $this->options[$this->highlighted] ?? null;
         } else {
@@ -138,17 +146,5 @@ class SelectPrompt extends Prompt
         } elseif ($this->highlighted === 0) {
             $this->firstVisible = 0;
         }
-    }
-
-    /**
-     * Return the default value if it passes validation.
-     */
-    protected function default(): mixed
-    {
-        if ($this->default === null) {
-            throw new NonInteractiveValidationException('Required.');
-        }
-
-        return parent::default();
     }
 }

--- a/tests/Feature/ConfirmPromptTest.php
+++ b/tests/Feature/ConfirmPromptTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\Prompts\ConfirmPrompt;
+use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 
@@ -99,3 +100,21 @@ test('support emacs style key binding', function () {
 
     expect($result)->toBeFalse();
 });
+
+it('returns the default value when non-interactive', function () {
+    Prompt::interactive(false);
+
+    $result = confirm('Would you like to continue?', false);
+
+    expect($result)->toBeFalse();
+});
+
+it('validates the default value when non-interactive', function () {
+    Prompt::interactive(false);
+
+    confirm(
+        'Would you like to continue?',
+        default: false,
+        required: true,
+    );
+})->throws(NonInteractiveValidationException::class, 'Required.');

--- a/tests/Feature/MultiselectPromptTest.php
+++ b/tests/Feature/MultiselectPromptTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\MultiSelectPrompt;
 use Laravel\Prompts\Prompt;
@@ -153,3 +154,37 @@ it('support emacs style key binding', function () {
 
     expect($result)->toBe(['green', 'blue']);
 });
+
+it('returns an empty array when non-interactive', function () {
+    Prompt::interactive(false);
+
+    $result = multiselect('What is your favorite color?', [
+        'Red',
+        'Green',
+        'Blue',
+    ]);
+
+    expect($result)->toBe([]);
+});
+
+it('returns the default value when non-interactive', function () {
+    Prompt::interactive(false);
+
+    $result = multiselect('What is your favorite color?', [
+        'Red',
+        'Green',
+        'Blue',
+    ], default: ['Green']);
+
+    expect($result)->toBe(['Green']);
+});
+
+it('validates the default value when non-interactive', function () {
+    Prompt::interactive(false);
+
+    multiselect('What is your favorite color?', [
+        'Red',
+        'Green',
+        'Blue',
+    ], required: true);
+})->throws(NonInteractiveValidationException::class, 'Required.');

--- a/tests/Feature/PasswordPromptTest.php
+++ b/tests/Feature/PasswordPromptTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\PasswordPrompt;
 use Laravel\Prompts\Prompt;
@@ -64,3 +65,17 @@ it('can fall back', function () {
 
     expect($result)->toBe('result');
 });
+
+it('returns an empty string when non-interactive', function () {
+    Prompt::interactive(false);
+
+    $result = password('What is the password?');
+
+    expect($result)->toBe('');
+});
+
+it('fails validation when non-interactive', function () {
+    Prompt::interactive(false);
+
+    password('What is the password?', required: true);
+})->throws(NonInteractiveValidationException::class, 'Required.');

--- a/tests/Feature/SearchPromptTest.php
+++ b/tests/Feature/SearchPromptTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\SearchPrompt;
@@ -116,3 +117,9 @@ it('support emacs style key binding', function () {
 
     expect($result)->toBe('blue');
 });
+
+it('fails when when non-interactive', function () {
+    Prompt::interactive(false);
+
+    search('What is your favorite color?', fn () => []);
+})->throws(NonInteractiveValidationException::class, 'Required.');

--- a/tests/Feature/SelectPromptTest.php
+++ b/tests/Feature/SelectPromptTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\SelectPrompt;
@@ -224,3 +225,41 @@ it('support emacs style key binding', function () {
 
     expect($result)->toBe('Green');
 });
+
+it('fails when there is no default in non-interactive mode', function () {
+    Prompt::interactive(false);
+
+    select('What is your favorite color?', [
+        'Red',
+        'Green',
+        'Blue',
+    ]);
+})->throws(NonInteractiveValidationException::class, 'Required.');
+
+it('returns the default value when non-interactive', function () {
+    Prompt::interactive(false);
+
+    $result = select('What is your favorite color?', [
+        'Red',
+        'Green',
+        'Blue',
+    ], default: 'Green');
+
+    expect($result)->toBe('Green');
+});
+
+it('validates the default value when non-interactive', function () {
+    Prompt::interactive(false);
+
+    select(
+        label: 'What is your favorite color?',
+        options: [
+            'None',
+            'Red',
+            'Green',
+            'Blue',
+        ],
+        default: 'None',
+        validate: fn ($value) => $value === 'None' ? 'Required.' : null,
+    );
+})->throws(NonInteractiveValidationException::class, 'Required.');

--- a/tests/Feature/SuggestPromptTest.php
+++ b/tests/Feature/SuggestPromptTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\SuggestPrompt;
@@ -117,3 +118,37 @@ it('support emacs style key binding', function () {
 
     expect($result)->toBe('Black');
 });
+
+it('returns an empty string when non-interactive', function () {
+    Prompt::interactive(false);
+
+    $result = suggest('What is your favorite color?', [
+        'Red',
+        'Green',
+        'Blue',
+    ]);
+
+    expect($result)->toBe('');
+});
+
+it('returns the default value when non-interactive', function () {
+    Prompt::interactive(false);
+
+    $result = suggest('What is your favorite color?', [
+        'Red',
+        'Green',
+        'Blue',
+    ], default: 'Yellow');
+
+    expect($result)->toBe('Yellow');
+});
+
+it('validates the default value when non-interactive', function () {
+    Prompt::interactive(false);
+
+    suggest('What is your favorite color?', [
+        'Red',
+        'Green',
+        'Blue',
+    ], required: true);
+})->throws(NonInteractiveValidationException::class, 'Required.');

--- a/tests/Feature/TextPromptTest.php
+++ b/tests/Feature/TextPromptTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\TextPrompt;
@@ -91,3 +92,25 @@ test('move to the beginning and end of line', function () {
 
     expect($result)->toBe('Jess');
 });
+
+it('returns an empty string when non-interactive', function () {
+    Prompt::interactive(false);
+
+    $result = text('What is your name?');
+
+    expect($result)->toBe('');
+});
+
+it('returns the default value when non-interactive', function () {
+    Prompt::interactive(false);
+
+    $result = text('What is your name?', default: 'Taylor');
+
+    expect($result)->toBe('Taylor');
+});
+
+it('validates the default value when non-interactive', function () {
+    Prompt::interactive(false);
+
+    text('What is your name?', required: true);
+})->throws(NonInteractiveValidationException::class, 'Required.');


### PR DESCRIPTION
This PR introduces a non-interactive mode for Prompts.

When Prompts are non-interactive, they will attempt to return the configured default value instead of prompting. Most prompts have a safe default when none is provided. An exception will be thrown if the default value does not pass any validation checks.

This is useful when prompts occur in a non-interactive environment, such as a scheduled task, queued job, CI, or deploy script.

The behaviour is currently mixed, depending on the scenario. #63 prevented prompts from waiting indefinitely for input when the fallback was not triggered, but everything now depends on the fallback to handle non-interactive mode. When using a Symfony fallback, there are some inconsistencies. For example, the `choice` component doesn't allow you to select nothing in interactive mode but will return `null` in non-interactive mode. With this PR, the fallbacks no longer need to be used for non-interactive mode - just for Windows and when testing (for now).

This is a breaking change because Laravel depends on the fallback when running tests and the non-interactive mode will take over in a CI testing environment. If we release this change in `v0.2`, Laravel can update its version constraint and ensure interactive mode is enabled when testing. The companion PR is at https://github.com/laravel/framework/pull/48468

In the future, I would like to prevent the need for fallbacks when testing so that fallback mode is only required for Windows environments (and maybe that can even be solved with #17).

This also paves the way for #57, which needs to know when Laravel commands are explicitly told to be non-interactive (via the `-n` argument), regardless of the presence of a tty.

Fixes #64