### PR TITLE
Adds Reversible Forms to Prompts

### DIFF
--- a/playground/form.php
+++ b/playground/form.php
@@ -40,11 +40,6 @@ $responses = form()
         name: 'path'
     )
     ->textarea('Describe your project')
-    ->when(
-        fn (array $responses) => $responses['path'] === './laravel',
-        fn (array $responses) => info('This is a Laravel project!'),
-        ignoreWhenReverting: true,
-    )
     ->pause()
     ->submit();
 

--- a/playground/form.php
+++ b/playground/form.php
@@ -39,6 +39,7 @@ $responses = form()
         },
         name: 'path'
     )
+    ->textarea('Describe your project')
     ->when(
         fn (array $responses) => $responses['path'] === './laravel',
         fn (array $responses) => info('This is a Laravel project!'),

--- a/playground/steps.php
+++ b/playground/steps.php
@@ -1,0 +1,102 @@
+<?php
+
+use function Laravel\Prompts\alert;
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\error;
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\multiselect;
+use function Laravel\Prompts\note;
+use function Laravel\Prompts\outro;
+use function Laravel\Prompts\password;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\spin;
+use function Laravel\Prompts\suggest;
+use function Laravel\Prompts\text;
+use function Laravel\Prompts\warning;
+
+require __DIR__.'/../vendor/autoload.php';
+
+$responses = steps()
+    ->add(fn () => intro('Welcome to Laravel'), revert: false)
+    ->add(fn () => suggest(
+        label: 'What is your name?',
+        placeholder: 'E.g. Taylor Otwell',
+        options: [
+            'Dries Vints',
+            'Guus Leeuw',
+            'James Brooks',
+            'Jess Archer',
+            'Joe Dixon',
+            'Mior Muhammad Zaki Mior Khairuddin',
+            'Nuno Maduro',
+            'Taylor Otwell',
+            'Tim MacDonald',
+        ],
+        validate: fn ($value) => match (true) {
+            ! $value => 'Please enter your name.',
+            default => null,
+        },
+    ))
+    ->add(fn () => text(
+        label: 'Where should we create your project?',
+        placeholder: 'E.g. ./laravel',
+        validate: fn ($value) => match (true) {
+            ! $value => 'Please enter a path',
+            $value[0] !== '.' => 'Please enter a relative path',
+            default => null,
+        },
+    ))
+    ->add(fn () => password(
+        label: 'Provide a password',
+        validate: fn ($value) => match (true) {
+            ! $value => 'Please enter a password.',
+            strlen($value) < 5 => 'Password should have at least 5 characters.',
+            default => null,
+        },
+    ), revert: false)
+    ->add(fn () => select(
+        label: 'Pick a project type',
+        default: 'ts',
+        options: [
+            'ts' => 'TypeScript',
+            'js' => 'JavaScript',
+        ],
+    ))
+    ->add(fn () => multiselect(
+        label: 'Select additional tools.',
+        default: ['pint', 'eslint'],
+        options: [
+            'pint' => 'Pint',
+            'eslint' => 'ESLint',
+            'prettier' => 'Prettier',
+        ],
+        validate: function ($values) {
+            if (count($values) === 0) {
+                return 'Please select at least one tool.';
+            }
+        }
+    ))
+    ->add(function () {
+        $install = confirm(
+            label: 'Install dependencies?',
+        );
+
+        if ($install) {
+            spin(fn () => sleep(3), 'Installing dependencies...');
+        }
+
+        return $install;
+    }, revert: function () {
+        spin(fn () => sleep(3), 'Uninstalling...');
+    })
+    ->add(fn ($responses) => note(<<<EOT
+    Installation complete!
+
+    To get started, run:
+
+        cd {$responses[2]}
+        php artisan serve
+    EOT))
+    ->run();
+
+var_dump($responses);

--- a/src/Exceptions/FormRevertedException.php
+++ b/src/Exceptions/FormRevertedException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Prompts\Exceptions;
+
+use RuntimeException;
+
+class FormRevertedException extends RuntimeException
+{
+    //
+}

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Prompts;
 
-use BadFunctionCallException;
 use Closure;
 use Illuminate\Support\Collection;
 use Laravel\Prompts\Exceptions\FormRevertedException;
@@ -81,7 +80,7 @@ class FormBuilder
      */
     public function text(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\text', get_defined_vars());
+        return $this->runPrompt(text(...), get_defined_vars());
     }
 
     /**
@@ -89,7 +88,7 @@ class FormBuilder
      */
     public function textarea(string $label, string $placeholder = '', string $default = '', bool|string $required = false, ?Closure $validate = null, string $hint = '', int $rows = 5, ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\textarea', get_defined_vars());
+        return $this->runPrompt(textarea(...), get_defined_vars());
     }
 
     /**
@@ -97,7 +96,7 @@ class FormBuilder
      */
     public function password(string $label, string $placeholder = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\password', get_defined_vars());
+        return $this->runPrompt(password(...), get_defined_vars());
     }
 
     /**
@@ -108,7 +107,7 @@ class FormBuilder
      */
     public function select(string $label, array|Collection $options, int|string|null $default = null, int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\select', get_defined_vars());
+        return $this->runPrompt(select(...), get_defined_vars());
     }
 
     /**
@@ -119,7 +118,7 @@ class FormBuilder
      */
     public function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\multiselect', get_defined_vars());
+        return $this->runPrompt(multiselect(...), get_defined_vars());
     }
 
     /**
@@ -127,7 +126,7 @@ class FormBuilder
      */
     public function confirm(string $label, bool $default = true, string $yes = 'Yes', string $no = 'No', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\confirm', get_defined_vars());
+        return $this->runPrompt(confirm(...), get_defined_vars());
     }
 
     /**
@@ -135,7 +134,7 @@ class FormBuilder
      */
     public function pause(string $message = 'Press enter to continue...', ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\pause', get_defined_vars());
+        return $this->runPrompt(pause(...), get_defined_vars());
     }
 
     /**
@@ -145,7 +144,7 @@ class FormBuilder
      */
     public function suggest(string $label, array|Collection|Closure $options, string $placeholder = '', string $default = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\suggest', get_defined_vars());
+        return $this->runPrompt(suggest(...), get_defined_vars());
     }
 
     /**
@@ -156,7 +155,7 @@ class FormBuilder
      */
     public function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\search', get_defined_vars());
