### PR TITLE
Fix type error in suggest with collection

### DIFF
--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -91,7 +91,8 @@ class SuggestPrompt extends Prompt
         }
 
         if ($this->options instanceof Closure) {
-            return $this->matches = array_values(($this->options)($this->value()));
+            $matches = ($this->options)($this->value());
+            return $this->matches = array_values($matches instanceof Collection ? $matches->toArray() : $matches);
         }
 
         return $this->matches = array_values(array_filter($this->options, function ($option) {

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -14,7 +14,7 @@ class SuggestPrompt extends Prompt
     /**
      * The options for the suggest prompt.
      *
-     * @var array<string>|Closure(string): array<string>
+     * @var array<string>|Closure(string): (array<string>|Collection<int, string>)
      */
     public array|Closure $options;
 
@@ -28,7 +28,7 @@ class SuggestPrompt extends Prompt
     /**
      * Create a new SuggestPrompt instance.
      *
-     * @param  array<string>|Collection<int, string>|Closure(string): array<string>  $options
+     * @param  array<string>|Collection<int, string>|Closure(string): (array<string>|Collection<int, string>)  $options
      */
     public function __construct(
         public string $label,
@@ -92,7 +92,7 @@ class SuggestPrompt extends Prompt
 
         if ($this->options instanceof Closure) {
             $matches = ($this->options)($this->value());
-            // @phpstan-ignore-next-line
+
             return $this->matches = array_values($matches instanceof Collection ? $matches->toArray() : $matches);
         }
 

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -93,7 +93,7 @@ class SuggestPrompt extends Prompt
         if ($this->options instanceof Closure) {
             $matches = ($this->options)($this->value());
 
-            return $this->matches = array_values($matches instanceof Collection ? $matches->toArray() : $matches);
+            return $this->matches = array_values($matches instanceof Collection ? $matches->all() : $matches);
         }
 
         return $this->matches = array_values(array_filter($this->options, function ($option) {

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -92,6 +92,7 @@ class SuggestPrompt extends Prompt
 
         if ($this->options instanceof Closure) {
             $matches = ($this->options)($this->value());
+            // @phpstan-ignore-next-line
             return $this->matches = array_values($matches instanceof Collection ? $matches->toArray() : $matches);
         }
 

--- a/tests/Feature/SuggestPromptTest.php
+++ b/tests/Feature/SuggestPromptTest.php
@@ -98,6 +98,26 @@ it('accepts a collection', function () {
     expect($result)->toBe('Blue');
 });
 
+it('accepts a callback returning a collection', function () {
+    Prompt::fake(['b', Key::TAB, Key::ENTER]);
+
+    $result = suggest(
+        label: 'What is your favorite color?',
+        options: fn ($value) => collect([
+            'Red',
+            'Green',
+            'Blue',
+        ])->filter(
+            fn ($name) => str_contains(
+                strtoupper($name),
+                strtoupper($value)
+            )
+        )
+    );
+
+    expect($result)->toBe('Blue');
+});
+
 it('validates', function () {
     Prompt::fake([Key::ENTER, 'X', Key::ENTER]);
 


### PR DESCRIPTION
This PR fixes the bug below:

running the code below written in the [document](https://laravel.com/docs/11.x/prompts#suggest) results in `TypeError`.
```php
$name = suggest(
    'What is your name?',
    fn ($value) => collect(['Taylor', 'Dayle'])
        ->filter(fn ($name) => Str::contains($name, $value, ignoreCase: true))
)
```
![laravel_prompts_suggest_type_error](https://github.com/laravel/prompts/assets/19181121/3530e3ff-6c2b-46b8-bb64-0bde89c180c3)

Because `($this->options)($this->value())` in line 94 of `Laravel/Prompts/SuggestPrompt` returns `Collection` in this case, and it is passed as a parameter of `array_values()`.
