### PR TITLE
Add DrawsTabs trait with tests

### DIFF
--- a/src/Themes/Default/Concerns/DrawsTabs.php
+++ b/src/Themes/Default/Concerns/DrawsTabs.php
@@ -39,11 +39,11 @@ trait DrawsTabs
 
         // automatic horizontal tab scrolling
         if ($strippedWidth($top_row) > $width) {
+            $scroll = $selected / ($tabs->count() - 1);
             $chars_to_kill = $strippedWidth($top_row) - $width;
-            $percent = $selected / ($tabs->count() - 1);
-            $left = (int) round($percent * $chars_to_kill);
+            $offset = (int) round($scroll * $chars_to_kill);
             foreach ([&$top_row, &$middle_row, &$bottom_row] as &$row) {
-                $row = mb_substr($row, $left, mb_strwidth($row) - $chars_to_kill);
+                $row = mb_substr($row, $offset, mb_strwidth($row) - $chars_to_kill);
             }
         }
 

--- a/src/Themes/Default/Concerns/DrawsTabs.php
+++ b/src/Themes/Default/Concerns/DrawsTabs.php
@@ -21,23 +21,34 @@ trait DrawsTabs
     ): string {
         $strippedWidth = fn (string $value): int => mb_strwidth($this->stripEscapeSequences($value));
 
+        // Build the top row for the tabs by adding whitespace equal
+        // to the width of each tab plus padding, or by adding an
+        // equal number of box characters for the selected tab.
         $top_row = $tabs->map(fn($value, $key) => $key === $selected
             ? '╭' . str_repeat('─', $strippedWidth($value) + 2) . '╮'
             : str_repeat(' ', $strippedWidth($value) + 4)
         )->implode('');
 
+        // Build the middle row for the tabs by adding the tab name
+        // surrounded by some padding. But if the tab is selected
+        // then highlight the tab and surround it in box chars.
         $middle_row = $tabs->map(fn($value, $key) => $key === $selected
             ? "{$this->dim('│')} {$this->{$color}($value)} {$this->dim('│')}"
             : "  {$value}  "
         )->implode('');
 
+        // Build the bottom row for the tabs by adding box characters equal to the width
+        // of each tab, plus padding. If the tab is selected, add the appropriate box
+        // characters instead. Finally, pad the whole line to fill the width fully.
         $bottom_row = $tabs->map(fn($value, $key) => $key === $selected
             ? '┴' . str_repeat('─', $strippedWidth($value) + 2) . '┴'
             : str_repeat('─', $strippedWidth($value) + 4)
         )->implode('');
         $bottom_row = $this->pad($bottom_row, $width, '─');
 
-        // automatic horizontal tab scrolling
+        // If the tabs are wider than the provided width, we need to trim the tabs to fit.
+        // We remove the appropriate number of characters from the beginning and end of
+        // each row by using the highlighted tab's index to get it's scroll position.
         if ($strippedWidth($top_row) > $width) {
             $scroll = $selected / ($tabs->count() - 1);
             $chars_to_kill = $strippedWidth($top_row) - $width;
@@ -47,6 +58,9 @@ trait DrawsTabs
             }
         }
 
+        // We wait until now to dim the top and bottom
+        // rows, otherwise the horizontal scrolling
+        // could easily strip those instructions.
         return collect([$this->dim($top_row), $middle_row, $this->dim($bottom_row)])->implode(PHP_EOL);
     }
 }

--- a/src/Themes/Default/Concerns/DrawsTabs.php
+++ b/src/Themes/Default/Concerns/DrawsTabs.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Laravel\Prompts\Themes\Default\Concerns;
+
+use Illuminate\Support\Collection;
+
+trait DrawsTabs
+{
+    use InteractsWithStrings;
+
+    /**
+     * Render a row of tabs.
+     *
+     * @param Collection<int, string>  $tabs
+     */
+    protected function tabs(
+        Collection $tabs,
+        int $selected,
+        int $width,
+        string $color = 'cyan',
+    ): string {
+        $strippedWidth = fn (string $value): int => mb_strwidth($this->stripEscapeSequences($value));
+
+        $top_row = $tabs->map(fn($value, $key) => $key === $selected
+            ? '╭' . str_repeat('─', $strippedWidth($value) + 2) . '╮'
+            : str_repeat(' ', $strippedWidth($value) + 4)
+        )->implode('');
+
+        $middle_row = $tabs->map(fn($value, $key) => $key === $selected
+            ? "{$this->dim('│')} {$this->{$color}($value)} {$this->dim('│')}"
+            : "  {$value}  "
+        )->implode('');
+
+        $bottom_row = $tabs->map(fn($value, $key) => $key === $selected
+            ? '┴' . str_repeat('─', $strippedWidth($value) + 2) . '┴'
+            : str_repeat('─', $strippedWidth($value) + 4)
+        )->implode('');
+        $bottom_row = $this->pad($bottom_row, $width, '─');
+
+        // automatic horizontal tab scrolling
+        if ($strippedWidth($top_row) > $width) {
+            $chars_to_kill = $strippedWidth($top_row) - $width;
+            $percent = $selected / ($tabs->count() - 1);
+            $left = (int) round($percent * $chars_to_kill);
+            foreach ([&$top_row, &$middle_row, &$bottom_row] as &$row) {
+                $row = mb_substr($row, $left, mb_strwidth($row) - $chars_to_kill);
+            }
+        }
+
+        return collect([$this->dim($top_row), $middle_row, $this->dim($bottom_row)])->implode(PHP_EOL);
+    }
+}