+        return $this->runPrompt(search(...), get_defined_vars());
     }
 
     /**
@@ -166,7 +165,7 @@ class FormBuilder
      */
     public function multisearch(string $label, Closure $options, string $placeholder = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\multisearch', get_defined_vars());
+        return $this->runPrompt(multisearch(...), get_defined_vars());
     }
 
     /**
@@ -176,7 +175,7 @@ class FormBuilder
      */
     public function spin(Closure $callback, string $message = '', ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\spin', get_defined_vars(), true);
+        return $this->runPrompt(spin(...), get_defined_vars(), true);
     }
 
     /**
@@ -184,7 +183,7 @@ class FormBuilder
      */
     public function note(string $message, ?string $type = null, ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\note', get_defined_vars(), true);
+        return $this->runPrompt(note(...), get_defined_vars(), true);
     }
 
     /**
@@ -192,7 +191,7 @@ class FormBuilder
      */
     public function error(string $message, ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\error', get_defined_vars(), true);
+        return $this->runPrompt(error(...), get_defined_vars(), true);
     }
 
     /**
@@ -200,7 +199,7 @@ class FormBuilder
      */
     public function warning(string $message, ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\warning', get_defined_vars(), true);
+        return $this->runPrompt(warning(...), get_defined_vars(), true);
     }
 
     /**
@@ -208,7 +207,7 @@ class FormBuilder
      */
     public function alert(string $message, ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\alert', get_defined_vars(), true);
+        return $this->runPrompt(alert(...), get_defined_vars(), true);
     }
 
     /**
@@ -216,7 +215,7 @@ class FormBuilder
      */
     public function info(string $message, ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\info', get_defined_vars(), true);
+        return $this->runPrompt(info(...), get_defined_vars(), true);
     }
 
     /**
@@ -224,7 +223,7 @@ class FormBuilder
      */
     public function intro(string $message, ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\intro', get_defined_vars(), true);
+        return $this->runPrompt(intro(...), get_defined_vars(), true);
     }
 
     /**
@@ -232,7 +231,7 @@ class FormBuilder
      */
     public function outro(string $message, ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\outro', get_defined_vars(), true);
+        return $this->runPrompt(outro(...), get_defined_vars(), true);
     }
 
     /**
@@ -243,7 +242,7 @@ class FormBuilder
      */
     public function table(array|Collection $headers = [], array|Collection|null $rows = null, ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\table', get_defined_vars(), true);
+        return $this->runPrompt(table(...), get_defined_vars(), true);
     }
 
     /**
@@ -257,21 +256,16 @@ class FormBuilder
      */
     public function progress(string $label, iterable|int $steps, ?Closure $callback = null, string $hint = '', ?string $name = null): self
     {
-        return $this->runPrompt('\\Laravel\\Prompts\\progress', get_defined_vars(), true);
+        return $this->runPrompt(progress(...), get_defined_vars(), true);
     }
 
     /**
      * Execute the given prompt passing the given arguments.
      *
-     * @param  callable-string  $prompt
      * @param  array<mixed>  $arguments
      */
