### PR TITLE
Watch feature

### DIFF
--- a/playground/watch.php
+++ b/playground/watch.php
@@ -1,0 +1,44 @@
+<?php
+
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\note;
+use function Laravel\Prompts\progress;
+use function Laravel\Prompts\table;
+use function Laravel\Prompts\text;
+use function Laravel\Prompts\watch;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+watch(
+    function () {
+        static $iteration = 0;
+        static $items = [];
+
+        if (count($items) === 5) {
+            array_shift($items);
+        }
+
+        $items[] = [$iteration += 1, (new Datetime())->format(DateTime::RFC850)];
+
+        if (count($items) === 5) {
+            info(sprintf('Now the table just scrolls, %s and counting...', $iteration));
+        } else {
+            info('Filling up the table...');
+        }
+
+        progress('a nice progressbar', 5)->advance($iteration % 5);
+
+        $ralph = text('Ralph', default: 'Ralph Wiggum: I\'m ignored!');
+
+        note($ralph);
+
+        table(
+            [
+                'Iteration',
+                'DateTime'
+            ],
+            $items
+        );
+    },
+    1,
+);

--- a/src/Concerns/FakesInputOutput.php
+++ b/src/Concerns/FakesInputOutput.php
@@ -4,6 +4,7 @@ namespace Laravel\Prompts\Concerns;
 
 use Laravel\Prompts\Output\BufferedConsoleOutput;
 use Laravel\Prompts\Terminal;
+use Mockery\MockInterface;
 use PHPUnit\Framework\Assert;
 use RuntimeException;
 
@@ -35,6 +36,14 @@ trait FakesInputOutput
         static::$terminal = $mock;
 
         self::setOutput(new BufferedConsoleOutput());
+    }
+
+    /**
+     * Tells if Prompt is currently being faked.
+     */
+    protected static function isFaked(): bool
+    {
+        return static::terminal() instanceof MockInterface;
     }
 
     /**

--- a/src/Concerns/Themes.php
+++ b/src/Concerns/Themes.php
@@ -29,6 +29,8 @@ use Laravel\Prompts\Themes\Default\SpinnerRenderer;
 use Laravel\Prompts\Themes\Default\SuggestPromptRenderer;
 use Laravel\Prompts\Themes\Default\TableRenderer;
 use Laravel\Prompts\Themes\Default\TextPromptRenderer;
+use Laravel\Prompts\Themes\Default\WatchRenderer;
+use Laravel\Prompts\Watch;
 
 trait Themes
 {
@@ -57,6 +59,7 @@ trait Themes
             Note::class => NoteRenderer::class,
             Table::class => TableRenderer::class,
             Progress::class => ProgressRenderer::class,
+            Watch::class => WatchRenderer::class,
         ],
     ];
 

--- a/src/Themes/Default/WatchRenderer.php
+++ b/src/Themes/Default/WatchRenderer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Prompts\Themes\Default;
+
+use Closure;
+use Laravel\Prompts\Output\BufferedConsoleOutput;
+use Laravel\Prompts\Prompt;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class WatchRenderer extends Renderer
+{
+    /**
+     * buffers the output generated inside the Closure and flushes the output to Prompt
+     * in order to utilize Prompts neat way of updating lines
+     */
+    public function __invoke(Closure $watch, OutputInterface $originalOutput): string
+    {
+        $bufferedOutput = new BufferedConsoleOutput();
+
+        Prompt::setOutput($bufferedOutput);
+
+        $watch();
+
+        Prompt::setOutput($originalOutput);
+
+        return $bufferedOutput->fetch();
+    }
+}

