### PR TITLE
Add field ids to bug-report template for prefilling via url

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.yml
@@ -4,48 +4,55 @@ body:
   - type: markdown
     attributes:
       value: "Before submitting your report, [please ensure your Laravel version is still supported](https://laravel.com/docs/releases#support-policy)."
-  - type: input
+  - id: package-version
+    type: input
     attributes:
       label: Laravel Prompts Version
       description: Provide the Laravel Prompts version that you are using.
       placeholder: 1.0.0
     validations:
       required: true
-  - type: input
+  - id: laravel-version
+    type: input
     attributes:
       label: Laravel Version
       description: Provide the Laravel version that you are using.
       placeholder: 10.4.1
     validations:
       required: true
-  - type: input
+  - id: php-version
+    type: input
     attributes:
       label: PHP Version
       description: Provide the PHP version that you are using.
       placeholder: 8.1.4
     validations:
       required: true
-  - type: input
+  - id: operating-system
+    type: input
     attributes:
       label: Operating System & Version
       description: Provide the operating system and version you are using.
       placeholder: "macOS 13.0"
     validations:
       required: true
-  - type: input
+  - id: terminal
+    type: input
     attributes:
       label: Terminal Application
       description: Provide the name of the terminal application you are using
       placeholder: "iTerm"
     validations:
       required: true
-  - type: textarea
+  - id: issue-description
+    type: textarea
     attributes:
       label: Description
       description: Provide a detailed description of the issue you are facing.
     validations:
       required: true
-  - type: textarea
+  - id: steps-to-reproduce
+    type: textarea
     attributes:
       label: Steps To Reproduce
       description: Provide detailed steps to reproduce your issue. If necessary, please provide a GitHub repository to demonstrate your issue using `laravel new bug-report --github="--public"`.


### PR DESCRIPTION
# Objective
This pull request introduces field IDs to the bug-report template, enhancing the ease of prefilling fields through URLs. This addition is aimed at improving the efficiency and accuracy of bug report submissions.

# Background
Currently, the bug-report template in the Laravel project does not support URL prefilling due to the absence of field IDs. By incorporating field IDs, we can streamline the process of reporting bugs, especially in scenarios where specific versions or configurations are involved.

# Changes Made
Added Field IDs: Each field in the bug-report template now has a unique ID, ensuring they can be easily targeted for URL prefilling.

# Testing
Could not Test

# Benefits to End Users
## Efficiency
I can build a tool that autofills the laravel version into the issue url.

## Accuracy
It reduces the chances of incomplete or incorrect bug reports.

## Ease of Use
New contributors or less technical users can report bugs more easily when the majority of technical details are pre-filled.

# No Break in Existing Features:**
The addition of field IDs is non-intrusive and does not modify the existing workflow or the structure of the template.
Existing links to the bug-report template will function as before, with no changes in behavior.

# Ease of Web Application Development
By streamlining the bug reporting process, developers can expect more accurate and complete reports, leading to quicker resolutions and a smoother development cycle.

Looking forward to feedback and suggestions for further improvements.