-    protected function runPrompt(string $prompt, array $arguments, bool $ignoreWhenReverting = false): self
+    protected function runPrompt(callable $prompt, array $arguments, bool $ignoreWhenReverting = false): self
     {
-        if (! function_exists($prompt)) {
-            throw new BadFunctionCallException("The given prompt {$prompt} does not exist.");
-        }
-
         return $this->add(function (array $responses, mixed $previousResponse) use ($prompt, $arguments) {
             unset($arguments['name']);
 

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace Laravel\Prompts;
+
+use BadFunctionCallException;
+use Closure;
+use Illuminate\Support\Collection;
+
+class FormBuilder
+{
+    /**
+     * Each step that should be executed.
+     *
+     * @var array<int, \Laravel\Prompts\FormStep>
+     */
+    protected array $steps = [];
+
+    /**
+     * The responses provided by each step.
+     *
+     * @var array<mixed>
+     */
+    protected array $responses = [];
+
+    /**
+     * Add a new step.
+     */
+    public function add(Closure $step, ?string $name = null, bool $ignoreWhenReverting = false): self
+    {
+        return $this->when(true, $step, $name, $ignoreWhenReverting);
+    }
+
+    /**
+     * Add a step if the given condition evaluates to true.
+     *
+     * @param  bool|(Closure(array<mixed>): bool)  $condition
+     */
+    public function when(bool|Closure $condition, Closure $step, ?string $name = null, bool $ignoreWhenReverting = false): self
+    {
+        $this->steps[] = new FormStep($step, $condition, $name, $ignoreWhenReverting);
+
+        return $this;
+    }
+
+    /**
+     * Run all of the given steps.
+     *
+     * @return array<mixed>
+     */
+    public function submit(): array
+    {
+        $index = 0;
+        $wasReverted = false;
+
+        while ($index < count($this->steps)) {
+            $step = $this->steps[$index];
+
+            if ($wasReverted && $index > 0 && $step->shouldIgnoreWhenReverting($this->responses)) {
+                $index--;
+
+                continue;
+            }
+
+            $wasReverted = false;
+
+            $index > 0
+                ? Prompt::revertUsing(function () use (&$wasReverted) {
+                    $wasReverted = true;
+                })
+                : Prompt::preventReverting();
+
+            $this->responses[$step->name ?? $index] = $step->run(
+                $this->responses,
+                $this->responses[$step->name ?? $index] ?? null,
+            );
+
+            $wasReverted ? $index-- : $index++;
+        }
+
+        Prompt::preventReverting();
+
+        return $this->responses;
+    }
+
+    /**
+     * Prompt the user for text input.
+     */
+    public function text(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\text', get_defined_vars());
+    }
+
+    /**
+     * Prompt the user for input, hiding the value.
+     */
+    public function password(string $label, string $placeholder = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\password', get_defined_vars());
+    }
+
+    /**
+     * Prompt the user to select an option.
+     *
+     * @param  array<int|string, string>|Collection<int|string, string>  $options
+     * @param  true|string  $required
+     */
+    public function select(string $label, array|Collection $options, int|string|null $default = null, int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\select', get_defined_vars());
+    }
+
+    /**
+     * Prompt the user to select multiple options.
+     *
+     * @param  array<int|string, string>|Collection<int|string, string>  $options
+     * @param  array<int|string>|Collection<int, int|string>  $default
+     */
+    public function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\multiselect', get_defined_vars());
+    }
+
+    /**
+     * Prompt the user to confirm an action.
+     */
+    public function confirm(string $label, bool $default = true, string $yes = 'Yes', string $no = 'No', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\confirm', get_defined_vars());
+    }
+
+    /**
+     * Prompt the user to continue or cancel after pausing.
+     */
+    public function pause(string $message = 'Press enter to continue...', ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\pause', get_defined_vars());
+    }
+
+    /**
+     * Prompt the user for text input with auto-completion.
+     *
+     * @param  array<string>|Collection<int, string>|Closure(string): array<string>  $options
+     */
+    public function suggest(string $label, array|Collection|Closure $options, string $placeholder = '', string $default = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\suggest', get_defined_vars());
+    }
+
+    /**
+     * Allow the user to search for an option.
+     *
+     * @param  Closure(string): array<int|string, string>  $options
+     * @param  true|string  $required
+     */
+    public function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\search', get_defined_vars());
+    }
+
+    /**
+     * Allow the user to search for multiple option.
+     *
+     * @param  Closure(string): array<int|string, string>  $options
+     */
+    public function multisearch(string $label, Closure $options, string $placeholder = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\multisearch', get_defined_vars());
+    }
+
+    /**
+     * Render a spinner while the given callback is executing.
+     *
+     * @param  \Closure(): mixed  $callback
+     */
+    public function spin(Closure $callback, string $message = '', ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\spin', get_defined_vars(), true);
+    }
+
+    /**
+     * Display a note.
+     */
+    public function note(string $message, ?string $type = null, ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\note', get_defined_vars(), true);
+    }
+
+    /**
+     * Display an error.
+     */
+    public function error(string $message, ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\error', get_defined_vars(), true);
+    }
+
+    /**
+     * Display a warning.
+     */
+    public function warning(string $message, ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\warning', get_defined_vars(), true);
+    }
+
+    /**
+     * Display an alert.
+     */
+    public function alert(string $message, ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\alert', get_defined_vars(), true);
+    }
+
+    /**
+     * Display an informational message.
+     */
+    public function info(string $message, ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\info', get_defined_vars(), true);
+    }
+
+    /**
+     * Display an introduction.
+     */
+    public function intro(string $message, ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\intro', get_defined_vars(), true);
+    }
+
+    /**
+     * Display a closing message.
+     */
+    public function outro(string $message, ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\outro', get_defined_vars(), true);
+    }
+
+    /**
+     * Display a table.
+     *
+     * @param  array<int, string|array<int, string>>|Collection<int, string|array<int, string>>  $headers
+     * @param  array<int, array<int, string>>|Collection<int, array<int, string>>  $rows
+     */
+    public function table(array|Collection $headers = [], array|Collection|null $rows = null, ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\table', get_defined_vars(), true);
+    }
+
+    /**
+     * Display a progress bar.
+     *
+     * @template TSteps of iterable<mixed>|int
+     * @template TReturn
+     *
+     * @param  TSteps  $steps
+     * @param  ?Closure((TSteps is int ? int : value-of<TSteps>), Progress<TSteps>): TReturn  $callback
+     */
+    public function progress(string $label, iterable|int $steps, ?Closure $callback = null, string $hint = '', ?string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\progress', get_defined_vars(), true);
+    }
+
+    /**
+     * Execute the given prompt passing the given arguments.
+     *
+     * @param  callable-string  $prompt
+     * @param  array<mixed>  $arguments
+     */
+    protected function runPrompt(string $prompt, array $arguments, bool $ignoreWhenReverting = false): self
+    {
+        if (! function_exists($prompt)) {
+            throw new BadFunctionCallException("The given prompt {$prompt} does not exist.");
+        }
+
+        return $this->add(function (array $responses, mixed $previousResponse) use ($prompt, $arguments) {
+            unset($arguments['name']);
+
+            if (array_key_exists('default', $arguments) && $previousResponse !== null) {
+                $arguments['default'] = $previousResponse;
+            }
+
+            return $prompt(...$arguments);
+        }, name: $arguments['name'], ignoreWhenReverting: $ignoreWhenReverting);
+    }
+}

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -91,6 +91,14 @@ class FormBuilder
     }
 
     /**
+     * Prompt the user for multiline text input.
+     */
+    public function textarea(string $label, string $placeholder = '', string $default = '', bool|string $required = false, ?Closure $validate = null, string $hint = '', int $rows = 5, string $name = null): self
+    {
+        return $this->runPrompt('\\Laravel\\Prompts\\textarea', get_defined_vars());
+    }
+
+    /**
      * Prompt the user for input, hiding the value.
      */
     public function password(string $label, string $placeholder = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null): self

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -27,17 +27,7 @@ class FormBuilder
      */
     public function add(Closure $step, ?string $name = null, bool $ignoreWhenReverting = false): self
     {
-        return $this->when(true, $step, $name, $ignoreWhenReverting);
-    }
-
-    /**
-     * Add a step if the given condition evaluates to true.
-     *
-     * @param  bool|(Closure(array<mixed>): bool)  $condition
-     */
-    public function when(bool|Closure $condition, Closure $step, ?string $name = null, bool $ignoreWhenReverting = false): self
-    {
-        $this->steps[] = new FormStep($step, $condition, $name, $ignoreWhenReverting);
+        $this->steps[] = new FormStep($step, true, $name, $ignoreWhenReverting);
 
         return $this;
     }

