### PR TITLE
Fix `multisearch` array handling

### DIFF
--- a/src/Themes/Default/MultiSearchPromptRenderer.php
+++ b/src/Themes/Default/MultiSearchPromptRenderer.php
@@ -115,7 +115,7 @@ class MultiSearchPromptRenderer extends Renderer implements Scrolling
                 ->map(function ($label, $key) use ($prompt) {
                     $index = array_search($key, array_keys($prompt->matches()));
                     $active = $index === $prompt->highlighted;
-                    $selected = array_is_list($prompt->visible())
+                    $selected = $prompt->isList()
                         ? in_array($label, $prompt->value())
                         : in_array($key, $prompt->value());
 
@@ -156,7 +156,7 @@ class MultiSearchPromptRenderer extends Renderer implements Scrolling
         $info = count($prompt->value()).' selected';
 
         $hiddenCount = count($prompt->value()) - collect($prompt->matches())
-            ->filter(fn ($label, $key) => in_array(array_is_list($prompt->matches()) ? $label : $key, $prompt->value()))
+            ->filter(fn ($label, $key) => in_array($prompt->isList() ? $label : $key, $prompt->value()))
             ->count();
 
         if ($hiddenCount > 0) {

--- a/tests/Feature/MultiSearchPromptTest.php
+++ b/tests/Feature/MultiSearchPromptTest.php
@@ -8,12 +8,13 @@ use function Laravel\Prompts\multisearch;
 
 it('supports default results', function ($options, $expected) {
     Prompt::fake([
-        Key::DOWN, // Highlight "Red"
+        Key::UP, // Highlight "Violet"
+        Key::SPACE, // Select "Violet"
+        'G', // Search for "Green"
+        'r', // Search for "Green"
         Key::DOWN, // Highlight "Green"
         Key::SPACE, // Select "Green"
-        'B', // Search for "Blue"
-        Key::DOWN, // Highlight "Blue"
-        Key::SPACE, // Select "Blue"
+        Key::BACKSPACE, // Clear search
         Key::BACKSPACE, // Clear search
         Key::ENTER, // Confirm selection
     ]);
@@ -28,25 +29,78 @@ it('supports default results', function ($options, $expected) {
          ┌ What are your favorite colors? ──────────────────────────────┐
          │ Search...                                                    │
          ├──────────────────────────────────────────────────────────────┤
-         │   ◻ Red                                                      │
-         │   ◻ Green                                                    │
-         │   ◻ Blue                                                     │
+         │   ◻ Red                                                    ┃ │
+         │   ◻ Orange                                                 │ │
+         │   ◻ Yellow                                                 │ │
+         │   ◻ Green                                                  │ │
+         │   ◻ Blue                                                   │ │
          └────────────────────────────────────────────────── 0 selected ┘
         OUTPUT);
 
     Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌ What are your favorite colors? ──────────────────────────────┐
          │ Search...                                                    │
          ├──────────────────────────────────────────────────────────────┤
-         │   ◻ Red                                                      │
-         │   ◼ Green                                                    │
-         │   ◼ Blue                                                     │
+         │   ◻ Yellow                                                 │ │
+         │   ◻ Green                                                  │ │
+         │   ◻ Blue                                                   │ │
+         │   ◻ Indigo                                                 │ │
+         │ › ◻ Violet                                                 ┃ │
+         └────────────────────────────────────────────────── 0 selected ┘
+        OUTPUT);
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌ What are your favorite colors? ──────────────────────────────┐
+         │ Search...                                                    │
+         ├──────────────────────────────────────────────────────────────┤
+         │   ◻ Yellow                                                 │ │
+         │   ◻ Green                                                  │ │
+         │   ◻ Blue                                                   │ │
+         │   ◻ Indigo                                                 │ │
+         │ › ◼ Violet                                                 ┃ │
+         └────────────────────────────────────────────────── 1 selected ┘
+        OUTPUT);
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌ What are your favorite colors? ──────────────────────────────┐
+         │ Gr                                                           │
+         ├──────────────────────────────────────────────────────────────┤
+         │   ◻ Green                                                    │
+         └─────────────────────────────────────── 1 selected (1 hidden) ┘
+        OUTPUT);
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌ What are your favorite colors? ──────────────────────────────┐
+         │ Gr                                                           │
+         ├──────────────────────────────────────────────────────────────┤
+         │ › ◻ Green                                                    │
+         └─────────────────────────────────────── 1 selected (1 hidden) ┘
+        OUTPUT);
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌ What are your favorite colors? ──────────────────────────────┐
+         │ Gr                                                           │
+         ├──────────────────────────────────────────────────────────────┤
+         │ › ◼ Green                                                    │
+         └─────────────────────────────────────── 2 selected (1 hidden) ┘
+        OUTPUT);
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌ What are your favorite colors? ──────────────────────────────┐
+         │ Search...                                                    │
+         ├──────────────────────────────────────────────────────────────┤
+         │   ◻ Red                                                    ┃ │
+         │   ◻ Orange                                                 │ │
+         │   ◻ Yellow                                                 │ │
+         │   ◼ Green                                                  │ │
+         │   ◻ Blue                                                   │ │
          └────────────────────────────────────────────────── 2 selected ┘
         OUTPUT);
 
     Prompt::assertStrippedOutputContains(<<<'OUTPUT'
          ┌ What are your favorite colors? ──────────────────────────────┐
+         │ Violet                                                       │
          │ Green                                                        │
-         │ Blue                                                         │
          └──────────────────────────────────────────────────────────────┘
         OUTPUT);
 
