### PR TITLE
Allow using stderr for prompt output

### DIFF
--- a/src/Concerns/Cursor.php
+++ b/src/Concerns/Cursor.php
@@ -14,7 +14,7 @@ trait Cursor
      */
     public function hideCursor(): void
     {
-        static::writeDirectly("\e[?25l");
+        static::writer()->writeDirectly("\e[?25l");
 
         static::$cursorHidden = true;
     }
@@ -24,7 +24,7 @@ trait Cursor
      */
     public function showCursor(): void
     {
-        static::writeDirectly("\e[?25h");
+        static::writer()->writeDirectly("\e[?25h");
 
         static::$cursorHidden = false;
     }
@@ -58,6 +58,6 @@ trait Cursor
             $sequence .= "\e[{$y}B"; // Down
         }
 
-        static::writeDirectly($sequence);
+        static::writer()->writeDirectly($sequence);
     }
 }

--- a/src/Concerns/Erase.php
+++ b/src/Concerns/Erase.php
@@ -18,7 +18,7 @@ trait Erase
             $clear .= "\e[G";
         }
 
-        static::writeDirectly($clear);
+        static::writer()->writeDirectly($clear);
     }
 
     /**
@@ -26,6 +26,6 @@ trait Erase
      */
     public function eraseDown(): void
     {
-        static::writeDirectly("\e[J");
+        static::writer()->writeDirectly("\e[J");
     }
 }

