### PR TITLE
Spin spacing between elements after erasing

### DIFF
--- a/src/Output/ConsoleOutput.php
+++ b/src/Output/ConsoleOutput.php
@@ -12,11 +12,24 @@ class ConsoleOutput extends SymfonyConsoleOutput
     protected int $newLinesWritten = 1;
 
     /**
+     * Ignore incoming new lines, keeping the previous $newLinesWritten value.
+     */
+    protected bool $ignoreNewLines = false;
+
+    /**
      * How many new lines were written by the last output.
      */
     public function newLinesWritten(): int
     {
         return $this->newLinesWritten;
+    }
+
+    /**
+     * Ignore incoming new lines, keeping the previous $newLinesWritten value.
+     */
+    public function ignoreNewLines(bool $shouldIgnore = true): void
+    {
+        $this->ignoreNewLines = $shouldIgnore;
     }
 
     /**
@@ -28,6 +41,10 @@ class ConsoleOutput extends SymfonyConsoleOutput
 
         if ($newline) {
             $message .= \PHP_EOL;
+        }
+
+        if ($this->ignoreNewLines) {
+            return;
         }
 
         $trailingNewLines = strlen($message) - strlen(rtrim($message, \PHP_EOL));

--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -41,6 +41,7 @@ class Spinner extends Prompt
     public function spin(Closure $callback): mixed
     {
         $this->capturePreviousNewLines();
+        $this->ignoreNewLines(true);
 
         register_shutdown_function(fn () => $this->restoreCursor());
 
@@ -94,6 +95,18 @@ class Spinner extends Prompt
 
         $this->eraseRenderedLines();
         $this->showCursor();
+        $this->ignoreNewLines(false);
+    }
+
+    /**
+     * If the method exists, instruct the output to ignore new lines
+     * as the spinner will erase itself at the end of the process.
+     */
+    protected function ignoreNewLines(bool $ignore = true): void
+    {
+        if (method_exists(static::output(), 'ignoreNewLines')) {
+            static::output()->ignoreNewLines($ignore);
+        }
     }
 
     /**


### PR DESCRIPTION
Ok, taking another stab at this one based on your feedback in #72.

I tested the following scenarios:
- Question -> Spinner -> Question
- Spinner -> Question
- Spinner -> Spinner -> Question

and the spacing looked consistent:

https://github.com/laravel/prompts/assets/2702148/d89b5f96-057a-4f90-a5f7-69beca4f2a6f

I think the main question is do you like the API and the fact that this adds another method and some light logic to the `ConsoleOutput` class.

I thought about abstracting this further in case other components might want to use it, but it felt like overkill and I couldn't think of another scenario where it would be relevant.

Let me know what you think!
