### PR TITLE
Feature: TabbedScrollableSelectPrompt

### DIFF
--- a/playground/tabbedscrollableselect.php
+++ b/playground/tabbedscrollableselect.php
@@ -1,0 +1,129 @@
+<?php
+
+use function Laravel\Prompts\tabbedscrollableselect;
+
+require __DIR__.'/../vendor/autoload.php';
+
+$application = tabbedscrollableselect(
+    label: 'Which persons application would you like to choose?',
+    options: [
+        [
+            'id' => 0,
+            'tab' => 'Jess Archer',
+            'body' => <<<BODY
+            Subject: Application for Software Developer Position - The Code to Success!
+
+            Dear Hiring Manager,
+            
+            I am writing to apply for the Software Developer position at [Company Name], a role I am extremely excited about as it seems tailor-made for someone with my background and unique blend of skills – I'm not just another cog in the machine, but a potential key in your company's codebase! Having honed my programming skills in various languages, I am confident in my ability to debug your expectations and log significant achievements. My previous experience at Tech Innovations, where I developed high-quality, scalable code, was not just a job but a daily opportunity to go through "exceptional" handling!
+            
+            Why do I think I'm a great fit for your team? Well, it's not only because I can navigate through complex algorithms like a pro, but also because I believe that a good coder knows how to iterate over coffee cups and lines of code alike. My friends say I'm like a human debugger, always ready to sort out arrays of problems – and they're not wrong. At my current job, they don't use Java because when I touched the code, the coffee machine started programming itself!
+            
+            In my quest to find the perfect role, I've interfaced with many APIs, but none seem to offer a RESTful career path quite like [Company Name]. I am eager to bring my skills to your innovative projects, and together, we can push the envelope, or should I say, "push the commit"? I am especially impressed by your recent project on [specific project], and I have some ideas that might optimize our runtime by reducing the time complexity of making an impact.
+            
+            Thank you for considering my application. I look forward to the possibility of discussing how I can contribute to your team and help [Company Name] continue to excel and debug the myth that all software development is just about coding. Let's set up a time to connect - I promise it won't be a "hard commit"!
+            
+            Warm regards,
+            
+            [Your Name]
+            BODY,
+        ],
+        [
+            'id' => 1,
+            'tab' => 'Joe Dixon',
+            'body' => <<<BODY
+            Subject: Innovative Applicant Alert: Ready to Engineer Success at [Company Name]!
+
+            Dear Hiring Manager,
+
+            It's not every day you find an applicant who can seamlessly integrate into any team, debug complex problems, and still manage to be the life of the code party! My name is [Your Name], and I'm thrilled to submit my resume for the Software Developer position at [Company Name]. Not only do I bring a robust portfolio of programming skills to the table, but I also carry a toolkit filled with enthusiasm, creativity, and a knack for turning challenges into checkpoints. I've spent the past few years at [Previous Company] not only pushing code but pushing the boundaries of what our applications could achieve—imagine what I could do with your state-of-the-art resources!
+
+            Now, let's talk about why I'm a perfect match for your team. You need someone who knows their way around code, certainly. But what about navigating through Monday mornings and tight deadlines? Fear not, because I excel in optimizing coffee consumption while minimizing bug production. My previous project manager often said I could find the "root" in any "tree" and the fun in any function, making me an asset in both team dynamics and product development.
+
+            I am particularly impressed by [Company Name]'s recent foray into [specific technology or project], and I am buzzing with ideas that could further enhance its scalability and performance. With my proactive approach and your company's innovative culture, we could very well be the next big breakpoint in the industry! I am all set to help [Company Name] not only meet its goals but exceed them with flying colors (and yes, I mean both the syntax highlighting and the business metrics).
+
+            Thank you for considering my application. I am looking forward to the opportunity to dive deep into a conversation with you and explore how my background, skills, and enthusiasms align with the vision of [Company Name]. Let's synchronize our calendars for a chat—I assure you, it will be more engaging than a silent console!
+
+            Best regards,
+
+            [Your Name]
+            BODY,
+        ],
+        [
+            'id' => 2,
+            'tab' => 'Tim MacDonald',
+            'body' => <<<BODY
+            Subject: Ready to Commit: My Application for Software Developer at [Company Name]
+
+            Dear Hiring Team,
+
+            Hello from a passionate coder who not only loves semicolons; but also knows where to put them! My name is [Your Name], and I am enthusiastic about the opportunity to join [Company Name] as a Software Developer. With a rich background in software engineering complemented by my quick-witted problem-solving skills, I am prepared to contribute to your innovative projects and ensure that every loop in our code is as smooth as the user interfaces we design.
+
+            I've always believed that a good developer is like a good comedian; they need timing, creativity, and the ability to keep an audience—whether users or fellow coders—engaged. My experience at [Previous Company] taught me to manage databases and deadlines with a smile, and I've successfully led several projects from concept through to debugging and deployment. At [Company Name], I'm eager to bring laughter and high-quality code to the table, making sure that our productivity and spirits are always compiling smoothly.
+
+            Your commitment to [specific technology or project] is particularly compelling to me. Having followed your team's achievements through industry publications and conferences, I am excited about the prospect of contributing my own ideas on [a technology or approach]. Together, I believe we can enhance your systems to not only perform efficiently but also deliver a punchline of power and precision that the industry will notice.
+
+            I appreciate your consideration of my application and am looking forward to the opportunity to further discuss how my programming prowess and proactive attitude can be of great benefit to [Company Name]. I'm ready to checkout my current position and push forward with your team. Let's connect and discuss how we can sync our goals and start scripting our next success story!
+
+            Warmest regards,
+
+            [Your Name]
+            BODY,
+        ],
+        [
+            'id' => 3,
+            'tab' => 'Mohammed Said',
+            'body' => <<<BODY
+            Subject: Coding My Way Into Your Team: Software Developer Application at [Company Name]
+
+            Dear Hiring Manager,
+
+            I am [Your Name], and I'm sending this application encoded with enthusiasm and a track record of success in the tech industry, hoping to join [Company Name] as a Software Developer. With a knack for cracking code faster than most people crack a smile, I've been a dynamic part of tech teams that thrive on creativity and precision—just like your esteemed company. I believe that with my blend of skills, humor, and dedication, I can contribute significantly to your innovative projects and vibrant team culture.
+
+            Why am I excited about the possibility of working with you? Beyond my love for crafting clean, efficient code, I thrive in environments that challenge the status quo and reward agility and innovation. At my current position with [Previous Company], I've not only debugged and developed, but also delivered pun-tastic presentations that have made sprint reviews as anticipated as the latest software release. My approach has always been to think outside the "box model," applying both logical and creative thinking to solve complex problems.
+
+            I am particularly impressed by [Company Name]'s recent work on [specific project or technology], which I believe aligns perfectly with my expertise in [related technology or skill]. I am eager to bring my array of skills from [specific languages or technologies you are proficient in] to your team, ensuring that together, we can enhance user experiences and backend functionality in ways that are not only functional but also fun.
+
+            Thank you for considering my application. I am looking forward to the opportunity to discuss how my technical skills, light-hearted approach, and passion for software development can be effectively integrated into your team. Let's schedule a meeting to decode the possibilities together. I am confident that it will be a productive and cheerful dialogue, or my name isn’t [Your Name]—and trust me, it is!
+
+            Best regards,
+
+            [Your Name]
+            BODY,
+        ],
+        [
+            'id' => 4,
+            'tab' => 'Nuno Maduro',
+            'body' => <<<BODY
+            Subject: Debugging Opportunities: Application for Software Developer at [Company Name]
+
+            Dear Hiring Team,
+
+            Greetings! I'm [Your Name], a software developer with a penchant for turning complex, buggy code into sleek, efficient applications. I'm applying for the Software Developer position at [Company Name], drawn by your commitment to innovation and quality, and the humorous yet professional spirit of your company culture. My background in [Your Specialty or Previous Experience] has equipped me with the tools to enhance your projects and add a little extra byte to your team's dynamic.
+
+            In my current role at [Previous Company], I’ve proven my ability to manage and improve software systems, delivering solutions that not only meet but exceed expectations. I approach each project with the mindset of a 'code surgeon,' meticulously refining and optimizing to ensure peak performance. But it’s not all serious—my colleagues often say I add a 'debugging delight' to our team meetings, making even the most complex problem-solving sessions enjoyable with my puns and quick wit.
+
+            I am particularly enthusiastic about [Company Name]'s recent initiatives in [specific field or project], and I am eager to bring my experience in [specific technology or method] to your esteemed team. Your project aligns seamlessly with my skills and ambitions, and I am excited about the prospect of contributing to your continued success. I'm looking to not only push code but also push the boundaries of what we can achieve together with a mix of innovation, collaboration, and a few well-timed jokes!
+
+            Thank you for considering my application. I look forward to the possibility of joining your team and contributing to [Company Name]'s future projects. I am keen to discuss how my background, skills, and enthusiasms align with the goals of your company. Let’s connect to compile our thoughts and begin scripting a successful chapter together.
+
+            Warmest regards,
+
+            [Your Name]
+            BODY,
+        ],
+    ],
+    default: 0,
+    scroll: 14,
+    max_width: 120,
+    required: false,
+    // validate: fn ($values) => match (true) {
+    //     empty($values) => 'Please select at least one permission.',
+    //     default => null,
+    // },
+    hint: 'The chosen application will determine who gets the job.',
+);
+
+var_dump($application);
+
+echo str_repeat(PHP_EOL, 1);