--- a/src/FormStep.php
+++ b/src/FormStep.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Laravel\Prompts;
+
+use Closure;
+
+class FormStep
+{
+    protected readonly Closure $condition;
+
+    public function __construct(
+        protected readonly Closure $step,
+        bool|Closure $condition,
+        public readonly ?string $name,
+        protected readonly bool $ignoreWhenReverting,
+    ) {
+        $this->condition = is_bool($condition)
+            ? fn () => $condition
+            : $condition;
+    }
+
+    /**
+     * Execute this step.
+     *
+     * @param  array<mixed>  $responses
+     */
+    public function run(array $responses, mixed $previousResponse): mixed
+    {
+        if (! $this->shouldRun($responses)) {
+            return null;
+        }
+
+        return ($this->step)($responses, $previousResponse);
+    }
+
+    /**
+     * Whether the step should run based on the given condition.
+     *
+     * @param  array<mixed>  $responses
+     */
+    protected function shouldRun(array $responses): bool
+    {
+        return ($this->condition)($responses);
+    }
+
+    /**
+     * Whether this step should be skipped over when a subsequent step is reverted.
+     *
+     * @param  array<mixed>  $responses
+     */
+    public function shouldIgnoreWhenReverting(array $responses): bool
+    {
+        if (! $this->shouldRun($responses)) {
+            return true;
+        }
+
+        return $this->ignoreWhenReverting;
+    }
+}