--- a/src/Watch.php
+++ b/src/Watch.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Laravel\Prompts;
+
+use Closure;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Assert;
+use RuntimeException;
+use ValueError;
+
+class Watch extends Prompt
+{
+    /**
+     * How many times to fake an iteration.
+     */
+    protected static int $fakeTimes = 1;
+
+    /**
+     * count of faked iterations.
+     */
+    protected int $fakedTimes = 0;
+
+    /**
+     * Faking sleep or not.
+     */
+    protected static bool $fakeSleep = true;
+
+    /**
+     * The amount of seconds slept during intervals in total.
+     */
+    protected static int $sleptSeconds = 0;
+
+    /**
+     * The closure to execute on interval.
+     */
+    protected Closure $watch;
+
+    /**
+     * The interval between updates.
+     */
+    protected int $interval;
+
+    /**
+     * Create a new Watch instance.
+     */
+    public function __construct(callable $watch, ?int $interval = 2)
+    {
+        static::$sleptSeconds = 0;
+        $this->watch = $watch(...);
+        $this->interval = $interval ?? 2;
+
+        if ($this->interval < 0) {
+            throw new ValueError('watch interval must be greater than or equal to 0');
+        }
+    }
+    /**
+     * displays the watched output and updates after the specified interval.
+     */
+    public function render(): void
+    {
+        $faked = static::isFaked();
+
+        static::interactive(false);
+
+        while (!$faked || $this->fakedTimes < static::$fakeTimes) {
+
+            parent::render();
+
+            if ($faked) {
+                $this->fakedTimes++;
+
+                if ($this->fakedTimes >= static::$fakeTimes) {
+
+                    if (static::$terminal instanceof MockInterface) {
+                        $this->state = 'submit';
+                        static::$terminal->expects('read')->zeroOrMoreTimes()->andReturn(false);
+                    }
+                    static::$fakeSleep = true;
+                    break;
+                }
+
+                if (static::$fakeSleep) {
+                    static::$sleptSeconds += $this->interval;
+                    continue;
+                }
+            }
+
+            sleep($this->interval);
+        }
+    }
+
+    /**
+     * Render the prompt using the active theme.
+     * Overrides default behaviour to pass along the current output.
+     */
+    protected function renderTheme(): string
+    {
+        $renderer = static::getRenderer();
+
+        return $renderer($this->watch, static::output());
+    }
+
+    /**
+     * Get the value of the prompt.
+     */
+    public function value(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Tell Prompt how many iterations to fake.
+     */
+    public static function fakeTimes(int $times): void
+    {
+        if (!static::isFaked()) {
+            throw new RuntimeException('Prompt must be faked before faking iterations.');
+        }
+
+        static::$fakeTimes = $times;
+    }
+
+    /**
+     * Asserts the amount of seconds slept during intervals in total.
+     */
+    public static function assertSecondsSleptBetweenIntervals(int $seconds): void
+    {
+        if (!static::isFaked()) {
+            throw new RuntimeException('Prompt must be faked before asserting.');
+        }
+
+        Assert::assertEquals($seconds, static::$sleptSeconds);
+    }
+
+    /**
+     * By default, when Prompt is faked, the intervals are faked.
+     * Use this to actually sleep between updates.
+     */
+    public static function shouldNotFakeIntervalSleep(): void
+    {
+        if (!self::isFaked()) {
+            throw new RuntimeException('Not faking sleep makes no sense when not faking Prompt.');
+        }
+
+        static::$fakeSleep = false;
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -192,3 +192,13 @@ function progress(string $label, iterable|int $steps, ?Closure $callback = null,
 
     return $progress;
 }
+
+/**
+ * Continuously updates output on each interval.
+ *
+ * @param callable(): void $watch
+ */
+function watch(callable $watch, ?int $interval = 2): void
+{
+    (new Watch($watch, $interval))->prompt();
+}

--- a/tests/Feature/WatchTest.php
+++ b/tests/Feature/WatchTest.php
@@ -1,0 +1,157 @@
+<?php
+
+
+use Laravel\Prompts\Prompt;
+use Laravel\Prompts\Terminal;
+use Laravel\Prompts\Watch;
+use function Laravel\Prompts\note;
+use function Laravel\Prompts\text;
+use function Laravel\Prompts\watch;
+
+it('should render', function () {
+    Prompt::fake();
+
+    watch(function () {
+        note('This should render');
+    });
+
+    Watch::assertSecondsSleptBetweenIntervals(0);
+
+    Prompt::assertOutputContains('This should render');
+});
+
+it('should ignore interactive prompts', function () {
+    Prompt::fake();
+
+    watch(function () {
+        text('A question.');
+        note('This should render');
+    });
+
+    Prompt::assertOutputContains('This should render');
+});
+
+it('should render callable array', function () {
+    Prompt::fake();
+
+    $watch = new class() {
+        public function watch(): void
+        {
+            note('This should render through array');
+        }
+    };
+
+    watch([$watch, 'watch']);
+
+    Watch::assertSecondsSleptBetweenIntervals(0);
+
+    Prompt::assertOutputContains('This should render through array');
+});
+
+it('should render invokable', function () {
+    Prompt::fake();
+
+    $watch = new class() {
+        public function __invoke(): void
+        {
+            note('This should render through invokable');
+        }
+    };
+
+    watch($watch);
+
+    Watch::assertSecondsSleptBetweenIntervals(0);
+
+    Prompt::assertOutputContains('This should render through invokable');
+});
+
+it('should render buffered', function () {
+    Prompt::fake();
+
+    watch(function () {
+
+        note('This should not render');
+
+        (fn() => Watch::output())
+            ->bindTo(null, Watch::class)()->fetch();
+    });
+
+    Prompt::assertOutputDoesntContain('This should not render');
+});
+
+it('should fake sleep when faking', function (
+    int $expected,
+    int $iteration,
+    int $interval = null
+) {
+    Prompt::fake();
+
+    Watch::fakeTimes($iteration);
+
+    watch(function () {
+    }, $interval);
+
+    Watch::assertSecondsSleptBetweenIntervals($expected);
+})->with(
+    [
+        ['expected' => 2, 'iteration' => 2, 'interval' => 2],
+        ['expected' => 3, 'iteration' => 2, 'interval' => 3],
+        ['expected' => 6, 'iteration' => 3, 'interval' => 3],
+        ['expected' => 4, 'iteration' => 3, 'interval' => null],
+    ]
+);
+
+it('should throw exception with a negative interval ', function () {
+    Prompt::fake();
+
+    watch(fn() => null, -1);
+
+})->throws(ValueError::class);
+
+it('should sleep 2 seconds by default', function () {
+    Prompt::fake();
+
+    Watch::fakeTimes(2);
+
+    watch(function () {
+    });
+
+    Watch::assertSecondsSleptBetweenIntervals(2);
+});
+
+it('should actually sleep at intervals', function () {
+
+    Prompt::fake();
+
+    Watch::fakeTimes(2);
+
+    Watch::shouldNotFakeIntervalSleep();
+
+    $start = time();
+
+    watch(function () {
+        note('This should render');
+    }, 1);
+
+    $end = time();
+
+    expect($end - $start)->toBe(1);
+
+    Prompt::assertOutputContains('This should render');
+});
+
+it('should throw exception when invoking fakeTimes when not faked', function () {
+    (function () {
+        Prompt::$terminal = new Terminal();
+    })->bindTo(null, Prompt::class)();
+    Watch::fakeTimes(2);
+})->throws(RuntimeException::class);
+
+it('should throw exception when invoking assertSlept when not faked', function () {
+
+    (function () {
+        Prompt::$terminal = new Terminal();
+    })->bindTo(null, Prompt::class)();
+
+    Watch::assertSecondsSleptBetweenIntervals(2);
+})->throws(RuntimeException::class);


### PR DESCRIPTION
### What?
Introducing `watch`. A simple feature that mimics the basic features of the `watch` function found on Linux/Unix systems.

### Why?

I've developed a lot of command line tools, and I often needed to monitor output in the console. Most of the time with tables and such.

Using the `watch` functionality on Linux systems should do it, but this requires the entire framework to be loaded every time, which can put a strain on the server capacity. With this, we don't even need cache, but we can use the `once` function instead for things that shouldn't be cached, but still are needed.

### Example

In the playground directory, there is an example with a table updating with new records every second. Here to just demonstrate the simplicity.

````php
use function Laravel\Prompts\table;
use function Laravel\Prompts\watch;

watch(
   watch: function(){
       table(['header'], [random_int()]);
   },
   interval: 2 // intervals are in seconds
);
````

###Testing

Watch comes with a few testing tools. 

#### fakeTimes

By default it iterates just once, but you can tell how many iterations `watch` should execute.

````php
use Laravel\Prompts\Prompts;
use Laravel\Prompts\Watch;
use function Laravel\Prompts\watch;
use function Laravel\Prompts\info;

Prompts::fake();
Watch::fakeTimes(2);

watch(
    function(){
       info('hello world');
    }
);

Prompts::content(); // would contain hello world twice
````

#### assertSecondsSleptBetweenIntervals

Allows you to assert the total seconds slept between intervals. Allows users to test if they passed the correct value.

````php
use Laravel\Prompts\Prompts;
use Laravel\Prompts\Watch;
use function Laravel\Prompts\watch;
use function Laravel\Prompts\info;

Prompts::fake();
Watch::fakeTimes(2);

watch(
    function(){
       info('hello world');
    }
);

Watch::assertSecondsSleptBetweenIntervals(4); // would succeed because default interval is 2 and it iterated twice.
````

#### shouldNotFakeIntervalSleep

This is not really a thing users would most likely use, but I used it to allow actually test sleeping. I can remove it if you don't want us to actually test sleep functions.

### Considerations

Right now, Prompt is resetting the cursor position using the lines count. When a user presses enter, this messes up the output.

I added a new method `isFaked` to the FakesInputOutput trait which can be used to detect if Prompt is currently being faked. This might be helpful in the future if things like sections as described in #115 are going to be added.