### PR TITLE
Remove terminal height requirement

### DIFF
--- a/src/Concerns/Cursor.php
+++ b/src/Concerns/Cursor.php
@@ -60,4 +60,20 @@ trait Cursor
 
         static::writeDirectly($sequence);
     }
+
+    /**
+     * Move the cursor to the given column.
+     */
+    public function moveCursorToColumn(int $column): void
+    {
+        static::writeDirectly("\e[{$column}G");
+    }
+
+    /**
+     * Move the cursor up by the given number of lines.
+     */
+    public function moveCursorUp(int $lines): void
+    {
+        static::writeDirectly("\e[{$lines}A");
+    }
 }

--- a/src/Concerns/FakesInputOutput.php
+++ b/src/Concerns/FakesInputOutput.php
@@ -27,6 +27,7 @@ trait FakesInputOutput
         $mock->shouldReceive('restoreTty')->byDefault();
         $mock->shouldReceive('cols')->byDefault()->andReturn(80);
         $mock->shouldReceive('lines')->byDefault()->andReturn(24);
+        $mock->shouldReceive('initDimensions')->byDefault();
 
         foreach ($keys as $key) {
             $mock->shouldReceive('read')->once()->andReturn($key);

--- a/src/Concerns/Scrolling.php
+++ b/src/Concerns/Scrolling.php
@@ -38,7 +38,7 @@ trait Scrolling
     {
         $reservedLines = ($renderer = $this->getRenderer()) instanceof ScrollingRenderer ? $renderer->reservedLines() : 0;
 
-        $this->scroll = min($this->scroll, $this->terminal()->lines() - $reservedLines);
+        $this->scroll = max(1, min($this->scroll, $this->terminal()->lines() - $reservedLines));
     }
 
     /**

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -208,6 +208,8 @@ abstract class Prompt
      */
     protected function render(): void
     {
+        $this->terminal()->initDimensions();
+
         $frame = $this->renderTheme();
 
         if ($frame === $this->prevFrame) {
@@ -223,35 +225,14 @@ abstract class Prompt
             return;
         }
 
-        $this->resetCursorPosition();
+        $terminalHeight = $this->terminal()->lines();
+        $previousFrameHeight = count(explode(PHP_EOL, $this->prevFrame));
+        $renderableLines = array_slice(explode(PHP_EOL, $frame), abs(min(0, $terminalHeight - $previousFrameHeight)));
 
-        // Ensure that the full frame is buffered so subsequent output can see how many trailing newlines were written.
-        if ($this->state === 'submit') {
-            $this->eraseDown();
-            static::output()->write($frame);
-
-            $this->prevFrame = '';
-
-            return;
-        }
-
-        $diff = $this->diffLines($this->prevFrame, $frame);
-
-        if (count($diff) === 1) { // Update the single line that changed.
-            $diffLine = $diff[0];
-            $this->moveCursor(0, $diffLine);
-            $this->eraseLines(1);
-            $lines = explode(PHP_EOL, $frame);
-            static::output()->write($lines[$diffLine]);
-            $this->moveCursor(0, count($lines) - $diffLine - 1);
-        } elseif (count($diff) > 1) { // Re-render everything past the first change
-            $diffLine = $diff[0];
-            $this->moveCursor(0, $diffLine);
-            $this->eraseDown();
-            $lines = explode(PHP_EOL, $frame);
-            $newLines = array_slice($lines, $diffLine);
-            static::output()->write(implode(PHP_EOL, $newLines));
-        }
+        $this->moveCursorToColumn(1);
+        $this->moveCursorUp(min($terminalHeight, $previousFrameHeight) - 1);
+        $this->eraseDown();
+        $this->output()->write(implode(PHP_EOL, $renderableLines));
 
         $this->prevFrame = $frame;
     }
@@ -266,40 +247,6 @@ abstract class Prompt
         if ($this->state !== 'error') {
             $this->state = 'submit';
         }
-    }
-
-    /**
-     * Reset the cursor position to the beginning of the previous frame.
-     */
-    private function resetCursorPosition(): void
-    {
-        $lines = count(explode(PHP_EOL, $this->prevFrame)) - 1;
-
-        $this->moveCursor(-999, $lines * -1);
-    }
-
-    /**
-     * Get the difference between two strings.
-     *
-     * @return array<int>
-     */
-    private function diffLines(string $a, string $b): array
-    {
-        if ($a === $b) {
-            return [];
-        }
-
-        $aLines = explode(PHP_EOL, $a);
-        $bLines = explode(PHP_EOL, $b);
-        $diff = [];
-
-        for ($i = 0; $i < max(count($aLines), count($bLines)); $i++) {
-            if (! isset($aLines[$i]) || ! isset($bLines[$i]) || $aLines[$i] !== $bLines[$i]) {
-                $diff[] = $i;
-            }
-        }
-
-        return $diff;
     }
 
     /**

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Prompts;
 
+use ReflectionClass;
 use RuntimeException;
 use Symfony\Component\Console\Terminal as SymfonyTerminal;
 
@@ -13,14 +14,17 @@ class Terminal
     protected ?string $initialTtyMode;
 
     /**
-     * The number of columns in the terminal.
+     * The Symfony Terminal instance.
      */
