### PR TITLE
Add description to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "laravel/prompts",
     "type": "library",
+    "description": "Add beautiful and user-friendly forms to your command-line applications.",
     "license": "MIT",
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
When validating my composer.json file, a warning occurred for this package: "the property description is required".

![Screenshot 2024-04-26 at 16 25 42](https://github.com/laravel/prompts/assets/9265514/2c02d22b-37d2-401a-a8e0-4118bbe9311a)

I added a description to the `composer.json` file.

-- Edwin