### PR TITLE
Add ability to specify character in pad function

### DIFF
--- a/src/Themes/Default/Concerns/DrawsBoxes.php
+++ b/src/Themes/Default/Concerns/DrawsBoxes.php
@@ -74,9 +74,9 @@ trait DrawsBoxes
     /**
      * Pad text ignoring ANSI escape sequences.
      */
-    protected function pad(string $text, int $length): string
+    protected function pad(string $text, int $length, string $char = ' '): string
     {
-        $rightPadding = str_repeat(' ', max(0, $length - mb_strwidth($this->stripEscapeSequences($text))));
+        $rightPadding = str_repeat($char, max(0, $length - mb_strwidth($this->stripEscapeSequences($text))));
 
         return "{$text}{$rightPadding}";
     }


### PR DESCRIPTION
This PR adds the ability to specify the character used to pad strings in the `DrawsBoxes` trait. By using a default value of `[SPACE]` as an **optional** _third_ parameter, this is fully backward compatible, and the test suite shows that no existing functionality is broken as a result.

This will allow the `pad()` method to be used with `box characters`, or whatever else might be needed.