### PR TITLE
[0.x] Fix `multisearch` long option truncation

### DIFF
--- a/src/Themes/Default/MultiSearchPromptRenderer.php
+++ b/src/Themes/Default/MultiSearchPromptRenderer.php
@@ -111,7 +111,7 @@ class MultiSearchPromptRenderer extends Renderer implements Scrolling
 
         return $this->scrollbar(
             collect($prompt->visible())
-                ->map(fn ($label) => $this->truncate($label, $prompt->terminal()->cols() - 10))
+                ->map(fn ($label) => $this->truncate($label, $prompt->terminal()->cols() - 12))
                 ->map(function ($label, $key) use ($prompt) {
                     $index = array_search($key, array_keys($prompt->matches()));
                     $active = $index === $prompt->highlighted;


### PR DESCRIPTION
This PR fixes an issue with the `multisearch` prompt when options are longer than the terminal width, which would cause wrapping. The `multisearch` prompt needs two more columns than the `search` prompt due to the checkbox.

Fixes #113 