--- a/src/Concerns/FakesInputOutput.php
+++ b/src/Concerns/FakesInputOutput.php
@@ -74,11 +74,12 @@ trait FakesInputOutput
      */
     public static function content(): string
     {
-        if (! static::output() instanceof BufferedConsoleOutput) {
+        $output = static::writer()->getOutput();
+        if (! $output instanceof BufferedConsoleOutput) {
             throw new RuntimeException('Prompt must be faked before accessing content.');
         }
 
-        return static::output()->content();
+        return $output->content();
     }
 
     /**

--- a/src/Note.php
+++ b/src/Note.php
@@ -29,7 +29,7 @@ class Note extends Prompt
 
         $this->state = 'submit';
 
-        static::output()->write($this->renderTheme());
+        static::writer()->write($this->renderTheme());
 
         return true;
     }

--- a/src/Output/BufferedConsoleOutput.php
+++ b/src/Output/BufferedConsoleOutput.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Prompts\Output;
 
+use Symfony\Component\Console\Output\ConsoleOutput;
+
 class BufferedConsoleOutput extends ConsoleOutput
 {
     /**

--- a/src/Output/PromptWriter.php
+++ b/src/Output/PromptWriter.php
@@ -2,32 +2,18 @@
 
 namespace Laravel\Prompts\Output;
 
-use Symfony\Component\Console\Formatter\OutputFormatterInterface;
-use Symfony\Component\Console\Output\ConsoleOutput as SymfonyConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Output\StreamOutput;
 
-class ConsoleOutput extends SymfonyConsoleOutput
+class PromptWriter
 {
     /**
      * How many new lines were written by the last output.
      */
     protected int $newLinesWritten = 1;
 
-    protected OutputInterface $promptOutput;
-
     public function __construct(
-        int $verbosity = self::VERBOSITY_NORMAL,
-        ?bool $decorated = null,
-        ?OutputFormatterInterface $formatter = null
+        private OutputInterface $output
     ) {
-        parent::__construct($verbosity, $decorated, $formatter);
-
-        if (stream_isatty(STDERR) && ! stream_isatty(STDOUT)) {
-            $this->promptOutput = $this->getErrorOutput();
-        } else {
-            $this->promptOutput = new StreamOutput($this->getStream());
-        }
     }
 
     /**
@@ -41,9 +27,9 @@ class ConsoleOutput extends SymfonyConsoleOutput
     /**
      * Write the output and capture the number of trailing new lines.
      */
-    protected function doWrite(string $message, bool $newline): void
+    public function write(string $message, bool $newline = false): void
     {
-        $this->promptOutput->write($message, $newline);
+        $this->output->write($message, $newline);
 
         if ($newline) {
             $message .= \PHP_EOL;
@@ -61,8 +47,13 @@ class ConsoleOutput extends SymfonyConsoleOutput
     /**
      * Write output directly, bypassing newline capture.
      */
-    public function writeDirectly(string $message): void
+    public function writeDirectly(string $message, bool $newline = false): void
     {
-        $this->promptOutput->write($message, false);
+        $this->output->write($message, $newline);
+    }
+
+    public function getOutput(): OutputInterface
+    {
+        return $this->output;
     }
 }

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -210,6 +210,7 @@ abstract class Prompt
     public static function useStderr(): void
     {
         $output = static::output();
+
         if ($output instanceof ConsoleOutputInterface) {
             static::setOutput($output->getErrorOutput());
         }

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -5,6 +5,7 @@ namespace Laravel\Prompts;
 use Closure;
 use Laravel\Prompts\Output\ConsoleOutput;
 use RuntimeException;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
@@ -201,6 +202,17 @@ abstract class Prompt
     public static function validateUsing(Closure $callback): void
     {
         static::$validateUsing = $callback;
+    }
+
+    /**
+     * Use stderr for prompt output
+     */
+    public static function useStderr(): void
+    {
+        $output = static::output();
+        if ($output instanceof ConsoleOutputInterface) {
+            static::setOutput($output->getErrorOutput());
+        }
     }
 
     /**

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -5,7 +5,6 @@ namespace Laravel\Prompts;
 use Closure;
 use Laravel\Prompts\Output\ConsoleOutput;
 use RuntimeException;
-use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
@@ -92,7 +91,7 @@ abstract class Prompt
                 return $this->fallback();
             }
 
-            static::$interactive ??= stream_isatty(STDIN);
+            static::$interactive ??= stream_isatty(STDIN) && (stream_isatty(STDOUT) || stream_isatty(STDERR));
 
             if (! static::$interactive) {
                 return $this->default();
@@ -202,18 +201,6 @@ abstract class Prompt
     public static function validateUsing(Closure $callback): void
     {
         static::$validateUsing = $callback;
-    }
-
-    /**
-     * Use stderr for prompt output
-     */
-    public static function useStderr(): void
-    {
-        $output = static::output();
-
-        if ($output instanceof ConsoleOutputInterface) {
-            static::setOutput($output->getErrorOutput());
-        }
     }
 
     /**

--- a/src/Table.php
+++ b/src/Table.php
@@ -56,7 +56,7 @@ class Table extends Prompt
 
         $this->state = 'submit';
 
-        static::output()->write($this->renderTheme());
+        static::writer()->write($this->renderTheme());
 
         return true;
     }


### PR DESCRIPTION
Sending the prompt output to `stdout` (which is the default behavior) can be problematic in situations where the output of the command needs to be redirected to a file, or piped to another command.
- If the output is redirected to a file, e.g. `> data.json`, the prompt is sent directly to the file and won't be displayed in the console. The command will keep running, waiting for input, but the user won't know what's going on.
- If the output is piped to another command, e.g. `|  grep "foo"`, the prompt might also be invisible, or if the receiving command expects structured data like csv or json, it might cause an error.

The fix is easy. Just send the prompt output to `stderr` in stead. That's what [Symfony's QuestionHelper](https://github.com/symfony/console/blob/b95e86a6ed738fa91f3853a34ce6819ce065de8d/Helper/QuestionHelper.php#L54-L56) does by default. And according to [this excellent post](https://fideloper.com/laravel-symfony-console-commands-stderr) by Chris Fidao, it's actually a well established unix convention.

Like I mentioned in #107, I think the best solution would be to use stderr by default, but I realize that this could be considered a breaking change. So in stead I've just added a simple `Prompt::useStderr()` method that makes it easy to send all prompts to stderr.

I really wanted to add some tests that assert that actual output is sent to stdout, and prompts are send to stderr, but I honestly have no idea how to do that.