### PR TITLE
Adds support for nested forms

### DIFF
--- a/playground/form.php
+++ b/playground/form.php
@@ -1,5 +1,7 @@
 <?php
 
+use Laravel\Prompts\FormBuilder;
+
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\form;
 use function Laravel\Prompts\note;
@@ -27,6 +29,24 @@ $responses = form()
             ! $value => 'Please enter your name.',
             default => null,
         },
+    )
+    ->select('Which scaffolding project would you like?', ['Breeze', 'Jetstream', 'None'], required: true, name: 'scaffolding')
+    ->form(
+        fn (FormBuilder $form, array $responses) => $form
+            ->note("{$responses['scaffolding']} selected")
+            ->confirm('Would you like to install dark mode?')
+            ->select('Which stack would you like?', ['Blade', 'Vue', 'React']),
+        when: fn (array $responses) => $responses['scaffolding'] === 'Breeze',
+        name: 'breeze-stack',
+    )
+    ->form(
+        fn (FormBuilder $form, array $responses) => $form
+            ->note("{$responses['scaffolding']} selected")
+            ->confirm('Would you like to install teams support?')
+            ->confirm('Would you like to support dark mode?')
+            ->select('Which stack would you like', ['Inertia', 'Livewire']),
+        when: fn (array $responses) => $responses['scaffolding'] === 'Jetstream',
+        name: 'jet-stack',
     )
     ->text(
         label: 'Where should we create your project?',

--- a/playground/form.php
+++ b/playground/form.php
@@ -1,7 +1,5 @@
 <?php
 
-use Laravel\Prompts\FormBuilder;
-
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\form;
 use function Laravel\Prompts\note;
@@ -31,17 +29,16 @@ $responses = form()
         },
     )
     ->select('Which scaffolding project would you like?', ['Breeze', 'Jetstream', 'None'], required: true, name: 'scaffolding')
-    ->form(
-        fn (FormBuilder $form, array $responses) => $form
+    ->nested(
+        fn (array $responses) => form()
             ->note("{$responses['scaffolding']} selected")
             ->confirm('Would you like to install dark mode?')
             ->select('Which stack would you like?', ['Blade', 'Vue', 'React']),
         when: fn (array $responses) => $responses['scaffolding'] === 'Breeze',
         name: 'breeze-stack',
     )
-    ->form(
-        fn (FormBuilder $form, array $responses) => $form
-            ->note("{$responses['scaffolding']} selected")
+    ->nested(
+        form()
             ->confirm('Would you like to install teams support?')
             ->confirm('Would you like to support dark mode?')
             ->select('Which stack would you like', ['Inertia', 'Livewire']),

--- a/tests/Feature/FormTest.php
+++ b/tests/Feature/FormTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Laravel\Prompts\FormBuilder;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 
@@ -198,7 +197,7 @@ it('allows a form inside a form', function () {
 
     $responses = form()
         ->confirm('Are you sure?')
-        ->form(fn (FormBuilder $form) => $form
+        ->nested(form()
             ->intro('And so begins a nested form…')
             ->text('What is your name?', name: 'name')
             ->text('How old are you?'),
@@ -231,15 +230,15 @@ it('can conditionally run a nested form based on previous responses', function (
 
     $responses = form()
         ->text('What is your name?', name: 'name', required: true)
-        ->form(
-            fn (FormBuilder $form, array $responses) => $form
+        ->nested(
+            fn (array $responses) => form()
                 ->confirm("Do you work at Laracasts, {$responses['name']}?")
                 ->text('How many days a week do you work?'),
             when: fn (array $responses) => $responses['name'] === 'Luke',
             name: 'form-for-luke'
         )
-        ->form(
-            fn (FormBuilder $form) => $form->confirm('Do you work at Laravel?'),
+        ->nested(
+            form()->confirm('Do you work at Laravel?'),
             when: fn (array $responses) => $responses['name'] === 'Jess',
             name: 'form-for-jess'
         )


### PR DESCRIPTION
Hi all,

I wasn't quite ready to push this in with #118, so thought it best to do in a follow-up PR. This essentially adds support for nested forms, which can optionally be executed under a given condition.

## Reasoning

Take the example of the Laravel installer. It asks the user which stack they'd like to install: Jetstream, Breeze or nothing. If you think about it, a different set of inputs will be displayed depending on the stack that you select. In the current setup, it isn't possible to do this in a single form; you'd have to separate it out into multiple forms, but doing so would prevent you from reverting through the various form options (ie. once you selected Breeze, you can't go back and select Jetstream without cancelling the command).

## Example

```php
$responses = form()
    ->select(
        'Which scaffolding project would you like?', 
        ['Breeze', 'Jetstream', 'None'], 
        required: true, 
        name: 'scaffolding'
    )
    ->nested(
        fn (array $responses) => form()
            ->note("{$responses['scaffolding']} selected")
            ->confirm('Would you like to install dark mode?')
            ->select('Which stack would you like?', ['Blade', 'Vue', 'React']),
        when: fn (array $responses) => $responses['scaffolding'] === 'Breeze',
        name: 'breeze-stack',
    )
    ->nested(
        form()
            ->confirm('Would you like to install teams support?')
            ->confirm('Would you like to support dark mode?')
            ->select('Which stack would you like', ['Inertia', 'Livewire']),
        when: fn (array $responses) => $responses['scaffolding'] === 'Jetstream',
        name: 'jet-stack',
    )
    ->submit();
```

> 💡 This exact scenario is available to play with by running `php playground/form.php`

Here is an example based on the previously described scenario. The `when` condition passed allows us only run the nested forms if the given closure for each returns `true`. From the front-end perspective, it feels seamless, as though it were a single, unified form. However, the user can revert back to the first statement at any time. Here is a video showing this example:

https://github.com/laravel/prompts/assets/12202279/3f961df7-5e46-4d26-816e-52c221c03609

You can see that previous responses are pre-filled, as in standard forms, and that we step through the inputs in logical order.

You can pass the `nested` method either a FormBuilder instance by calling `form` directly, or a `Closure` if you need access to previous responses from the form.

Would love to hear your thoughts! Thanks for all the hard work.

Kind Regards,
Luke