--- a/src/Concerns/Themes.php
+++ b/src/Concerns/Themes.php
@@ -14,6 +14,7 @@ use Laravel\Prompts\SearchPrompt;
 use Laravel\Prompts\SelectPrompt;
 use Laravel\Prompts\Spinner;
 use Laravel\Prompts\SuggestPrompt;
+use Laravel\Prompts\TabbedScrollableSelectPrompt;
 use Laravel\Prompts\Table;
 use Laravel\Prompts\TextareaPrompt;
 use Laravel\Prompts\TextPrompt;
@@ -28,6 +29,7 @@ use Laravel\Prompts\Themes\Default\SearchPromptRenderer;
 use Laravel\Prompts\Themes\Default\SelectPromptRenderer;
 use Laravel\Prompts\Themes\Default\SpinnerRenderer;
 use Laravel\Prompts\Themes\Default\SuggestPromptRenderer;
+use Laravel\Prompts\Themes\Default\TabbedScrollableSelectRenderer;
 use Laravel\Prompts\Themes\Default\TableRenderer;
 use Laravel\Prompts\Themes\Default\TextareaPromptRenderer;
 use Laravel\Prompts\Themes\Default\TextPromptRenderer;
@@ -51,6 +53,7 @@ trait Themes
             PasswordPrompt::class => PasswordPromptRenderer::class,
             SelectPrompt::class => SelectPromptRenderer::class,
             MultiSelectPrompt::class => MultiSelectPromptRenderer::class,