@@ -55,32 +109,38 @@ it('supports default results', function ($options, $expected) {
     'associative' => [
         fn ($value) => collect([
             'red' => 'Red',
+            'orange' => 'Orange',
+            'yellow' => 'Yellow',
             'green' => 'Green',
             'blue' => 'Blue',
+            'indigo' => 'Indigo',
+            'violet' => 'Violet',
         ])->when(
             strlen($value),
             fn ($colors) => $colors->filter(fn ($label) => str_contains(strtolower($label), strtolower($value)))
         )->all(),
-        ['green', 'blue'],
+        ['violet', 'green'],
     ],
     'list' => [
-        fn ($value) => collect(['Red', 'Green', 'Blue'])->when(
+        fn ($value) => collect(['Red', 'Orange', 'Yellow', 'Green', 'Blue', 'Indigo', 'Violet'])->when(
             strlen($value),
             fn ($colors) => $colors->filter(fn ($label) => str_contains(strtolower($label), strtolower($value)))
         )->values()->all(),
-        ['Green', 'Blue'],
+        ['Violet', 'Green'],
     ],
 ]);
 
 it('supports no default results', function ($options, $expected) {
     Prompt::fake([
-        'B', // Search for "Blue"
-        Key::DOWN, // Highlight "Blue"
-        Key::SPACE, // Select "Blue"
+        'V', // Search for "Violet"
+        Key::UP, // Highlight "Violet"
+        Key::SPACE, // Select "Violet"
         Key::BACKSPACE, // Clear search
         'G', // Search for "Green"
+        'r', // Search for "Green"
         Key::DOWN, // Highlight "Green"
         Key::SPACE, // Select "Green"
+        Key::BACKSPACE, // Clear search
         Key::BACKSPACE, // Clear search
         Key::ENTER, // Confirm selection
     ]);
@@ -98,16 +158,73 @@ it('supports no default results', function ($options, $expected) {
         OUTPUT);
 
     Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌ What are your favorite colors? ──────────────────────────────┐
+         │ V                                                            │
+         ├──────────────────────────────────────────────────────────────┤
+         │   ◻ Violet                                                   │
+         └────────────────────────────────────────────────── 0 selected ┘
+        OUTPUT);
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌ What are your favorite colors? ──────────────────────────────┐
+         │ V                                                            │
+         ├──────────────────────────────────────────────────────────────┤
+         │ › ◻ Violet                                                   │
+         └────────────────────────────────────────────────── 0 selected ┘
+        OUTPUT);
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌ What are your favorite colors? ──────────────────────────────┐
+         │ V                                                            │
+         ├──────────────────────────────────────────────────────────────┤
+         │ › ◼ Violet                                                   │
+         └────────────────────────────────────────────────── 1 selected ┘
+        OUTPUT);
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌ What are your favorite colors? ──────────────────────────────┐
          │ Search...                                                    │
          ├──────────────────────────────────────────────────────────────┤
-         │   ◼ Blue                                                     │
+         │   ◼ Violet                                                   │
+         └────────────────────────────────────────────────── 1 selected ┘
+        OUTPUT);
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌ What are your favorite colors? ──────────────────────────────┐
+         │ Gr                                                           │
+         ├──────────────────────────────────────────────────────────────┤
+         │   ◻ Green                                                    │
+         └─────────────────────────────────────── 1 selected (1 hidden) ┘
+        OUTPUT);
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌ What are your favorite colors? ──────────────────────────────┐
+         │ Gr                                                           │
+         ├──────────────────────────────────────────────────────────────┤
+         │ › ◻ Green                                                    │
+         └─────────────────────────────────────── 1 selected (1 hidden) ┘
+        OUTPUT);
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌ What are your favorite colors? ──────────────────────────────┐
+         │ Gr                                                           │
+         ├──────────────────────────────────────────────────────────────┤
+         │ › ◼ Green                                                    │
+         └─────────────────────────────────────── 2 selected (1 hidden) ┘
+        OUTPUT);
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌ What are your favorite colors? ──────────────────────────────┐
+         │ Search...                                                    │
+         ├──────────────────────────────────────────────────────────────┤
+         │   ◼ Violet                                                   │
          │   ◼ Green                                                    │
          └────────────────────────────────────────────────── 2 selected ┘
         OUTPUT);
 
     Prompt::assertStrippedOutputContains(<<<'OUTPUT'
          ┌ What are your favorite colors? ──────────────────────────────┐
-         │ Blue                                                         │
+         │ Violet                                                       │
          │ Green                                                        │
          └──────────────────────────────────────────────────────────────┘
         OUTPUT);
