### PR TITLE
Prioritize fallback over non-interactive mode

### DIFF
--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -75,16 +75,16 @@ abstract class Prompt
     public function prompt(): mixed
     {
         try {
-            static::$interactive ??= stream_isatty(STDIN);
-
-            if (! static::$interactive) {
-                return $this->default();
-            }
-
             $this->capturePreviousNewLines();
 
             if (static::shouldFallback()) {
                 return $this->fallback();
+            }
+
+            static::$interactive ??= stream_isatty(STDIN);
+
+            if (! static::$interactive) {
+                return $this->default();
             }
 
             $this->checkEnvironment();


### PR DESCRIPTION
This PR solves an obscure Windows issue when using `mintty` without `wintty`, which causes `stream_isatty(STDIN)` to incorrectly return `false`, which triggers non-interactive mode.

This can occur when using "Git Bash" (which uses `mintty` under the hood) without the `php` CLI alias. I.e when prefixing a script with `php.exe` instead of `php`, or when directly executing a PHP script with a shebang (like the Laravel installer).

I can't find a reliable way to determine whether `STDIN` is interactive or not in this scenario because `mintty` simulates a TTY by using a pipe, which is typically not interactive. The most reliable workaround I can think of for the time being is to make the Windows fallback take precedence over non-interactive mode. We could alternatively force-enable interactive mode when using `mintty` without `wintty`, but I'm not sure if there is a scenario where this would be genuinely non-interactive.

Fixes https://github.com/laravel/installer/issues/286