### PR TITLE
Replace shutdown handlers with destructors

### DIFF
--- a/src/Concerns/Events.php
+++ b/src/Concerns/Events.php
@@ -30,4 +30,12 @@ trait Events
             $listener(...$data);
         }
     }
+
+    /**
+     * Clean the event listeners.
+     */
+    public function clearListeners(): void
+    {
+        $this->listeners = [];
+    }
 }

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -74,52 +74,48 @@ abstract class Prompt
      */
     public function prompt(): mixed
     {
-        static::$interactive ??= stream_isatty(STDIN);
-
-        if (! static::$interactive) {
-            return $this->default();
-        }
-
-        $this->capturePreviousNewLines();
-
-        if (static::shouldFallback()) {
-            return $this->fallback();
-        }
-
-        $this->checkEnvironment();
-
         try {
-            static::terminal()->setTty('-icanon -isig -echo');
-        } catch (Throwable $e) {
-            static::output()->writeln("<comment>{$e->getMessage()}</comment>");
-            static::fallbackWhen(true);
+            static::$interactive ??= stream_isatty(STDIN);
 
-            return $this->fallback();
-        }
+            if (! static::$interactive) {
+                return $this->default();
+            }
 
-        register_shutdown_function(function () {
-            $this->restoreCursor();
-            static::terminal()->restoreTty();
-        });
+            $this->capturePreviousNewLines();
 
-        $this->hideCursor();
-        $this->render();
+            if (static::shouldFallback()) {
+                return $this->fallback();
+            }
 
-        while (($key = static::terminal()->read()) !== null) {
-            $continue = $this->handleKeyPress($key);
+            $this->checkEnvironment();
 
+            try {
+                static::terminal()->setTty('-icanon -isig -echo');
+            } catch (Throwable $e) {
+                static::output()->writeln("<comment>{$e->getMessage()}</comment>");
+                static::fallbackWhen(true);
+
+                return $this->fallback();
+            }
+
+            $this->hideCursor();
             $this->render();
 
-            if ($continue === false || $key === Key::CTRL_C) {
-                $this->restoreCursor();
-                static::terminal()->restoreTty();
+            while (($key = static::terminal()->read()) !== null) {
+                $continue = $this->handleKeyPress($key);
 
-                if ($key === Key::CTRL_C) {
-                    static::terminal()->exit();
+                $this->render();
+
+                if ($continue === false || $key === Key::CTRL_C) {
+                    if ($key === Key::CTRL_C) {
+                        static::terminal()->exit();
+                    }
+
+                    return $this->value();
                 }
-
-                return $this->value();
             }
+        } finally {
+            $this->clearListeners();
         }
     }
 
@@ -342,5 +338,15 @@ abstract class Prompt
         if (PHP_OS_FAMILY === 'Windows') {
             throw new RuntimeException('Prompts is not currently supported on Windows. Please use WSL or configure a fallback.');
         }
+    }
+
+    /**
+     * Restore the cursor and terminal state.
+     */
+    public function __destruct()
+    {
+        $this->restoreCursor();
+
+        static::terminal()->restoreTty();
     }
 }

--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -23,6 +23,11 @@ class Spinner extends Prompt
     public bool $static = false;
 
     /**
+     * The process ID after forking.
+     */
+    protected int $pid;
+
+    /**
      * Create a new Spinner instance.
      */
     public function __construct(public string $message = '')
@@ -42,8 +47,6 @@ class Spinner extends Prompt
     {
         $this->capturePreviousNewLines();
 
-        register_shutdown_function(fn () => $this->restoreCursor());
-
         if (! function_exists('pcntl_fork')) {
             return $this->renderStatically($callback);
         }
@@ -56,9 +59,9 @@ class Spinner extends Prompt
             $this->hideCursor();
             $this->render();
 
-            $pid = pcntl_fork();
+            $this->pid = pcntl_fork();
 
-            if ($pid === 0) {
+            if ($this->pid === 0) {
                 while (true) { // @phpstan-ignore-line
                     $this->render();
 
@@ -67,11 +70,7 @@ class Spinner extends Prompt
                     usleep($this->interval * 1000);
                 }
             } else {
-                register_shutdown_function(fn () => posix_kill($pid, SIGHUP));
-
                 $result = $callback();
-
-                posix_kill($pid, SIGHUP);
 
                 $this->resetTerminal($originalAsync);
 
@@ -93,7 +92,6 @@ class Spinner extends Prompt
         pcntl_signal(SIGINT, SIG_DFL);
 
         $this->eraseRenderedLines();
-        $this->showCursor();
     }
 
     /**
@@ -115,7 +113,6 @@ class Spinner extends Prompt
             $result = $callback();
         } finally {
             $this->eraseRenderedLines();
-            $this->showCursor();
         }
 
         return $result;
@@ -147,5 +144,17 @@ class Spinner extends Prompt
         $lines = explode(PHP_EOL, $this->prevFrame);
         $this->moveCursor(-999, -count($lines) + 1);
         $this->eraseDown();
+    }
+
+    /**
+     * Clean up after the spinner.
+     */
+    public function __destruct()
+    {
+        parent::__destruct();
+
+        if (! empty($this->pid)) {
+            posix_kill($this->pid, SIGHUP);
+        }
     }
 }

--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -151,10 +151,10 @@ class Spinner extends Prompt
      */
     public function __destruct()
     {
-        parent::__destruct();
-
         if (! empty($this->pid)) {
             posix_kill($this->pid, SIGHUP);
         }
+
+        parent::__destruct();
     }
 }

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -47,7 +47,7 @@ class Terminal
      */
     public function restoreTty(): void
     {
-        if ($this->initialTtyMode) {
+        if (isset($this->initialTtyMode)) {
             $this->exec("stty {$this->initialTtyMode}");
 
             $this->initialTtyMode = null;


### PR DESCRIPTION
This PR fixes a memory leak by:

* Replacing calls to `register_shutdown_handler` with class destructors. (thanks @nunomaduro :raised_hands:)
* Clearing the event listeners to remove any circular references in callback functions that would prevent GC.

I've also removed redundant calls to restore the cursor and TTY now that the destructor will handle it immediately after each prompt, regardless of whether it's successful or fails due to exception, exit, or `SIGINT`/`Ctrl+C`.

_Best viewed with "Hide whitespace" enabled._