--- a/src/Key.php
+++ b/src/Key.php
@@ -77,6 +77,11 @@ class Key
     const CTRL_E = "\x05";
 
     /**
+     * Negative affirmation
+     */
+    const CTRL_U = "\x15";
+
+    /**
      * Checks for the constant values for the given match and returns the match
      *
      * @param  array<string|array<string>>  $keys

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -3,6 +3,7 @@
 namespace Laravel\Prompts;
 
 use Closure;
+use Laravel\Prompts\Exceptions\FormRevertedException;
 use Laravel\Prompts\Output\ConsoleOutput;
 use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -133,6 +134,10 @@ abstract class Prompt
                         } else {
                             static::terminal()->exit();
                         }
+                    }
+
+                    if ($key === Key::CTRL_U && self::$revertUsing) {
+                        throw new FormRevertedException();
                     }
 
                     return $this->value();

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -30,6 +30,11 @@ abstract class Prompt
     public string $error = '';
 
     /**
+     * The cancel message displayed when this prompt is cancelled.
+     */
+    public string $cancelMessage = 'Cancelled.';
+
+    /**
      * The previously rendered frame.
      */
     protected string $prevFrame = '';
@@ -290,14 +295,15 @@ abstract class Prompt
         }
 
         if ($key === Key::CTRL_U) {
-            $this->state = 'error';
-            $this->error = 'Reverted.';
-
             if (! self::$revertUsing) {
+                $this->state = 'error';
                 $this->error = 'This cannot be reverted.';
 
                 return true;
             }
+
+            $this->state = 'cancel';
+            $this->cancelMessage = 'Reverted.';
 
             call_user_func(self::$revertUsing);
 

--- a/src/Themes/Default/ConfirmPromptRenderer.php
+++ b/src/Themes/Default/ConfirmPromptRenderer.php
@@ -26,7 +26,7 @@ class ConfirmPromptRenderer extends Renderer
                     $this->renderOptions($prompt),
                     color: 'red'
                 )
-                ->error('Cancelled.'),
+                ->error($prompt->cancelMessage),
 
             'error' => $this
                 ->box(

--- a/src/Themes/Default/MultiSearchPromptRenderer.php
+++ b/src/Themes/Default/MultiSearchPromptRenderer.php
@@ -30,7 +30,7 @@ class MultiSearchPromptRenderer extends Renderer implements Scrolling
                     $this->strikethrough($this->dim($this->truncate($prompt->searchValue() ?: $prompt->placeholder, $maxWidth))),
                     color: 'red',
                 )
-                ->error('Cancelled'),
+                ->error($prompt->cancelMessage),
 
             'error' => $this
                 ->box(

--- a/src/Themes/Default/MultiSelectPromptRenderer.php
+++ b/src/Themes/Default/MultiSelectPromptRenderer.php
@@ -28,7 +28,7 @@ class MultiSelectPromptRenderer extends Renderer implements Scrolling
                     $this->renderOptions($prompt),
                     color: 'red',
                 )
-                ->error('Cancelled.'),
+                ->error($prompt->cancelMessage),
 
             'error' => $this
                 ->box(

--- a/src/Themes/Default/PasswordPromptRenderer.php
+++ b/src/Themes/Default/PasswordPromptRenderer.php
@@ -28,7 +28,7 @@ class PasswordPromptRenderer extends Renderer
                     $this->strikethrough($this->dim($this->truncate($prompt->masked() ?: $prompt->placeholder, $maxWidth))),
                     color: 'red',
                 )
