### PR TITLE
Displaying a final message when rendering spinner

### DIFF
--- a/playground/spin.php
+++ b/playground/spin.php
@@ -2,7 +2,7 @@
 
 use function Laravel\Prompts\spin;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__.'/../vendor/autoload.php';
 
 $result1 = spin(
     function () {

--- a/playground/spin.php
+++ b/playground/spin.php
@@ -2,9 +2,9 @@
 
 use function Laravel\Prompts\spin;
 
-require __DIR__.'/../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
-$result = spin(
+$result1 = spin(
     function () {
         sleep(4);
 
@@ -13,8 +13,28 @@ $result = spin(
     'Installing dependencies...',
 );
 
+$result2 = spin(
+    function () {
+        sleep(4);
+
+        return 'A-OK';
+    },
+    'Checking system...',
+    'System looks good!',
+);
+
+$result3 = spin(
+    function () {
+        sleep(4);
+
+        return '8.2';
+    },
+    'Detecting PHP Version...',
+    fn ($result) => "PHP Version: <info>{$result}</info>",
+);
+
 echo PHP_EOL;
 
-var_dump($result);
+var_dump($result1, $result2, $result3);
 
 echo str_repeat(PHP_EOL, 6);

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -83,7 +83,7 @@ abstract class Prompt
 
             static::$interactive ??= stream_isatty(STDIN);
 
-            if (!static::$interactive) {
+            if (! static::$interactive) {
                 return $this->default();
             }
 
@@ -264,7 +264,7 @@ abstract class Prompt
         $diff = [];
 
         for ($i = 0; $i < max(count($aLines), count($bLines)); $i++) {
-            if (!isset($aLines[$i]) || !isset($bLines[$i]) || $aLines[$i] !== $bLines[$i]) {
+            if (! isset($aLines[$i]) || ! isset($bLines[$i]) || $aLines[$i] !== $bLines[$i]) {
                 $diff[] = $i;
             }
         }
@@ -314,13 +314,13 @@ abstract class Prompt
             return;
         }
 
-        if (!isset($this->validate)) {
+        if (! isset($this->validate)) {
             return;
         }
 
         $error = ($this->validate)($value);
 
-        if (!is_string($error) && !is_null($error)) {
+        if (! is_string($error) && ! is_null($error)) {
             throw new \RuntimeException('The validator must return a string or null.');
         }
 

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -83,7 +83,7 @@ abstract class Prompt
 
             static::$interactive ??= stream_isatty(STDIN);
 
-            if (! static::$interactive) {
+            if (!static::$interactive) {
                 return $this->default();
             }
 
@@ -264,7 +264,7 @@ abstract class Prompt
         $diff = [];
 
         for ($i = 0; $i < max(count($aLines), count($bLines)); $i++) {
-            if (! isset($aLines[$i]) || ! isset($bLines[$i]) || $aLines[$i] !== $bLines[$i]) {
+            if (!isset($aLines[$i]) || !isset($bLines[$i]) || $aLines[$i] !== $bLines[$i]) {
                 $diff[] = $i;
             }
         }
@@ -314,13 +314,13 @@ abstract class Prompt
             return;
         }
 
-        if (! isset($this->validate)) {
+        if (!isset($this->validate)) {
             return;
         }
 
         $error = ($this->validate)($value);
 
-        if (! is_string($error) && ! is_null($error)) {
+        if (!is_string($error) && !is_null($error)) {
             throw new \RuntimeException('The validator must return a string or null.');
         }
 

--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -29,8 +29,6 @@ class Spinner extends Prompt
 
     /**
      * The final message to display.
-     *
-     * @var string
      */
     public string $finalMessage = '';
 
@@ -63,7 +61,7 @@ class Spinner extends Prompt
     {
         $this->capturePreviousNewLines();
 
-        if (!function_exists('pcntl_fork')) {
+        if (! function_exists('pcntl_fork')) {
             return $this->renderStatically($callback);
         }
 
@@ -191,7 +189,7 @@ class Spinner extends Prompt
      */
     public function __destruct()
     {
-        if (!empty($this->pid)) {
+        if (! empty($this->pid)) {
             posix_kill($this->pid, SIGHUP);
         }
 

--- a/src/Themes/Default/SpinnerRenderer.php
+++ b/src/Themes/Default/SpinnerRenderer.php
@@ -31,7 +31,7 @@ class SpinnerRenderer extends Renderer
         if ($spinner->finalMessage !== '') {
             $finalMessage = wordwrap($spinner->finalMessage, $spinner->terminal()->cols() - 6);
 
-            collect(explode(PHP_EOL, $finalMessage))->each(fn ($line) => $this->line(' ' . $line));
+            collect(explode(PHP_EOL, $finalMessage))->each(fn ($line) => $this->line(' '.$line));
 
             // Avoid partial line indicator on re-render
             $this->line('');

--- a/src/Themes/Default/SpinnerRenderer.php
+++ b/src/Themes/Default/SpinnerRenderer.php
@@ -28,6 +28,17 @@ class SpinnerRenderer extends Renderer
      */
     public function __invoke(Spinner $spinner): string
     {
+        if ($spinner->finalMessage !== '') {
+            $finalMessage = wordwrap($spinner->finalMessage, $spinner->terminal()->cols() - 6);
+
+            collect(explode(PHP_EOL, $finalMessage))->each(fn ($line) => $this->line(' ' . $line));
+
+            // Avoid partial line indicator on re-render
+            $this->line('');
+
+            return $this;
+        }
+
         if ($spinner->static) {
             return $this->line(" {$this->cyan($this->staticFrame)} {$spinner->message}");
         }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -90,11 +90,12 @@ function multisearch(string $label, Closure $options, string $placeholder = '', 
  * @template TReturn of mixed
  *
  * @param  \Closure(): TReturn  $callback
+ * @param  string|\Closure(TReturn): string  $finalMessage
  * @return TReturn
  */
-function spin(Closure $callback, string $message = ''): mixed
+function spin(Closure $callback, string $message = '', string|Closure $finalMessage = ''): mixed
 {
-    return (new Spinner($message))->spin($callback);
+    return (new Spinner($message, $finalMessage))->spin($callback);
 }
 
 /**

--- a/tests/Feature/SpinnerTest.php
+++ b/tests/Feature/SpinnerTest.php
@@ -17,3 +17,21 @@ it('renders a spinner while executing a callback and then returns the value', fu
 
     Prompt::assertOutputContains('Running...');
 });
+
+it('renders a spinner and displays a final message', function ($finalMessageHandler, $expectedMessage) {
+    Prompt::fake();
+
+    $result = spin(function () {
+        usleep(1000);
+
+        return 'result!';
+    }, 'Running...', $finalMessageHandler);
+
+    expect($result)->toBe('result!');
+
+    Prompt::assertOutputContains('Running...');
+    Prompt::assertOutputContains($expectedMessage);
+})->with([
+    'string' => ['All done!', 'All done!'],
+    'closure' => [fn ($result) => "All done: {$result}", 'All done: result!'],
+]);


### PR DESCRIPTION
This PR introduces an optional third argument to the `spin` helper, allowing the user to display a final message after the spinner has completed its process.

The message can either be a string:

```php
spin(
    function () {
        sleep(4);

        return 'A-OK';
    },
    'Checking system...',
    'System looks good!',
);
```

or a closure that receives the result as an argument:

```php
spin(
    function () {
        sleep(4);

        return '8.2';
    },
    'Detecting PHP Version...',
    fn ($result) => "PHP Version: <info>{$result}</info>",
);
```

Here's what it looks like:

https://github.com/laravel/prompts/assets/2702148/a1f8a719-5c47-4ef1-9d2d-95b01e36adc3