+            TabbedScrollableSelectPrompt::class => TabbedScrollableSelectRenderer::class,
             ConfirmPrompt::class => ConfirmPromptRenderer::class,
             PausePrompt::class => PausePromptRenderer::class,
             SearchPrompt::class => SearchPromptRenderer::class,

--- a/src/Key.php
+++ b/src/Key.php
@@ -6,7 +6,11 @@ class Key
 {
     const UP = "\e[A";
 
+    const SHIFT_UP = "\e[1;2A";
+
     const DOWN = "\e[B";
+
+    const SHIFT_DOWN = "\e[1;2B";
 
     const RIGHT = "\e[C";
 
@@ -19,6 +23,8 @@ class Key
     const RIGHT_ARROW = "\eOC";
 
     const LEFT_ARROW = "\eOD";
+
+    const ESCAPE = "\e";
 
     const DELETE = "\e[3~";
 

--- a/src/TabbedScrollableSelectPrompt.php
+++ b/src/TabbedScrollableSelectPrompt.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Laravel\Prompts;
+
+use Closure;
+use Illuminate\Support\Collection;
+
+/**
+ * @phpstan-type TOption = array{id: int|string, tab: string, body: string}
+ */
+class TabbedScrollableSelectPrompt extends Prompt
+{
+    /**
+     * Index of the currently selected option.
+     */
+    public int|null $selected;
+
+    public int $firstVisible = 0;
+
+    public readonly int $width;
+
+    /**
+     * The processed content for the tabbed-scrollable-select prompt.
+     * 
+     * @var Collection<int, Collection<int, string>>
+     */
+    public readonly Collection $content;
+
+    /**
+     * The options for the tabbed-scrollable-select prompt.
+     *
+     * @var Collection<int, TOption>
+     */
+    public readonly Collection $options;
+
+    /**
+     * Create a new TabbedScrollableSelectPrompt instance.
+     * 
+     * @param  array<int, TOption>|Collection<int, TOption>  $options
+     * @param int|Closure(Collection<int, TOption>): Collection<int, TOption> $default The default value for the prompt. If Closure, it is passed `$options` and should return a Collection containing only the desired record.
+     */
+    public function __construct(
+        public string $label,
+        array|Collection $options,
+        int|Closure $default = 0,
+        public int $scroll = 14,
+        public int $max_width = 120,
+        public bool|string $required = true,
+        public mixed $validate = null,
+        public string $hint = '',
+    ) {
+        $this->width = min($this->terminal()->cols(), $this->max_width);
+        $this->options = $options instanceof Collection ? $options : collect($options);
+        $this->selected = is_callable($default) ? $default($this->options)->keys()->sole() : $default;
+        $this->scroll = max($this->scroll, 5); // Scrollbar is impractical below 5 lines.
+        $this->scroll = min($this->scroll, 14); // Scrollbar breaks above 14 lines.
+
+        $this->content = $this->options->map(function (array $option): Collection {
+            return $this->processContentBody((string) $option['body'], $this->width);
+        });
+
+        $this->on('key', fn ($key) => match($key) {
+            Key::ENTER => $this->submit(),
+            Key::ESCAPE => $this->handleEscape(),
+            Key::UP, Key::UP_ARROW => $this->handleUpArrow(),
+            Key::DOWN, Key::DOWN_ARROW => $this->handleDownArrow(),
+            Key::LEFT, Key::LEFT_ARROW => $this->handleLeftArrow(),
+            Key::RIGHT, Key::RIGHT_ARROW => $this->handleRightArrow(),
+            Key::oneOf([Key::HOME], $key) => $this->handleHome(),
+            Key::oneOf([Key::END], $key) => $this->handleEnd(),
+            Key::SHIFT_UP => $this->doTimes(5, fn () => $this->handleUpArrow()),
+            Key::SHIFT_DOWN => $this->doTimes(5, fn () => $this->handleDownArrow()),
+            default => null,
+        });
+    }
+
+    /**
+     * Get the selected value.
+     */
+    public function value(): int|string|null
+    {
+        return is_null($this->selected)
+            ? null
+            : $this->options->get($this->selected)['id'];
+    }
+
+    /**
+     * Get the visible content for the prompt.
+     *
+     * @return Collection<int, string>
+     */
+    public function visible(): Collection
+    {
+        return $this->content->get($this->selected)->slice($this->firstVisible, $this->scroll);
+    }
+
+    /**
+     * Get a collection of instructions for the prompt.
+     *
+     * @return Collection<int, string>
+     */
+    public function getInstructions(): Collection
+    {
+        $instructions = collect([
+            'Use the [LEFT] and [RIGHT] arrow keys to navigate between options.',
+            'Use the [UP] and [DOWN] arrow keys to scroll the selected area.',
+            'Press [ENTER] to select the highlighted option.',
+        ]);
+
+        if (! $this->required) {
+            $instructions->push('Press [ESCAPE] to select none of these options.');
+        }
+
+        return $instructions;
+    }
+
+    /**
+     * Process the content body.
+     *
+     * @return Collection<int, string>
+     */
+    protected function processContentBody(string $body, int $width): Collection
+    {
+        return collect(explode(PHP_EOL, wordwrap($body, $width - 8, PHP_EOL)))->pad($this->scroll, '');
+    }
+
+    protected function doTimes(int $times, Closure $closure): void
+    {
+        for ($i = 0; $i < $times; $i++) $closure();
+    }
+
+    protected function handleUpArrow(): void
+    {
+        $this->firstVisible = max($this->firstVisible - 1, 0);
+    }
+
+    protected function handleDownArrow(): void
+    {
+        $this->firstVisible = min($this->firstVisible + 1, $this->content->get($this->selected)->count() - $this->scroll);
+    }
+
+    protected function handleHome(): void
+    {
+        $this->firstVisible = 0;
+    }
+
+    protected function handleEnd(): void
+    {
+        $this->firstVisible = $this->content->get($this->selected)->count() - $this->scroll;
+    }
+
+    protected function handleLeftArrow(): void
+    {
+        $this->firstVisible = 0;
+        $this->selected = max($this->selected - 1, 0);
+    }
+
+    protected function handleRightArrow(): void
+    {
+        $this->firstVisible = 0;
+        $this->selected = min($this->selected + 1, $this->options->count() - 1);
+    }
+
+    protected function handleEscape(): void
+    {
+        if ($this->required) {
+            $this->error = 'You must select an option.';
+            $this->state = 'error';
+
+            return;
+        }
+
+        $this->selected = null;
+        $this->state = 'submit';
+    }
+}

--- a/src/Themes/Default/Concerns/DrawsBoxes.php
+++ b/src/Themes/Default/Concerns/DrawsBoxes.php
@@ -6,6 +6,8 @@ use Laravel\Prompts\Prompt;
 
 trait DrawsBoxes
 {
+    use HandlesStrings;
+
     protected int $minWidth = 60;
 
     /**
@@ -54,45 +56,5 @@ trait DrawsBoxes
         ).($info ? " {$info} " : '').'┘'));
 
         return $this;
-    }
-
-    /**
-     * Get the length of the longest line.
-     *
-     * @param  array<string>  $lines
-     */
-    protected function longest(array $lines, int $padding = 0): int
-    {
-        return max(
-            $this->minWidth,
-            collect($lines)
-                ->map(fn ($line) => mb_strwidth($this->stripEscapeSequences($line)) + $padding)
-                ->max()
-        );
-    }
-
-    /**
-     * Pad text ignoring ANSI escape sequences.
-     */
-    protected function pad(string $text, int $length, $char = ' '): string
-    {
-        $rightPadding = str_repeat($char, max(0, $length - mb_strwidth($this->stripEscapeSequences($text))));
-
-        return "{$text}{$rightPadding}";
-    }
-
-    /**
-     * Strip ANSI escape sequences from the given text.
-     */
-    protected function stripEscapeSequences(string $text): string
-    {
-        // Strip ANSI escape sequences.
-        $text = preg_replace("/\e[^m]*m/", '', $text);
-
-        // Strip Symfony named style tags.
-        $text = preg_replace("/<(info|comment|question|error)>(.*?)<\/\\1>/", '$2', $text);
-
-        // Strip Symfony inline style tags.
-        return preg_replace("/<(?:(?:[fb]g|options)=[a-z,;]+)+>(.*?)<\/>/i", '$1', $text);
     }
 }

--- a/src/Themes/Default/Concerns/DrawsBoxes.php
+++ b/src/Themes/Default/Concerns/DrawsBoxes.php
@@ -74,9 +74,9 @@ trait DrawsBoxes
     /**
      * Pad text ignoring ANSI escape sequences.
      */
-    protected function pad(string $text, int $length): string
+    protected function pad(string $text, int $length, $char = ' '): string
     {
-        $rightPadding = str_repeat(' ', max(0, $length - mb_strwidth($this->stripEscapeSequences($text))));
+        $rightPadding = str_repeat($char, max(0, $length - mb_strwidth($this->stripEscapeSequences($text))));
 
         return "{$text}{$rightPadding}";
     }

--- a/src/Themes/Default/Concerns/DrawsTabs.php
+++ b/src/Themes/Default/Concerns/DrawsTabs.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Laravel\Prompts\Themes\Default\Concerns;
+
+use Illuminate\Support\Collection;
+
+trait DrawsTabs
+{
+    use HandlesStrings;
+
+    /**
+     * Render a row of tabs.
+     *
+     * @param Collection<int, string>  $tabs
+     */
+    protected function tabs(
+        Collection $tabs,
+        int $selected,
+        int $width,
+        string $color = 'cyan',
+    ): string {
+        $strippedWidth = fn (string $value): int => mb_strwidth($this->stripEscapeSequences($value));
+
+        $top_row = $tabs->map(fn($value, $key) => $key === $selected
+            ? '╭' . str_repeat('─', $strippedWidth($value) + 2) . '╮'
+            : str_repeat(' ', $strippedWidth($value) + 4)
+        )->implode('');
+
+        $middle_row = $tabs->map(fn($value, $key) => $key === $selected
+            ? "{$this->dim('│')} {$this->{$color}($value)} {$this->dim('│')}"
+            : "  {$value}  "
+        )->implode('');
+
+        $bottom_row = $tabs->map(fn($value, $key) => $key === $selected
+            ? '┴' . str_repeat('─', $strippedWidth($value) + 2) . '┴'
+            : str_repeat('─', $strippedWidth($value) + 4)
+        )->implode('');
+        $bottom_row = $this->pad($bottom_row, $width, '─');
+
+        // automatic horizontal tab scrolling
+        if ($strippedWidth($top_row) > $width) {
+            $chars_to_kill = $strippedWidth($top_row) - $width;
+            $percent = $selected / ($tabs->count() - 1);
+            $left = (int) round($percent * $chars_to_kill);
+            foreach ([&$top_row, &$middle_row, &$bottom_row] as &$row) {
+                $row = mb_substr($row, $left, mb_strwidth($row) - $chars_to_kill);
+            }
+        }
+
+        return collect([$this->dim($top_row), $middle_row, $this->dim($bottom_row)])->implode(PHP_EOL);
+    }
+}

--- a/src/Themes/Default/Concerns/HandlesStrings.php
+++ b/src/Themes/Default/Concerns/HandlesStrings.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Laravel\Prompts\Themes\Default\Concerns;
+
+trait HandlesStrings
+{
+    /**
+     * Get the length of the longest line.
+     *
+     * @param  array<string>  $lines
+     */
+    protected function longest(array $lines, int $padding = 0): int
+    {
+        return max(
+            $this->minWidth,
+            collect($lines)
+                ->map(fn ($line) => mb_strwidth($this->stripEscapeSequences($line)) + $padding)
+                ->max()
+        );
+    }
+
+    /**
+     * Pad text ignoring ANSI escape sequences.
+     */
+    protected function pad(string $text, int $length, string $char = ' '): string
+    {
+        $rightPadding = str_repeat($char, max(0, $length - mb_strwidth($this->stripEscapeSequences($text))));
+
+        return "{$text}{$rightPadding}";
+    }
+
+    /**
+     * Strip ANSI escape sequences from the given text.
+     */
+    protected function stripEscapeSequences(string $text): string
+    {
+        // Strip ANSI escape sequences.
+        $text = preg_replace("/\e[^m]*m/", '', $text);
+
+        // Strip Symfony named style tags.
+        $text = preg_replace("/<(info|comment|question|error)>(.*?)<\/\\1>/", '$2', $text);
+
+        // Strip Symfony inline style tags.
+        return preg_replace("/<(?:(?:[fb]g|options)=[a-z,;]+)+>(.*?)<\/>/i", '$1', $text);
+    }
+}

--- a/src/Themes/Default/TabbedScrollableSelectRenderer.php
+++ b/src/Themes/Default/TabbedScrollableSelectRenderer.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Laravel\Prompts\Themes\Default;
+
+use Illuminate\Support\Collection;
+use Laravel\Prompts\TabbedScrollableSelectPrompt;
+use Laravel\Prompts\Themes\Contracts\Scrolling;
+
+class TabbedScrollableSelectRenderer extends Renderer implements Scrolling
+{
+    use Concerns\DrawsBoxes;
+    use Concerns\DrawsScrollbars;
+    use Concerns\DrawsTabs;
+
+    /**
+     * Render the tabbed-scrollable-select prompt.
+     */
+    public function __invoke(TabbedScrollableSelectPrompt $prompt): string
+    {
+        return match ($prompt->state) {
+            'submit' => $this
+                ->box(
+                    $this->truncate($this->dim($prompt->label), $prompt->terminal()->cols() - 6),
+                    $this->renderSelectedOption($prompt),
+                ),
+
+            'cancel' => $this
+                ->box(
+                    $this->truncate($prompt->label, $prompt->terminal()->cols() - 6),
+                    $this->renderBody($prompt),
+                    color: 'red',
+                )
+                ->error('Cancelled.'),
+
+            'error' => $this
+                ->box(
+                    $this->truncate($prompt->label, $prompt->terminal()->cols() - 6),
+                    $this->renderBody($prompt),
+                    color: 'yellow',
+                )
+                ->warning($this->truncate($prompt->error, $prompt->terminal()->cols() - 5)),
+
+            default => $this
+                ->box(
+                    title: $this->truncate($prompt->label, $prompt->terminal()->cols() - 6),
+                    body: $this->renderBody($prompt),
+                    footer: $prompt->hint,
+                    // color: 'gray',
+                    // info: count($prompt->options) > $prompt->scroll ? (count($prompt->value()).' selected') : '',
+                )
+                ->when(
+                    true,
+                    fn () => $this->renderInstructions($prompt)->each(fn($line) => $this->hint($line)),
+                    fn () => $this->newLine() // Space for errors
+                ),
+        };
+    }
+
+    /**
+     * Render the body.
+     */
+    protected function renderBody(TabbedScrollableSelectPrompt $prompt): string
+    {
+        return collect([
+            $this->tabs(
+                tabs: $prompt->options->pluck('tab'),
+                selected: $prompt->selected,
+                width: $prompt->width - 6,
+            ),
+            $this->scrollbar(
+                visible: $prompt->visible(),
+                firstVisible: $prompt->firstVisible,
+                height: $prompt->scroll,
+                total: $prompt->content->get($prompt->selected)->count(),
+                width: $prompt->width - 6,
+            )->implode(PHP_EOL),
+        ])->implode(PHP_EOL);
+    }
+
+    /**
+     * Render the selected options.
+     */
+    protected function renderSelectedOption(TabbedScrollableSelectPrompt $prompt): string
+    {
+        return is_null($prompt->selected)
+            ? 'No Option Selected'
+            : collect([
+                $prompt->options->get($prompt->selected)['tab'],
+                '',
+                ...$prompt->visible()->splice(0, 3),
+                '...',
+            ])->implode(PHP_EOL);
+    }
+
+    /**
+     * Render the instructions.
+     * 
+     * @return \Illuminate\Support\Collection<int, string>
+     */
+    protected function renderInstructions(TabbedScrollableSelectPrompt $prompt): Collection
+    {
+        return $prompt->getInstructions()
+            ->map(fn($line) => $this->dim($line));
+    }
+
+    /**
+     * The number of lines to reserve outside of the scrollable area.
+     */
+    public function reservedLines(): int
+    {
+        return 5;
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -53,6 +53,19 @@ function multiselect(string $label, array|Collection $options, array|Collection 
 }
 
 /**
+ * Prompt the user to select an option from a scrollable tabbed list.
+ * 
+ * @template TOption of array{id: int|string, tab: string, body: string}
+ * 
+ * @param  array<int, TOption>|Collection<int, TOption>  $options
+ * @param  int|Closure(Collection<int, TOption>): Collection<int, TOption> $default The default value for the prompt. If Closure, it is passed `$options` and should return a Collection containing only the desired record.
+ */
+function tabbedscrollableselect(string $label, array|Collection $options, int|Closure $default = 0, int $scroll = 14, int $max_width = 120, bool|string $required = true, mixed $validate = null, string $hint = ''): int|string|null
+{
+    return (new TabbedScrollableSelectPrompt(...func_get_args()))->prompt();
+}
+
+/**
  * Prompt the user to confirm an action.
  */
 function confirm(string $label, bool $default = true, string $yes = 'Yes', string $no = 'No', bool|string $required = false, mixed $validate = null, string $hint = ''): bool

--- a/tests/Feature/TabbedScrollableSelectPromptTest.php
+++ b/tests/Feature/TabbedScrollableSelectPromptTest.php
@@ -1,0 +1,203 @@
+<?php
+
+use Illuminate\Support\Collection;
+use Laravel\Prompts\Key;
+use Laravel\Prompts\Prompt;
+
+use function Laravel\Prompts\tabbedscrollableselect;
+
+beforeEach(function () {
+    $this->optionsData = [
+        [
+            'id' => 'ae912f',
+            'tab' => 'Mine',
+            'body' => 'This is my essay.',
+        ],
+        [
+            'id' => 'b3c4d5',
+            'tab' => 'Yours',
+            'body' => 'This is your essay.',
+        ],
+        [
+            'id' => 'f6g7h8',
+            'tab' => 'Theirs',
+            'body' => 'This is their essay.',
+        ],
+    ];
+});
+
+
+it('accepts an array of options', function () {
+    Prompt::fake([Key::RIGHT, Key::RIGHT, Key::ENTER]);
+
+    $result = tabbedscrollableselect(
+        label: 'Whose essay is best?',
+        options: $this->optionsData,
+    );
+
+    expect($result)->toBe('f6g7h8');
+
+    Prompt::assertStrippedOutputContains($this->optionsData[0]['tab']);
+    Prompt::assertStrippedOutputContains($this->optionsData[0]['body']);
+    Prompt::assertStrippedOutputContains($this->optionsData[1]['tab']);
+    Prompt::assertStrippedOutputContains($this->optionsData[1]['body']);
+    Prompt::assertStrippedOutputContains($this->optionsData[2]['tab']);
+    Prompt::assertStrippedOutputContains($this->optionsData[2]['body']);
+});
+
+it('accepts a collection of options', function () {
+    Prompt::fake([Key::RIGHT, Key::RIGHT, Key::ENTER]);
+
+    $result = tabbedscrollableselect(
+        label: 'Whose essay is best?',
+        options: collect($this->optionsData),
+    );
+
+    expect($result)->toBe('f6g7h8');
+
+    Prompt::assertStrippedOutputContains($this->optionsData[0]['tab']);
+    Prompt::assertStrippedOutputContains($this->optionsData[0]['body']);
+    Prompt::assertStrippedOutputContains($this->optionsData[1]['tab']);
+    Prompt::assertStrippedOutputContains($this->optionsData[1]['body']);
+    Prompt::assertStrippedOutputContains($this->optionsData[2]['tab']);
+    Prompt::assertStrippedOutputContains($this->optionsData[2]['body']);
+});
+
+it('accepts a default value', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = tabbedscrollableselect(
+        label: 'Whose essay is best?',
+        options: $this->optionsData,
+        default: 1,
+    );
+
+    expect($result)->toBe('b3c4d5');
+
+    Prompt::assertStrippedOutputDoesntContain($this->optionsData[0]['body']);
+    Prompt::assertStrippedOutputContains($this->optionsData[1]['tab']);
+    Prompt::assertStrippedOutputContains($this->optionsData[1]['body']);
+    Prompt::assertStrippedOutputContains($this->optionsData[2]['tab']);
+    Prompt::assertStrippedOutputDoesntContain($this->optionsData[2]['body']);
+});
+
+it('accepts a closure as a default value', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = tabbedscrollableselect(
+        label: 'Whose essay is best?',
+        options: collect($this->optionsData),
+        default: fn (Collection $options): Collection => $options->where('tab', 'Yours'),
+    );
+
+    expect($result)->toBe('b3c4d5');
+
+    Prompt::assertStrippedOutputDoesntContain($this->optionsData[0]['body']);
+    Prompt::assertStrippedOutputContains($this->optionsData[1]['tab']);
+    Prompt::assertStrippedOutputContains($this->optionsData[1]['body']);
+    Prompt::assertStrippedOutputContains($this->optionsData[2]['tab']);
+    Prompt::assertStrippedOutputDoesntContain($this->optionsData[2]['body']);
+});
+
+it('accepts a scroll value and enforces the minimum', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = tabbedscrollableselect(
+        label: 'This content should only display 5 lines of text.',
+        options: [
+            [
+                'id' => 0,
+                'tab' => 'Mine',
+                'body' => collect([
+                    'line 1',
+                    'line 2',
+                    'line 3',
+                    'line 4',
+                    'line 5',
+                    'line 6',
+                ])->implode(PHP_EOL),
+            ],
+        ],
+        scroll: 2,
+    );
+
+    expect($result)->toBe(0);
+
+    Prompt::assertStrippedOutputContains('line 1');
+    Prompt::assertStrippedOutputContains('line 5');
+    Prompt::assertStrippedOutputDoesntContain('line 6');
+});
+
+it('scrolls the content', function() {
+    Prompt::fake([Key:: DOWN, Key::ENTER]);
+
+    $result = tabbedscrollableselect(
+        label: 'This content should display the 6th line.',
+        options: [
+            [
+                'id' => 0,
+                'tab' => 'Mine',
+                'body' => collect([
+                    'line 1',
+                    'line 2',
+                    'line 3',
+                    'line 4',
+                    'line 5',
+                    'line 6',
+                ])->implode(PHP_EOL),
+            ],
+        ],
+        scroll: 2,
+    );
+
+    expect($result)->toBe(0);
+
+    Prompt::assertStrippedOutputContains('line 6');
+});
+
+it('accepts a validate value')->todo();
+
+it('accepts a hint value', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = tabbedscrollableselect(
+        label: 'Whose essay is best?',
+        options: $this->optionsData,
+        hint: 'Use the arrow keys to navigate.',
+    );
+
+    expect($result)->toBe('ae912f');
+
+    Prompt::assertStrippedOutputContains('Use the arrow keys to navigate.');
+
+});
+
+it('skips [ESC] instruction if required is true', function () {
+    Prompt::fake([Key::ESCAPE, KEY::ENTER]);
+
+    $result = tabbedscrollableselect(
+        label: 'Whose essay is best?',
+        options: $this->optionsData,
+        required: true,
+    );
+
+    expect($result)->toBe('ae912f');
+
+    Prompt::assertStrippedOutputDoesntContain('[ESCAPE]');
+    Prompt::assertStrippedOutputContains('You must select an option.');
+});
+
+it('allows to escape if required is false', function () {
+    Prompt::fake([Key::ESCAPE]);
+
+    $result = tabbedscrollableselect(
+        label: 'Whose essay is best?',
+        options: $this->optionsData,
+        required: false,
+    );
+
+    expect($result)->toBeNull();
+
+    Prompt::assertStrippedOutputContains('[ESCAPE]');
+    Prompt::assertStrippedOutputContains('No Option Selected');
+});


