### PR TITLE
[Feature] Automatic validation option upon toggling multi-select prompts

### DIFF
--- a/src/MultiSelectPrompt.php
+++ b/src/MultiSelectPrompt.php
@@ -42,6 +42,7 @@ class MultiSelectPrompt extends Prompt
         public int $scroll = 5,
         public bool|string $required = false,
         public mixed $validate = null,
+        public bool $validateOnToggle = false, 
         public string $hint = '',
     ) {
         $this->options = $options instanceof Collection ? $options->all() : $options;
@@ -128,6 +129,10 @@ class MultiSelectPrompt extends Prompt
             $this->values = array_filter($this->values, fn ($v) => $v !== $value);
         } else {
             $this->values[] = $value;
+        }
+
+        if ($this->validateOnToggle) {
+            $this->validated = true;
         }
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -39,7 +39,7 @@ function select(string $label, array|Collection $options, int|string|null $defau
  * @param  array<int|string>|Collection<int, int|string>  $default
  * @return array<int|string>
  */
-function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.'): array
+function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, mixed $validate = null, bool $validateOnToggle = false, string $hint = 'Use the space bar to select options.'): array
 {
     return (new MultiSelectPrompt(...func_get_args()))->prompt();
 }

--- a/tests/Feature/MultiSelectPromptTest.php
+++ b/tests/Feature/MultiSelectPromptTest.php
@@ -122,6 +122,25 @@ it('validates', function () {
     Prompt::assertOutputContains('You must select at least one color.');
 });
 
+it('can validate automatically upon toggling options', function () {
+    Prompt::fake([Key::DOWN, Key::SPACE, Key::SPACE, Key::UP, Key::SPACE, Key::ENTER]);
+
+    $result = multiselect(
+        label: 'What was the reason for the guard\'s retirement?',
+        options: [
+            'arrow' => 'He took an arrow in the knee',
+            'swordless' => 'He lost his sword',
+            'dragone' => 'He defeated all dragons',
+        ],
+        validate: fn ($values) => in_array('arrow', $values) ? null : 'Missing a joke!',
+        validateOnToggle: true,
+    );
+
+    expect($result)->toBe(['arrow']);
+
+    Prompt::assertOutputContains('Missing a joke!');
+});
+
 it('can fall back', function () {
     Prompt::fallbackWhen(true);
 


### PR DESCRIPTION
- Added an argument and a property "validateOnToggle" to MultiSelectPrompt that defaults to false
    - If set to true, `validated` property gets set to true upon `toggleHighlight`; which triggers validation
- Wrote a test for it
    - Ensured everything passes

I found this to be cool when it's accompanied with the next PR, which is about introducing re-evaluated and cached options closure; resulting in a reactive experience... Basically, it's what I was a bit confused about in #116 .

If you like it, should I do the docs?
