### PR TITLE
Adds support for alternate HOME and END escape keys

### DIFF
--- a/src/Concerns/TypedValue.php
+++ b/src/Concerns/TypedValue.php
@@ -36,8 +36,8 @@ trait TypedValue
                 match ($key) {
                     Key::LEFT, Key::LEFT_ARROW, Key::CTRL_B => $this->cursorPosition = max(0, $this->cursorPosition - 1),
                     Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_F => $this->cursorPosition = min(mb_strlen($this->typedValue), $this->cursorPosition + 1),
-                    Key::any(Key::HOME, $key), Key::CTRL_A => $this->cursorPosition = 0,
-                    Key::any(Key::END, $key), Key::CTRL_E => $this->cursorPosition = mb_strlen($this->typedValue),
+                    Key::oneOf([Key::HOME, Key::CTRL_A], $key) => $this->cursorPosition = 0,
+                    Key::oneOf([Key::END, Key::CTRL_E], $key) => $this->cursorPosition = mb_strlen($this->typedValue),
                     Key::DELETE => $this->typedValue = mb_substr($this->typedValue, 0, $this->cursorPosition).mb_substr($this->typedValue, $this->cursorPosition + 1),
                     default => null,
                 };

--- a/src/Concerns/TypedValue.php
+++ b/src/Concerns/TypedValue.php
@@ -36,8 +36,8 @@ trait TypedValue
                 match ($key) {
                     Key::LEFT, Key::LEFT_ARROW, Key::CTRL_B => $this->cursorPosition = max(0, $this->cursorPosition - 1),
                     Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_F => $this->cursorPosition = min(mb_strlen($this->typedValue), $this->cursorPosition + 1),
-                    Key::HOME, Key::CTRL_A => $this->cursorPosition = 0,
-                    Key::END, Key::CTRL_E => $this->cursorPosition = mb_strlen($this->typedValue),
+                    Key::any(Key::HOME, $key), Key::CTRL_A => $this->cursorPosition = 0,
+                    Key::any(Key::END, $key), Key::CTRL_E => $this->cursorPosition = mb_strlen($this->typedValue),
                     Key::DELETE => $this->typedValue = mb_substr($this->typedValue, 0, $this->cursorPosition).mb_substr($this->typedValue, $this->cursorPosition + 1),
                     default => null,
                 };

--- a/src/Key.php
+++ b/src/Key.php
@@ -88,6 +88,7 @@ class Key
         if (! is_array($keys)) {
             $keys = [$keys];
         }
+        
         return in_array($match, $keys) ? $match : null;
     }
 }

--- a/src/Key.php
+++ b/src/Key.php
@@ -32,9 +32,9 @@ class Key
 
     const SHIFT_TAB = "\e[Z";
 
-    const HOME = "\e[1~";
+    const HOME = ["\e[1~", "\eOH", "\e[H"];
 
-    const END = "\e[4~";
+    const END = ["\e[4~", "\eOF", "\e[F"];
 
     /**
      * Cancel/SIGINT
@@ -75,4 +75,19 @@ class Key
      * End
      */
     const CTRL_E = "\x05";
+
+    /**
+     * Checks for the constant values for the given match and returns the match
+     *
+     * @param string|string[] $keys
+     * @param string $match
+     * @return string|null
+     */
+    public static function any(mixed $keys, string $match): ?string
+    {
+        if (! is_array($keys)) {
+            $keys = [$keys];
+        }
+        return in_array($match, $keys) ? $match : null;
+    }
 }

--- a/src/Key.php
+++ b/src/Key.php
@@ -78,6 +78,10 @@ class Key
 
     /**
      * Checks for the constant values for the given match and returns the match
+     *
+     * @param array<string|array<string>> $keys
+     * @param string $match
+     * @return string|null
      */
     public static function oneOf(array $keys, string $match): ?string
     {

--- a/src/Key.php
+++ b/src/Key.php
@@ -32,9 +32,9 @@ class Key
 
     const SHIFT_TAB = "\e[Z";
 
-    const HOME = ["\e[1~", "\eOH", "\e[H"];
+    const HOME = ["\e[1~", "\eOH", "\e[H", "\e[7~"];
 
-    const END = ["\e[4~", "\eOF", "\e[F"];
+    const END = ["\e[4~", "\eOF", "\e[F", "\e[8~"];
 
     /**
      * Cancel/SIGINT

--- a/src/Key.php
+++ b/src/Key.php
@@ -78,10 +78,6 @@ class Key
 
     /**
      * Checks for the constant values for the given match and returns the match
-     *
-     * @param string[] $keys
-     * @param string $match
-     * @return string|null
      */
     public static function oneOf(array $keys, string $match): ?string
     {

--- a/src/Key.php
+++ b/src/Key.php
@@ -79,16 +79,12 @@ class Key
     /**
      * Checks for the constant values for the given match and returns the match
      *
-     * @param string|string[] $keys
+     * @param string[] $keys
      * @param string $match
      * @return string|null
      */
-    public static function any(mixed $keys, string $match): ?string
+    public static function oneOf(array $keys, string $match): ?string
     {
-        if (! is_array($keys)) {
-            $keys = [$keys];
-        }
-        
-        return in_array($match, $keys) ? $match : null;
+        return collect($keys)->flatten()->contains($match) ? $match : null;
     }
 }

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -54,7 +54,7 @@ class SearchPrompt extends Prompt
             Key::UP, Key::UP_ARROW, Key::SHIFT_TAB, Key::CTRL_P => $this->highlightPrevious(),
             Key::DOWN, Key::DOWN_ARROW, Key::TAB, Key::CTRL_N => $this->highlightNext(),
             Key::ENTER => $this->highlighted !== null ? $this->submit() : $this->search(),
-            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::any(Key::HOME, $key), Key::any(Key::END, $key), Key::CTRL_A, Key::CTRL_E => $this->highlighted = null,
+            Key::oneOf([Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::HOME, Key::END, Key::CTRL_A, Key::CTRL_E], $key) => $this->highlighted = null,
             default => $this->search(),
         });
     }

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -54,7 +54,7 @@ class SearchPrompt extends Prompt
             Key::UP, Key::UP_ARROW, Key::SHIFT_TAB, Key::CTRL_P => $this->highlightPrevious(),
             Key::DOWN, Key::DOWN_ARROW, Key::TAB, Key::CTRL_N => $this->highlightNext(),
             Key::ENTER => $this->highlighted !== null ? $this->submit() : $this->search(),