### PR DESCRIPTION
This PR includes all work to implement a new `TabbedScrollableSelectPrompt`. 

https://github.com/laravel/prompts/assets/1688608/89f08a04-49bb-4d2d-bbcc-021f7cc3e91b

**If you'd like me to extract these into separate PRs, I can do that**

The first three commits are structured such that they can be `cherry-picked` and merged as separate work beforehand. They involve the following changes:
- Adds support for `ESCAPE`, `SHIFT_UP`, and `SHIFT_DOWN` Keys.
- Adds the ability to specify the character to be used in `DrawsBoxes::pad()`, maintaining backwards compatibility by setting a default of `' '`.
- Moves three methods for working with strings from the `DrawsBoxes` trait into another dedicated `HandlesStrings` trait which is then consumed by the `DrawsTabs` trait to avoid duplicate method name collisions.

The new `DrawsTabs` trait could then be merged on it's own. It's built in a similar way to the `DrawsScrollbars` trait. It can be used in any new prompts in the same way. This is the feature that ultimately enables the prompt in the example. It will also automatically scroll horizontally based on the selected tab in order to prevent overflowing and ruining the output.

Finally, the final 5 commits put all of this together to create our new component. I built this component because I wanted to include some readable context for the items from which I'm selecting. I'm thrilled with this solution, and I'd like to provide it for others to use as well.