--- a/tests/Feature/DrawsTabsTest.php
+++ b/tests/Feature/DrawsTabsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use Illuminate\Support\Collection;
+use Laravel\Prompts\Prompt;
+use Laravel\Prompts\Themes\Default\Concerns\DrawsTabs;
+use Laravel\Prompts\Themes\Default\Renderer;
+
+class TestPrompt extends Prompt
+{
+    public function __construct(
+        public Collection $tabs,
+        public int $selected = 0,
+        public int $width = 60,
+    ) {
+        static::$themes['default'][static::class] = TestRenderer::class;
+    }
+
+    public function value(): mixed
+    {
+        return null;
+    }
+
+    public function display(): void
+    {
+        static::output()->write($this->renderTheme());
+    }
+}
+
+class TestRenderer extends Renderer
+{
+    use DrawsTabs;
+
+    public function __invoke(TestPrompt $prompt)
+    {
+        return $this->tabs($prompt->tabs, $prompt->selected, $prompt->width);
+    }
+}
+
+/**
+ * Note: Trailing whitespace is intentional in order to match the output.
+ * Removing it will cause the test to fail (correctly) while allowing
+ * the output to appear indistinguishable from the expected output.
+ */
+
+it('renders tabs', function () {
+    Prompt::fake();
+    
+    $tabs = collect(['One', 'Two', 'Three', 'Four', 'Five', 'Six']);
+
+    (new TestPrompt($tabs))->display();
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+    ╭─────╮                                       
+    │ One │  Two    Three    Four    Five    Six  
+    ┴─────┴─────────────────────────────────────────────────────
+    OUTPUT);
+});
+
+it('highlights tabs', function () {
+    Prompt::fake();
+
+    $tabs = collect(['One', 'Two', 'Three', 'Four', 'Five', 'Six']);
+
+    (new TestPrompt($tabs, 2))->display();
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+                  ╭───────╮                       
+      One    Two  │ Three │  Four    Five    Six  
+    ──────────────┴───────┴─────────────────────────────────────
+    OUTPUT);
+});
+
+it('truncates tabs', function () {
+    Prompt::fake();
+    
+    $tabs = collect(['One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight']);
+
+    (new TestPrompt($tabs))->display();
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+    ╭─────╮                                                     
+    │ One │  Two    Three    Four    Five    Six    Seven    Eig
+    ┴─────┴─────────────────────────────────────────────────────
+    OUTPUT);
+});
+
+it('scrolls tabs', function () {
+    Prompt::fake();
+
+    $tabs = collect(['One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight']);
+
+    (new TestPrompt($tabs, 7))->display();
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+                                                       ╭───────╮
+    e    Two    Three    Four    Five    Six    Seven  │ Eight │
+    ───────────────────────────────────────────────────┴───────┴
+    OUTPUT);
+});


### PR DESCRIPTION
This PR adds a trait that can be used in the same way as the `DrawsScrollbars` or `DrawsBoxes` traits to draw a series of tabs in a prompt. The selected index will be highlighted, and the tabs scroll horizontally automatically to make sure that the highlighted tab is **always** fully visible.

Example Usage:
```php
$this->tabs(
    tabs: collect(['One', 'Two', 'Three', 'Four', 'Five', 'Six']),
    selected: 0,
    width: 60,
);
```

Example Output:
```sh
    ╭─────╮                                       
    │ One │  Two    Three    Four    Five    Six  
    ┴─────┴─────────────────────────────────────────────────────
 ```

This could potentially be used at the top of a `box` for tabbed navigation in order to give extra context. Here's an example of this trait being used for exactly that purpose in a component I've built:

https://github.com/laravel/prompts/assets/1688608/3da28aa7-d77d-4fb5-b58c-27b51fcdc900