-            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::HOME, Key::END, Key::CTRL_A, Key::CTRL_E => $this->highlighted = null,
+            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::any(Key::HOME, $key), Key::any(Key::END, $key), Key::CTRL_A, Key::CTRL_E => $this->highlighted = null,
             default => $this->search(),
         });
     }

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -58,7 +58,7 @@ class SuggestPrompt extends Prompt
             Key::UP, Key::UP_ARROW, Key::SHIFT_TAB, Key::CTRL_P => $this->highlightPrevious(),
             Key::DOWN, Key::DOWN_ARROW, Key::TAB, Key::CTRL_N => $this->highlightNext(),
             Key::ENTER => $this->selectHighlighted(),
-            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::any(Key::HOME, $key), Key::any(Key::END, $key), Key::CTRL_A, Key::CTRL_E => $this->highlighted = null,
+            Key::oneOf([Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::HOME, Key::END, Key::CTRL_A, Key::CTRL_E], $key) => $this->highlighted = null,
             default => (function () {
                 $this->highlighted = null;
                 $this->matches = null;

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -58,7 +58,7 @@ class SuggestPrompt extends Prompt
             Key::UP, Key::UP_ARROW, Key::SHIFT_TAB, Key::CTRL_P => $this->highlightPrevious(),
             Key::DOWN, Key::DOWN_ARROW, Key::TAB, Key::CTRL_N => $this->highlightNext(),
             Key::ENTER => $this->selectHighlighted(),
-            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::HOME, Key::END, Key::CTRL_A, Key::CTRL_E => $this->highlighted = null,
+            Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F, Key::any(Key::HOME, $key), Key::any(Key::END, $key), Key::CTRL_A, Key::CTRL_E => $this->highlighted = null,
             default => (function () {
                 $this->highlighted = null;
                 $this->matches = null;

--- a/tests/Feature/TextPromptTest.php
+++ b/tests/Feature/TextPromptTest.php
@@ -86,11 +86,11 @@ test('support emacs style key binding', function () {
 });
 
 test('move to the beginning and end of line', function () {
-    Prompt::fake(['e', 's', Key::HOME, 'J', KEY::END, 's', Key::ENTER]);
+    Prompt::fake(['A', 'r', Key::HOME[0], 's', KEY::END[0], 'c', Key::HOME[1], 's', Key::END[1], 'h', 'e', Key::HOME[2], 'J', 'e', Key::END[2], 'r', Key::ENTER]);
 
     $result = text(label: 'What is your name?');
 
-    expect($result)->toBe('Jess');
+    expect($result)->toBe('JessArcher');
 });
 
 it('returns an empty string when non-interactive', function () {

--- a/tests/Feature/TextPromptTest.php
+++ b/tests/Feature/TextPromptTest.php
@@ -86,7 +86,7 @@ test('support emacs style key binding', function () {
 });
 
 test('move to the beginning and end of line', function () {
-    Prompt::fake(['A', 'r', Key::HOME[0], 's', KEY::END[0], 'c', Key::HOME[1], 's', Key::END[1], 'h', 'e', Key::HOME[2], 'J', 'e', Key::END[2], 'r', Key::ENTER]);
+    Prompt::fake(['A', 'r', Key::HOME[0], 's', KEY::END[0], 'c', Key::HOME[1], 's', Key::END[1], 'h', Key::HOME[2], 'e', Key::END[2], 'e', Key::HOME[3], 'J', Key::END[3], 'r', Key::ENTER]);
 
     $result = text(label: 'What is your name?');
 


### PR DESCRIPTION
The HOME and END keys don't work on Mac in iTerm2. After searching around I found that they could be any of the following depending on the terminal type:

```
"\e[1~": beginning-of-line
"\e[4~": end-of-line
"\e[7~": beginning-of-line
"\e[8~": end-of-line
"\eOH": beginning-of-line
"\eOF": end-of-line
"\e[H": beginning-of-line
"\e[F": end-of-line
```

Rather than creating multiple `Key::Home` alternates (`Home_1`, `Home_2`, etc), I converted it to an array and added an `oneOf()` method for the Key class to help resolve it via the existing match functions. 