@@ -117,17 +234,21 @@ it('supports no default results', function ($options, $expected) {
     'associative' => [
         fn ($value) => strlen($value) > 0 ? collect([
             'red' => 'Red',
+            'orange' => 'Orange',
+            'yellow' => 'Yellow',
             'green' => 'Green',
             'blue' => 'Blue',
+            'indigo' => 'Indigo',
+            'violet' => 'Violet',
         ])->filter(fn ($label) => str_contains(strtolower($label), strtolower($value)))->all() : [],
-        ['blue', 'green'],
+        ['violet', 'green'],
     ],
     'list' => [
-        fn ($value) => strlen($value) > 0 ? collect(['Red', 'Green', 'Blue'])
+        fn ($value) => strlen($value) > 0 ? collect(['Red', 'Orange', 'Yellow', 'Green', 'Blue', 'Indigo', 'Violet'])
             ->filter(fn ($label) => str_contains(strtolower($label), strtolower($value)))
             ->values()
             ->all() : [],
-        ['Blue', 'Green'],
+        ['Violet', 'Green'],
     ],
 ]);
 


### PR DESCRIPTION
While reviewing the issue raised in #130, I found some additional related issues with how the matches are determined after the user has selected something and then cleared the search field.

There were two main issues:

1. Array destructuring doesn't preserve numeric keys even if they are strings and/or non-sequential, causing issues in some scenarios with search results that use numeric ID keys where the keys should be returned instead of the values. In this scenario, the `+` operator is preferable, but it's not safe to use with lists.
2. `array_is_list` will return true on an empty array, so it's not safe to determine whether the selected values came from a list when the current `$matches` is empty. My solution is to capture whether `$matches` is a list the first time it is populated and use that for all future decisions.

This PR fixes these issues and also fixes the issue raised in #130 in a way that addresses the concerns I raised at https://github.com/laravel/prompts/pull/130#discussion_r1561870500.

Thanks to @macocci7 for finding the original issue and helping to solve it!