### PR TITLE
Allow empty strings on `select` prompt

### DIFF
--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -307,9 +307,9 @@ abstract class Prompt
     {
         $this->validated = true;
 
-        if (($this->required ?? false) && $this->isInvalidWhenRequired($value)) {
+        if ($this->required !== false && $this->isInvalidWhenRequired($value)) {
             $this->state = 'error';
-            $this->error = is_string($this->required) ? $this->required : 'Required.';
+            $this->error = is_string($this->required) && strlen($this->required) > 0 ? $this->required : 'Required.';
 
             return;
         }

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -307,7 +307,7 @@ abstract class Prompt
     {
         $this->validated = true;
 
-        if (($this->required ?? false) && ($value === '' || $value === [] || $value === false || $value === null)) {
+        if (($this->required ?? false) && $this->isInvalidWhenRequired($value)) {
             $this->state = 'error';
             $this->error = is_string($this->required) ? $this->required : 'Required.';
 
@@ -328,6 +328,14 @@ abstract class Prompt
             $this->state = 'error';
             $this->error = $error;
         }
+    }
+
+    /**
+     * Determine whether the given value is invalid when the prompt is required.
+     */
+    protected function isInvalidWhenRequired(mixed $value): bool
+    {
+        return $value === '' || $value === [] || $value === false || $value === null;
     }
 
     /**

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -96,4 +96,12 @@ class SelectPrompt extends Prompt
     {
         return array_slice($this->options, $this->firstVisible, $this->scroll, preserve_keys: true);
     }
+
+    /**
+     * Determine whether the given value is invalid when the prompt is required.
+     */
+    protected function isInvalidWhenRequired(mixed $value): bool
+    {
+        return $value === null;
+    }
 }

--- a/tests/Feature/SelectPromptTest.php
+++ b/tests/Feature/SelectPromptTest.php
@@ -257,6 +257,20 @@ it('supports the end key', function () {
     expect($result)->toBe('Blue');
 });
 
+it('allows empty strings', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = select(
+        label: 'What is your favorite color?',
+        options: [
+            '' => 'Empty',
+            'not-empty' => 'Not empty',
+        ],
+    );
+
+    expect($result)->toBe('');
+});
+
 it('fails when there is no default in non-interactive mode', function () {
     Prompt::interactive(false);
 


### PR DESCRIPTION
The current `required` validation approach is a "one size fits all" in terms of what is considered invalid when a prompt is required.

For a `text` prompt, an empty string from the user shouldn't be accepted when the prompt is required. But with a `select` prompt, it's possible to pass an empty string key as one of the configured `options` (potentially as a marker for something), and it seems unreasonable that a configured option would cause a validation error by default.

This PR addresses this by allowing each prompt to configure what should be considered invalid when the prompt is required. For now, I don't see a need to configure this for every prompt, so I've kept the current values as the "default" set and just updated the `SelectPrompt` with an override.

It's still possible to add a custom validation handler to prevent a configured option from being selected if needed.

It was also pointed out in #98 that setting the `$required` value to an empty string would disable validation due to truthy check, so I've also tightened this up.

Fixes #98.