-                ->error('Cancelled.'),
+                ->error($prompt->cancelMessage),
 
             'error' => $this
                 ->box(

--- a/src/Themes/Default/ProgressRenderer.php
+++ b/src/Themes/Default/ProgressRenderer.php
@@ -45,7 +45,7 @@ class ProgressRenderer extends Renderer
                     color: 'red',
                     info: $progress->progress.'/'.$progress->total,
                 )
-                ->error($prompt->cancelMessage),
+                ->error($progress->cancelMessage),
 
             default => $this
                 ->box(

--- a/src/Themes/Default/ProgressRenderer.php
+++ b/src/Themes/Default/ProgressRenderer.php
@@ -45,7 +45,7 @@ class ProgressRenderer extends Renderer
                     color: 'red',
                     info: $progress->progress.'/'.$progress->total,
                 )
-                ->error('Cancelled.'),
+                ->error($prompt->cancelMessage),
 
             default => $this
                 ->box(

--- a/src/Themes/Default/SearchPromptRenderer.php
+++ b/src/Themes/Default/SearchPromptRenderer.php
@@ -30,7 +30,7 @@ class SearchPromptRenderer extends Renderer implements Scrolling
                     $this->strikethrough($this->dim($this->truncate($prompt->searchValue() ?: $prompt->placeholder, $maxWidth))),
                     color: 'red',
                 )
-                ->error('Cancelled'),
+                ->error($prompt->cancelMessage),
 
             'error' => $this
                 ->box(

--- a/src/Themes/Default/SelectPromptRenderer.php
+++ b/src/Themes/Default/SelectPromptRenderer.php
@@ -30,7 +30,7 @@ class SelectPromptRenderer extends Renderer implements Scrolling
                     $this->renderOptions($prompt),
                     color: 'red',
                 )
-                ->error('Cancelled.'),
+                ->error($prompt->cancelMessage),
 
             'error' => $this
                 ->box(

--- a/src/Themes/Default/SuggestPromptRenderer.php
+++ b/src/Themes/Default/SuggestPromptRenderer.php
@@ -30,7 +30,7 @@ class SuggestPromptRenderer extends Renderer implements Scrolling
                     $this->strikethrough($this->dim($this->truncate($prompt->value() ?: $prompt->placeholder, $maxWidth))),
                     color: 'red',
                 )
-                ->error('Cancelled'),
+                ->error($prompt->cancelMessage),
 
             'error' => $this
                 ->box(

--- a/src/Themes/Default/TextPromptRenderer.php
+++ b/src/Themes/Default/TextPromptRenderer.php
@@ -28,7 +28,7 @@ class TextPromptRenderer extends Renderer
                     $this->strikethrough($this->dim($this->truncate($prompt->value() ?: $prompt->placeholder, $maxWidth))),
                     color: 'red',
                 )
-                ->error('Cancelled.'),
+                ->error($prompt->cancelMessage),
 
             'error' => $this
                 ->box(

--- a/src/Themes/Default/TextareaPromptRenderer.php
+++ b/src/Themes/Default/TextareaPromptRenderer.php
@@ -30,7 +30,7 @@ class TextareaPromptRenderer extends Renderer implements Scrolling
                     collect($prompt->lines())->map(fn ($line) => $this->strikethrough($this->dim($line)))->implode(PHP_EOL),
                     color: 'red',
                 )
