### PR TITLE
Allow `select` and `search` "required" message to be customized.

### DIFF
--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -3,6 +3,7 @@
 namespace Laravel\Prompts;
 
 use Closure;
+use InvalidArgumentException;
 
 class SearchPrompt extends Prompt
 {
@@ -19,11 +20,6 @@ class SearchPrompt extends Prompt
      * The index of the first visible option.
      */
     public int $firstVisible = 0;
-
-    /**
-     * Whether user input is required.
-     */
-    public bool|string $required = true;
 
     /**
      * The cached matches.
@@ -43,8 +39,13 @@ class SearchPrompt extends Prompt
         public string $placeholder = '',
         public int $scroll = 5,
         public ?Closure $validate = null,
-        public string $hint = ''
+        public string $hint = '',
+        public bool|string $required = true,
     ) {
+        if ($this->required === false) {
+            throw new InvalidArgumentException('Argument [required] must be true or a string.');
+        }
+
         $this->trackTypedValue(submit: false);
 
         $this->reduceScrollingToFitTerminal();

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -4,6 +4,7 @@ namespace Laravel\Prompts;
 
 use Closure;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 
 class SelectPrompt extends Prompt
 {
@@ -27,11 +28,6 @@ class SelectPrompt extends Prompt
     public array $options;
 
     /**
-     * Whether user input is required.
-     */
-    public bool|string $required = true;
-
-    /**
      * Create a new SelectPrompt instance.
      *
      * @param  array<int|string, string>|Collection<int|string, string>  $options
@@ -42,8 +38,13 @@ class SelectPrompt extends Prompt
         public int|string|null $default = null,
         public int $scroll = 5,
         public ?Closure $validate = null,
-        public string $hint = ''
+        public string $hint = '',
+        public bool|string $required = true,
     ) {
+        if ($this->required === false) {
+            throw new InvalidArgumentException('Argument [required] must be true or a string.');
+        }
+
         $this->options = $options instanceof Collection ? $options->all() : $options;
 
         $this->reduceScrollingToFitTerminal();

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -25,10 +25,11 @@ function password(string $label, string $placeholder = '', bool|string $required
  * Prompt the user to select an option.
  *
  * @param  array<int|string, string>|Collection<int|string, string>  $options
+ * @param  true|string  $required
  */
-function select(string $label, array|Collection $options, int|string $default = null, int $scroll = 5, Closure $validate = null, string $hint = ''): int|string
+function select(string $label, array|Collection $options, int|string $default = null, int $scroll = 5, Closure $validate = null, string $hint = '', bool|string $required = true): int|string
 {
-    return (new SelectPrompt($label, $options, $default, $scroll, $validate, $hint))->prompt();
+    return (new SelectPrompt($label, $options, $default, $scroll, $validate, $hint, $required))->prompt();
 }
 
 /**
@@ -65,10 +66,11 @@ function suggest(string $label, array|Collection|Closure $options, string $place
  * Allow the user to search for an option.
  *
  * @param  Closure(string): array<int|string, string>  $options
+ * @param  true|string  $required
  */
-function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, Closure $validate = null, string $hint = ''): int|string
+function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, Closure $validate = null, string $hint = '', bool|string $required = true): int|string
 {
-    return (new SearchPrompt($label, $options, $placeholder, $scroll, $validate, $hint))->prompt();
+    return (new SearchPrompt($label, $options, $placeholder, $scroll, $validate, $hint, $required))->prompt();
 }
 
 /**

--- a/tests/Feature/SearchPromptTest.php
+++ b/tests/Feature/SearchPromptTest.php
@@ -123,3 +123,9 @@ it('fails when when non-interactive', function () {
 
     search('What is your favorite color?', fn () => []);
 })->throws(NonInteractiveValidationException::class, 'Required.');
+
+it('allows the required validation message to be customised when non-interactive', function () {
+    Prompt::interactive(false);
+
+    search('What is your favorite color?', fn () => [], required: 'The color is required.');
+})->throws(NonInteractiveValidationException::class, 'The color is required.');

--- a/tests/Feature/SelectPromptTest.php
+++ b/tests/Feature/SelectPromptTest.php
@@ -263,3 +263,17 @@ it('validates the default value when non-interactive', function () {
         validate: fn ($value) => $value === 'None' ? 'Required.' : null,
     );
 })->throws(NonInteractiveValidationException::class, 'Required.');
+
+it('Allows the required validation message to be customised when non-interactive', function () {
+    Prompt::interactive(false);
+
+    select(
+        label: 'What is your favorite color?',
+        options: [
+            'Red',
+            'Green',
+            'Blue',
+        ],
+        required: 'The color is required.',
+    );
+})->throws(NonInteractiveValidationException::class, 'The color is required.');


### PR DESCRIPTION
This PR improves the changes made in #73 so that the "required" validation message can be customized for `select` and `search` prompts when running non-interactively.

These two prompts are inherently required (unless a default is provided to the `select` prompt), so I've prevented setting it to `false` to avoid a more confusing error message. When PHP 8.1 is no longer supported, we can specify `true|string` directly on the functions.