-    protected int $cols;
+    protected SymfonyTerminal $terminal;
 
     /**
-     * The number of lines in the terminal.
+     * Create a new Terminal instance.
      */
-    protected int $lines;
+    public function __construct()
+    {
+        $this->terminal = new SymfonyTerminal();
+    }
 
     /**
      * Read a line from the terminal.
@@ -59,7 +63,7 @@ class Terminal
      */
     public function cols(): int
     {
-        return $this->cols ??= (new SymfonyTerminal())->getWidth();
+        return $this->terminal->getWidth();
     }
 
     /**
@@ -67,7 +71,17 @@ class Terminal
      */
     public function lines(): int
     {
-        return $this->lines ??= (new SymfonyTerminal())->getHeight();
+        return $this->terminal->getHeight();
+    }
+
+    /**
+     * (Re)initialize the terminal dimensions.
+     */
+    public function initDimensions(): void
+    {
+        (new ReflectionClass($this->terminal))
+            ->getMethod('initDimensions')
+            ->invoke($this->terminal);
     }
 
     /**

--- a/src/Themes/Default/Renderer.php
+++ b/src/Themes/Default/Renderer.php
@@ -5,7 +5,6 @@ namespace Laravel\Prompts\Themes\Default;
 use Laravel\Prompts\Concerns\Colors;
 use Laravel\Prompts\Concerns\Truncation;
 use Laravel\Prompts\Prompt;
-use RuntimeException;
 
 abstract class Renderer
 {
@@ -22,7 +21,7 @@ abstract class Renderer
      */
     public function __construct(protected Prompt $prompt)
     {
-        $this->checkTerminalSize($prompt);
+        //
     }
 
     /**
@@ -99,20 +98,5 @@ abstract class Renderer
         return str_repeat(PHP_EOL, max(2 - $this->prompt->newLinesWritten(), 0))
             .$this->output
             .(in_array($this->prompt->state, ['submit', 'cancel']) ? PHP_EOL : '');
-    }
-
-    /**
-     * Check that the terminal is large enough to render the prompt.
-     */
-    private function checkTerminalSize(Prompt $prompt): void
-    {
-        $required = 8;
-        $actual = $prompt->terminal()->lines();
-
-        if ($actual < $required) {
-            throw new RuntimeException(
-                "The terminal height must be at least [$required] lines but is currently [$actual]. Please increase the height or reduce the font size."
-            );
-        }
     }
 }


### PR DESCRIPTION
This PR removes the exception that is thrown when the terminal is not at least eight lines tall.

This was previously required because rendering would get out of sync if the previous frame fell partially outside of the visible terminal area. Prompts assumed that the cursor was moved to the top of the previous frame, when in reality, this may not have been possible if the terminal height was shorter than the previous frame, causing an offset between frames.

With this PR, Prompts will determine how much of the previous frame is visible and only re-render that portion. The only consequence of this is if the prompt does not fit within the terminal, and the user scrolls back or increases their terminal height, the previously hidden lines of the prompt will show the state of a previous render. The first line of a prompt is always blank (for spacing) and won't be noticeable, so we can immediately handle seven-line tall terminals without any issue. Beyond that, the differences between frames may become more noticeable; for example, the border colour on the label line may not change on a validation error if it is outside the visible area. However, if the label is outside the visible area, the user may naturally want to increase the terminal height after the initial render, and all subsequent renders will re-render the entire prompt correctly. The worst-case scenario is that the user doesn't increase their terminal height and may see some weirdness if they scroll back later, but this seems preferable to just throwing an exception.

Note that re-rendering lines that have left the visible area is not possible (as far as I'm aware).

There is also a weird issue when using tmux when the pane is not tall enough to render the prompt. Each new frame will be rendered to the scrollback history in addition to the visible area. The only workaround I could find was to move the cursor to the second column, which seems to avoid the behaviour, but then additional logic would be required to not render the first character on the first line to keep things aligned. Any prompts that change characters in that left-most column on subsequent renders would suffer (although none currently do, as the left-most column is always blank for spacing). In any case, the new behaviour seems preferable to an exception, and we can always implement the workaround later if needed.

Another improvement we can investigate later is to not render the blank line below the prompt if the terminal height is too short, giving us an additional line before issues could occur. On the final render (submit or cancel) we can output the blank line so that the spacing between the next prompt remains unchanged.

Closes #127