### PR TITLE
[Enhancement] Reactive options as closure for multi-select prompt

### DIFF
--- a/src/Themes/Default/MultiSelectPromptRenderer.php
+++ b/src/Themes/Default/MultiSelectPromptRenderer.php
@@ -15,6 +15,10 @@ class MultiSelectPromptRenderer extends Renderer implements Scrolling
      */
     public function __invoke(MultiSelectPrompt $prompt): string
     {
+        if ($prompt->state === 'toggle' || $prompt->state === 'error') {
+            $prompt->evaluatedOptions = null;
+        }
+
         return match ($prompt->state) {
             'submit' => $this
                 ->box(
@@ -35,7 +39,7 @@ class MultiSelectPromptRenderer extends Renderer implements Scrolling
                     $this->truncate($prompt->label, $prompt->terminal()->cols() - 6),
                     $this->renderOptions($prompt),
                     color: 'yellow',
-                    info: count($prompt->options) > $prompt->scroll ? (count($prompt->value()).' selected') : '',
+                    info: count($prompt->options()) > $prompt->scroll ? (count($prompt->value()).' selected') : '',
                 )
                 ->warning($this->truncate($prompt->error, $prompt->terminal()->cols() - 5)),
 
@@ -43,7 +47,7 @@ class MultiSelectPromptRenderer extends Renderer implements Scrolling
                 ->box(
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $this->renderOptions($prompt),
-                    info: count($prompt->options) > $prompt->scroll ? (count($prompt->value()).' selected') : '',
+                    info: count($prompt->options()) > $prompt->scroll ? (count($prompt->value()).' selected') : '',
                 )
                 ->when(
                     $prompt->hint,
@@ -62,12 +66,12 @@ class MultiSelectPromptRenderer extends Renderer implements Scrolling
             collect($prompt->visible())
                 ->map(fn ($label) => $this->truncate($label, $prompt->terminal()->cols() - 12))
                 ->map(function ($label, $key) use ($prompt) {
-                    $index = array_search($key, array_keys($prompt->options));
+                    $index = array_search($key, array_keys($prompt->options()));
                     $active = $index === $prompt->highlighted;
-                    if (array_is_list($prompt->options)) {
-                        $value = $prompt->options[$index];
+                    if (array_is_list($prompt->options())) {
+                        $value = $prompt->options()[$index];
                     } else {
-                        $value = array_keys($prompt->options)[$index];
+                        $value = array_keys($prompt->options())[$index];
                     }
                     $selected = in_array($value, $prompt->value());
 
@@ -90,8 +94,8 @@ class MultiSelectPromptRenderer extends Renderer implements Scrolling
                 ->values(),
             $prompt->firstVisible,
             $prompt->scroll,
-            count($prompt->options),
-            min($this->longest($prompt->options, padding: 6), $prompt->terminal()->cols() - 6),
+            count($prompt->options()),
+            min($this->longest($prompt->options(), padding: 6), $prompt->terminal()->cols() - 6),
             $prompt->state === 'cancel' ? 'dim' : 'cyan'
         )->implode(PHP_EOL);
     }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -35,11 +35,11 @@ function select(string $label, array|Collection $options, int|string|null $defau
 /**
  * Prompt the user to select multiple options.
  *
- * @param  array<int|string, string>|Collection<int|string, string>  $options
+ * @param  array<int|string, string>|Collection<int|string, string>|Closure(array<int|string, string>): array<int|string, string>|Collection<int|string, string>  $options
  * @param  array<int|string>|Collection<int, int|string>  $default
  * @return array<int|string>
  */
-function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.'): array
+function multiselect(string $label, array|Collection|Closure $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.'): array
 {
     return (new MultiSelectPrompt(...func_get_args()))->prompt();
 }

--- a/tests/Feature/MultiSelectPromptTest.php
+++ b/tests/Feature/MultiSelectPromptTest.php
@@ -104,6 +104,44 @@ it('accepts collections', function () {
     expect($result)->toBe(['Green']);
 });
 
+it('accepts closures', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = multiselect(
+        label: 'What are your favorite colors?',
+        options: fn () => collect([
+            'Red',
+            'Green',
+            'Blue',
+        ]),
+        default: collect(['Green'])
+    );
+
+    expect($result)->toBe(['Green']);
+});
+
+it('can reactively change options', function () {
+    Prompt::fake([Key::DOWN, Key::SPACE, Key::DOWN, Key::SPACE, Key::UP, Key::SPACE, Key::SPACE, Key::ENTER]);
+
+    $result = multiselect(
+        label: "Pick up items (2 items slots available):",
+        options: fn($values) => collect([
+            'food' => 'Some food',
+            'map' => 'A map',
+            'jacket' => 'A life jacket',
+        ])->when(count($values) >= 2, fn ($collection) =>  $collection->only($values)),
+    );
+
+    expect($result)->toBe(['jacket', 'food']);
+});
+
+it('throws when options are empty', function () {
+    multiselect(
+        label: 'Hey, man! About the ahh... -just hold on... (keyboard typing)',
+        options: fn() => [],
+    );
+})->throws(NonInteractiveValidationException::class, 'All options are no longer available!');
+
 it('validates', function () {
     Prompt::fake([Key::ENTER, Key::SPACE, Key::ENTER]);
 


### PR DESCRIPTION
- Accepted options argument as closure
  - Turned options property to mixed type as it might hold the closure
  - Passed values property to the closure for reactivity; just like validate method
- Added an evaluatedOptions property for caching until it's set to null
  - Created options method that evaluates, caches and returns the options all around
  - Threw an exception when all options are no longer available
  - Removed previously selected options from values when they're gone
  - Adjusted the indexing
- Introduced a new "toggle" state to re-render without errors
  - Set the evaluatedOptions to null (resetting cache and evaluation) for toggle and error states
- Tested for closure, reactivity, and the empty options exception
  - Ensured all tests are passing
  
Again, I needed this use-case (#116).
  
A short demo: https://github.com/laravel/prompts/assets/121377476/bfce061c-30e3-4456-93c5-84d1ec68e77a