-                ->error('Cancelled.'),
+                ->error($prompt->cancelMessage),
 
             'error' => $this
                 ->box(

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -192,3 +192,8 @@ function progress(string $label, iterable|int $steps, ?Closure $callback = null,
 
     return $progress;
 }
+
+function form(): FormBuilder
+{
+    return new FormBuilder();
+}

--- a/tests/Feature/FormTest.php
+++ b/tests/Feature/FormTest.php
@@ -1,0 +1,189 @@
+<?php
+
+use Laravel\Prompts\Key;
+use Laravel\Prompts\Prompt;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\form;
+use function Laravel\Prompts\outro;
+
+it('can run multiple steps', function () {
+    Prompt::fake([
+        'L', 'u', 'k', 'e', Key::ENTER,
+        Key::ENTER,
+        Key::ENTER,
+    ]);
+
+    $responses = form()
+        ->text('What is your name?')
+        ->select('What is your language?', ['PHP', 'JS'])
+        ->confirm('Are you sure?')
+        ->submit();
+
+    expect($responses)->toBe([
+        'Luke',
+        'PHP',
+        true,
+    ]);
+});
+
+it('can revert steps', function () {
+    Prompt::fake([
+        'L', 'u', 'k', 'e', Key::ENTER,
+        Key::ENTER,
+        Key::CTRL_U, Key::CTRL_U,
+        ...array_fill(0, 4, Key::BACKSPACE),
+        'J', 'e', 's', 's', Key::ENTER,
+        Key::DOWN, Key::ENTER,
+        Key::ENTER,
+    ]);
+
+    $responses = form()
+        ->text('What is your name?')
+        ->select('What is your language?', ['PHP', 'JS'])
+        ->confirm('Are you sure?')
+        ->submit();
+
+    expect($responses)->toBe([
+        'Jess',
+        'JS',
+        true,
+    ]);
+});
+
+it('passes all available responses to each step', function () {
+    Prompt::fake([
+        'L', 'u', 'k', 'e', Key::ENTER,
+        Key::ENTER,
+        Key::ENTER,
+    ]);
+
+    $responses = form()
+        ->text('What is your name?')
+        ->select('What is your language?', ['PHP', 'JS'])
+        ->add(fn ($responses) => confirm("Are you sure your name is {$responses[0]} and your language is {$responses[1]}?"))
+        ->submit();
+
+    Prompt::assertOutputContains('Are you sure your name is Luke and your language is PHP?');
+});
+
+it('can key a response by a given string', function () {
+    Prompt::fake([
+        'L', 'u', 'k', 'e', Key::ENTER,
+        Key::ENTER,
+        Key::ENTER,
+    ]);
+
+    $responses = form()
+        ->text('What is your name?', name: 'name')
+        ->select('What is your language?', ['PHP', 'JS'], name: 'language')
+        ->add(fn ($responses) => confirm("Are you sure your name is {$responses['name']} and your language is {$responses['language']}?"))
+        ->submit();
+
+    Prompt::assertOutputContains('Are you sure your name is Luke and your language is PHP?');
+});
+
+it('does not allow reverting normal prompts', function () {
+    Prompt::fake([
+        'L', 'u', 'k', 'e', Key::ENTER,
+        Key::ENTER,
+        Key::CTRL_U,
+        Key::ENTER,
+    ]);
+
+    form()
+        ->text('What is your name?')
+        ->select('What is your language?', ['PHP', 'JS'])
+        ->submit();
+
+    $confirm = confirm('Are you sure?');
+
+    Prompt::assertOutputContains('This cannot be reverted.');
+    expect($confirm)->toBeTrue();
+});
+
+it('does not allow reverting the first step', function () {
+    Prompt::fake([Key::CTRL_U, Key::ENTER]);
+
+    $responses = form()->confirm('Are you sure?')->submit();
+
+    expect($responses)->toBe([true]);
+});
+
+it('can conditionally run a step', function () {
+    Prompt::fake([
+        Key::ENTER,
+        Key::DOWN, Key::ENTER,
+    ]);
+
+    form()
+        ->when(true, fn () => confirm('Are you sure?'), name: 'confirm')
+        ->when(
+            fn (array $responses) => $responses['confirm'],
+            fn (array $responses) => outro('This should display')
+        )
+        ->submit();
+
+    form()
+        ->when(false, fn () => outro('This should not display'))
+        ->submit();
+
+    form()
+        ->confirm('Are you sure?', name: 'confirm')
+        ->when(
+            fn (array $responses) => $responses['confirm'],
+            fn () => outro('This should not display')
+        )
+        ->submit();
+
+    Prompt::assertOutputContains('This should display');
+    Prompt::assertOutputDoesntContain('This should not display');
+});
+
+it('skips steps over steps that have no user input when reverting', function () {
+    Prompt::fake([
+        '3', Key::ENTER,
+        Key::CTRL_U,
+        '0', Key::ENTER,
+        Key::ENTER,
+    ]);
+
+    $responses = form()
+        ->text('How old are you?')
+        ->info('This should be skipped')
+        ->alert('This should be skipped')
+        ->confirm('Are you sure?')
+        ->submit();
+
+    expect($responses)->toBe(['30', null, null, true]);
+});
+
+it('will not skip over the first step when reverting', function () {
+    Prompt::fake([
+        Key::CTRL_U,
+        Key::ENTER,
+    ]);
+
+    $responses = form()
+        ->info('This should not be skipped')
+        ->confirm('Are you sure?')
+        ->submit();
+
+    expect($responses)->toBe([null, true]);
+});
+
+it('prefills existing responses when reverting', function () {
+    Prompt::fake([
+        'J', 'e', 's', 's', Key::ENTER,
+        Key::CTRL_U,
+        Key::ENTER,
+        Key::ENTER,
+    ]);
+
+    $responses = form()
+        ->text('What is your name?')
+        ->confirm('Are you sure?')
+        ->submit();
+
+    expect($responses[0])->toBe('Jess');
+});

--- a/tests/Feature/FormTest.php
+++ b/tests/Feature/FormTest.php
@@ -157,3 +157,25 @@ it('prefills existing responses when reverting', function () {
 
     expect($responses[0])->toBe('Jess');
 });
+
+it('stops steps at the moment of reverting', function () {
+    Prompt::fake([
+        '2', '7', Key::ENTER,
+        Key::DOWN,
+        Key::CTRL_U,
+        Key::ENTER,
+        Key::ENTER,
+    ]);
+
+    form()
+        ->text('What is your age?')
+        ->add(function () {
+            $confirmed = confirm('Are you sure?');
+
+            if (! $confirmed) {
+                outro('This should not appear!');
+            }
+        })->submit();
+
+    Prompt::assertOutputDoesntContain('This should not appear!');
+});

--- a/tests/Feature/FormTest.php
+++ b/tests/Feature/FormTest.php
@@ -110,36 +110,6 @@ it('does not allow reverting the first step', function () {
     expect($responses)->toBe([true]);
 });
 
-it('can conditionally run a step', function () {
-    Prompt::fake([
-        Key::ENTER,
-        Key::DOWN, Key::ENTER,
-    ]);
-
-    form()
-        ->when(true, fn () => confirm('Are you sure?'), name: 'confirm')
-        ->when(
-            fn (array $responses) => $responses['confirm'],
-            fn (array $responses) => outro('This should display')
-        )
-        ->submit();
-
-    form()
-        ->when(false, fn () => outro('This should not display'))
-        ->submit();
-
-    form()
-        ->confirm('Are you sure?', name: 'confirm')
-        ->when(
-            fn (array $responses) => $responses['confirm'],
-            fn () => outro('This should not display')
-        )
-        ->submit();
-
-    Prompt::assertOutputContains('This should display');
-    Prompt::assertOutputDoesntContain('This should not display');
-});
-
 it('skips steps over steps that have no user input when reverting', function () {
     Prompt::fake([
         '3', Key::ENTER,


### PR DESCRIPTION
Hey all!

This PR adds support for revertable forms to Prompts. Here's a little demo video,
which you can play with for yourself using `php playground/form.php` on this branch.

https://github.com/laravel/prompts/assets/12202279/b70ae8b3-c2dc-472d-9eb3-9bedc6a02a9d

## Purpose

Often, when navigating through a lenthy series of prompts, I make typos or mistakes 
and need to go back to make edits. Currently, the only way to fix them is to cancel
the command and start again from scratch.

To fix that frustration, you may now declare a series of steps that the user will
be taken through. By using the `CTRL+U` key combo, any step in the process can be
reverted by the user to retry the previous step again.

## Usage

A series of steps can be created using the `form` function, 
followed by the relevant prompt method for each desired step, like so:

```php
$responses = form()
    ->text('What is your name?')
    ->select('What is your favourite language?', ['PHP', 'JS'])
    ->submit();
```

Calling `submit` executes the steps in the terminal. In this case, once the user reaches
the "What is your favourite language?" prompt, they can hit `CTRL+U` (alternatively `CMD+BACKSPACE` on Mac)
to go back to "What is your name?" and fill it out again.

All prompts that support the `$default` parameter will autofill with the previously entered value when reverting to them, making it easy to fix little typos without having to type everything out again.

### Utilising previous responses

The `submit` method will return all responses at the end of the run. However, you may
need access to previous step responses inside of a later step. Each step is passed 
an array of all previous responses:

```php
$responses = form()
    ->text('What is your name?')
    ->select('What is your favourite language?', ['PHP', 'JS'])
    ->add(fn ($responses) => note("Your name is {$responses[0]} and your language is {$responses[1]}"))
    ->submit();
```

Often, finding the response by index is not a nice experience and can be too brittle. To remedy this, you can provide a `name` for each step, which will be used as the index in the response array:

```php
$responses = form()
    ->text('What is your name?', name: 'name')
    ->add(fn () => select('What is your favourite language?', ['PHP', 'JS']), name: 'language')
    ->add(fn ($responses) => note("Your name is {$responses['name']} and your language is {$responses['language']}"))
    ->submit();
```

## Wrap-up

All in all, I really think this will make life easier and less frustrating for complex prompt sequences. I'm
excited to hear your thoughts!

Thank you for all the hard work maintaining and working on Prompts; it's very much appreciated.

Regards,
Luke