### PR TITLE
[0.x] Fix box spacing with Symfony named style tags

### DIFF
--- a/src/Themes/Default/Concerns/DrawsBoxes.php
+++ b/src/Themes/Default/Concerns/DrawsBoxes.php
@@ -86,8 +86,13 @@ trait DrawsBoxes
      */
     protected function stripEscapeSequences(string $text): string
     {
+        // Strip ANSI escape sequences.
         $text = preg_replace("/\e[^m]*m/", '', $text);
 
+        // Strip Symfony named style tags.
+        $text = preg_replace("/<(info|comment|question|error)>(.*?)<\/\\1>/", '$2', $text);
+
+        // Strip Symfony inline style tags.
         return preg_replace("/<(?:(?:[fb]g|options)=[a-z,;]+)+>(.*?)<\/>/i", '$1', $text);
     }
 }


### PR DESCRIPTION
This PR fixes a box spacing issue when using Symfony named style tags (E.g. `<comment>...</comment>`). Previously we only supported the `fg`, `bg`, and `options` tags.

Note that the tags are only stripped prior to calculating the width for the purposes of adding spaces to have the border line up. The formatting is preserved in the actual output.

![image](https://github.com/laravel/prompts/assets/4977161/1295fc18-f30a-4615-82aa-5d473017e875)

Reference: https://symfony.com/doc/current/console/coloring.html

Fixes #124