### PR TITLE
Register shutdown function to kill process in the event of an early exit

### DIFF
--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -71,12 +71,14 @@ class Spinner extends Prompt
 
                 $result = $callback();
 
-                $this->resetTerminal($originalAsync, $pid);
+                posix_kill($pid, SIGHUP);
+
+                $this->resetTerminal($originalAsync);
 
                 return $result;
             }
         } catch (\Throwable $e) {
-            $this->resetTerminal($originalAsync, $pid ?? null);
+            $this->resetTerminal($originalAsync);
 
             throw $e;
         }
@@ -85,12 +87,8 @@ class Spinner extends Prompt
     /**
      * Reset the terminal.
      */
-    protected function resetTerminal(bool $originalAsync, ?int $pid): void
+    protected function resetTerminal(bool $originalAsync): void
     {
-        if ($pid) {
-            posix_kill($pid, SIGHUP);
-        }
-
         pcntl_async_signals($originalAsync);
         pcntl_signal(SIGINT, SIG_DFL);
 

--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -42,16 +42,15 @@ class Spinner extends Prompt
     {
         $this->capturePreviousNewLines();
 
+        register_shutdown_function(fn () => $this->restoreCursor());
+
         if (! function_exists('pcntl_fork')) {
             return $this->renderStatically($callback);
         }
 
         $originalAsync = pcntl_async_signals(true);
 
-        pcntl_signal(SIGINT, function () {
-            $this->showCursor();
-            exit();
-        });
+        pcntl_signal(SIGINT, fn () => exit());
 
         try {
             $this->hideCursor();

--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -68,6 +68,8 @@ class Spinner extends Prompt
                     usleep($this->interval * 1000);
                 }
             } else {
+                register_shutdown_function(fn () => posix_kill($pid, SIGHUP));
+
                 $result = $callback();
 
                 $this->resetTerminal($originalAsync, $pid);


### PR DESCRIPTION
I preface this PR by saying I don't _love_ this solution, but I was struggling to find another way to handle this.

There seems to be an issue where if the callback function exits early, the process rendering the spinner continues running:

```php
$result = spin(
    function () {
        exit('Heading out early.');
    },
    'Installing dependencies...',
);
```

https://github.com/laravel/prompts/assets/2702148/601fd315-1f9c-4d1a-ba61-aa748f98b60a

I'm using `register_shutdown_function` for the `$pid` that's not `0`, which, if this is the solution, might negate the need for the `posix_kill` in the `resetTerminal` method.

Is this something you're interested in handling? If so... is there a better way? I couldn't figure out a way to catch this otherwise.