### PR TITLE
fix(helper): ensure helpers can't be redeclared

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -5,203 +5,245 @@ namespace Laravel\Prompts;
 use Closure;
 use Illuminate\Support\Collection;
 
-/**
- * Prompt the user for text input.
- */
-function text(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = ''): string
-{
-    return (new TextPrompt(...func_get_args()))->prompt();
-}
-
-/**
- * Prompt the user for multiline text input.
- */
-function textarea(string $label, string $placeholder = '', string $default = '', bool|string $required = false, ?Closure $validate = null, string $hint = '', int $rows = 5): string
-{
-    return (new TextareaPrompt($label, $placeholder, $default, $required, $validate, $hint, $rows))->prompt();
-}
-
-/**
- * Prompt the user for input, hiding the value.
- */
-function password(string $label, string $placeholder = '', bool|string $required = false, mixed $validate = null, string $hint = ''): string
-{
-    return (new PasswordPrompt(...func_get_args()))->prompt();
-}
-
-/**
- * Prompt the user to select an option.
- *
- * @param  array<int|string, string>|Collection<int|string, string>  $options
- * @param  true|string  $required
- */
-function select(string $label, array|Collection $options, int|string|null $default = null, int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true): int|string
-{
-    return (new SelectPrompt(...func_get_args()))->prompt();
-}
-
-/**
- * Prompt the user to select multiple options.
- *
- * @param  array<int|string, string>|Collection<int|string, string>  $options
- * @param  array<int|string>|Collection<int, int|string>  $default
- * @return array<int|string>
- */
-function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.'): array
-{
-    return (new MultiSelectPrompt(...func_get_args()))->prompt();
-}
-
-/**
- * Prompt the user to confirm an action.
- */
-function confirm(string $label, bool $default = true, string $yes = 'Yes', string $no = 'No', bool|string $required = false, mixed $validate = null, string $hint = ''): bool
-{
-    return (new ConfirmPrompt(...func_get_args()))->prompt();
-}
-
-/**
- * Prompt the user to continue or cancel after pausing.
- */
-function pause(string $message = 'Press enter to continue...'): bool
-{
-    return (new PausePrompt(...func_get_args()))->prompt();
-}
-
-/**
- * Prompt the user for text input with auto-completion.
- *
- * @param  array<string>|Collection<int, string>|Closure(string): array<string>  $options
- */
-function suggest(string $label, array|Collection|Closure $options, string $placeholder = '', string $default = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = ''): string
-{
-    return (new SuggestPrompt(...func_get_args()))->prompt();
-}
-
-/**
- * Allow the user to search for an option.
- *
- * @param  Closure(string): array<int|string, string>  $options
- * @param  true|string  $required
- */
-function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true): int|string
-{
-    return (new SearchPrompt(...func_get_args()))->prompt();
-}
-
-/**
- * Allow the user to search for multiple option.
- *
- * @param  Closure(string): array<int|string, string>  $options
- * @return array<int|string>
- */
-function multisearch(string $label, Closure $options, string $placeholder = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.'): array
-{
-    return (new MultiSearchPrompt(...func_get_args()))->prompt();
-}
-
-/**
- * Render a spinner while the given callback is executing.
- *
- * @template TReturn of mixed
- *
- * @param  \Closure(): TReturn  $callback
- * @return TReturn
- */
-function spin(Closure $callback, string $message = ''): mixed
-{
-    return (new Spinner($message))->spin($callback);
-}
-
-/**
- * Display a note.
- */
-function note(string $message, ?string $type = null): void
-{
-    (new Note($message, $type))->display();
-}
-
-/**
- * Display an error.
- */
-function error(string $message): void
-{
-    (new Note($message, 'error'))->display();
-}
-
-/**
- * Display a warning.
- */
-function warning(string $message): void
-{
-    (new Note($message, 'warning'))->display();
-}
-
-/**
- * Display an alert.
- */
-function alert(string $message): void
-{
-    (new Note($message, 'alert'))->display();
-}
-
-/**
- * Display an informational message.
- */
-function info(string $message): void
-{
-    (new Note($message, 'info'))->display();
-}
-
-/**
- * Display an introduction.
- */
-function intro(string $message): void
-{
-    (new Note($message, 'intro'))->display();
-}
-
-/**
- * Display a closing message.
- */
-function outro(string $message): void
-{
-    (new Note($message, 'outro'))->display();
-}
-
-/**
- * Display a table.
- *
- * @param  array<int, string|array<int, string>>|Collection<int, string|array<int, string>>  $headers
- * @param  array<int, array<int, string>>|Collection<int, array<int, string>>  $rows
- */
-function table(array|Collection $headers = [], array|Collection|null $rows = null): void
-{
-    (new Table($headers, $rows))->display();
-}
-
-/**
- * Display a progress bar.
- *
- * @template TSteps of iterable<mixed>|int
- * @template TReturn
- *
- * @param  TSteps  $steps
- * @param  ?Closure((TSteps is int ? int : value-of<TSteps>), Progress<TSteps>): TReturn  $callback
- * @return ($callback is null ? Progress<TSteps> : array<TReturn>)
- */
-function progress(string $label, iterable|int $steps, ?Closure $callback = null, string $hint = ''): array|Progress
-{
-    $progress = new Progress($label, $steps, $hint);
-
-    if ($callback !== null) {
-        return $progress->map($callback);
+if (! function_exists(\Laravel\Prompts\text::class)) {
+    /**
+     * Prompt the user for text input.
+     */
+    function text(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = ''): string
+    {
+        return (new TextPrompt(...func_get_args()))->prompt();
     }
-
-    return $progress;
 }
 
-function form(): FormBuilder
-{
-    return new FormBuilder();
+if (! function_exists(\Laravel\Prompts\textarea::class)) {
+    /**
+     * Prompt the user for multiline text input.
+     */
+    function textarea(string $label, string $placeholder = '', string $default = '', bool|string $required = false, ?Closure $validate = null, string $hint = '', int $rows = 5): string
+    {
+        return (new TextareaPrompt($label, $placeholder, $default, $required, $validate, $hint, $rows))->prompt();
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\password::class)) {
+    /**
+     * Prompt the user for input, hiding the value.
+     */
+    function password(string $label, string $placeholder = '', bool|string $required = false, mixed $validate = null, string $hint = ''): string
+    {
+        return (new PasswordPrompt(...func_get_args()))->prompt();
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\select::class)) {
+    /**
+     * Prompt the user to select an option.
+     *
+     * @param  array<int|string, string>|Collection<int|string, string>  $options
+     * @param  true|string  $required
+     */
+    function select(string $label, array|Collection $options, int|string|null $default = null, int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true): int|string
+    {
+        return (new SelectPrompt(...func_get_args()))->prompt();
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\multiselect::class)) {
+    /**
+     * Prompt the user to select multiple options.
+     *
+     * @param  array<int|string, string>|Collection<int|string, string>  $options
+     * @param  array<int|string>|Collection<int, int|string>  $default
+     * @return array<int|string>
+     */
+    function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.'): array
+    {
+        return (new MultiSelectPrompt(...func_get_args()))->prompt();
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\confirm::class)) {
+    /**
+     * Prompt the user to confirm an action.
+     */
+    function confirm(string $label, bool $default = true, string $yes = 'Yes', string $no = 'No', bool|string $required = false, mixed $validate = null, string $hint = ''): bool
+    {
+        return (new ConfirmPrompt(...func_get_args()))->prompt();
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\pause::class)) {
+    /**
+     * Prompt the user to continue or cancel after pausing.
+     */
+    function pause(string $message = 'Press enter to continue...'): bool
+    {
+        return (new PausePrompt(...func_get_args()))->prompt();
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\suggest::class)) {
+    /**
+     * Prompt the user for text input with auto-completion.
+     *
+     * @param  array<string>|Collection<int, string>|Closure(string): array<string>  $options
+     */
+    function suggest(string $label, array|Collection|Closure $options, string $placeholder = '', string $default = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = ''): string
+    {
+        return (new SuggestPrompt(...func_get_args()))->prompt();
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\search::class)) {
+    /**
+     * Allow the user to search for an option.
+     *
+     * @param  Closure(string): array<int|string, string>  $options
+     * @param  true|string  $required
+     */
+    function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true): int|string
+    {
+        return (new SearchPrompt(...func_get_args()))->prompt();
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\multisearch::class)) {
+    /**
+     * Allow the user to search for multiple option.
+     *
+     * @param  Closure(string): array<int|string, string>  $options
+     * @return array<int|string>
+     */
+    function multisearch(string $label, Closure $options, string $placeholder = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.'): array
+    {
+        return (new MultiSearchPrompt(...func_get_args()))->prompt();
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\spin::class)) {
+    /**
+     * Render a spinner while the given callback is executing.
+     *
+     * @template TReturn of mixed
+     *
+     * @param  \Closure(): TReturn  $callback
+     * @return TReturn
+     */
+    function spin(Closure $callback, string $message = ''): mixed
+    {
+        return (new Spinner($message))->spin($callback);
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\note::class)) {
+    /**
+     * Display a note.
+     */
+    function note(string $message, ?string $type = null): void
+    {
+        (new Note($message, $type))->display();
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\error::class)) {
+    /**
+     * Display an error.
+     */
+    function error(string $message): void
+    {
+        (new Note($message, 'error'))->display();
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\warning::class)) {
+    /**
+     * Display a warning.
+     */
+    function warning(string $message): void
+    {
+        (new Note($message, 'warning'))->display();
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\alert::class)) {
+    /**
+     * Display an alert.
+     */
+    function alert(string $message): void
+    {
+        (new Note($message, 'alert'))->display();
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\info::class)) {
+    /**
+     * Display an informational message.
+     */
+    function info(string $message): void
+    {
+        (new Note($message, 'info'))->display();
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\intro::class)) {
+    /**
+     * Display an introduction.
+     */
+    function intro(string $message): void
+    {
+        (new Note($message, 'intro'))->display();
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\outro::class)) {
+    /**
+     * Display a closing message.
+     */
+    function outro(string $message): void
+    {
+        (new Note($message, 'outro'))->display();
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\table::class)) {
+    /**
+     * Display a table.
+     *
+     * @param  array<int, string|array<int, string>>|Collection<int, string|array<int, string>>  $headers
+     * @param  array<int, array<int, string>>|Collection<int, array<int, string>>  $rows
+     */
+    function table(array|Collection $headers = [], array|Collection|null $rows = null): void
+    {
+        (new Table($headers, $rows))->display();
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\progress::class)) {
+    /**
+     * Display a progress bar.
+     *
+     * @template TSteps of iterable<mixed>|int
+     * @template TReturn
+     *
+     * @param  TSteps  $steps
+     * @param  ?Closure((TSteps is int ? int : value-of<TSteps>), Progress<TSteps>): TReturn  $callback
+     * @return ($callback is null ? Progress<TSteps> : array<TReturn>)
+     */
+    function progress(string $label, iterable|int $steps, ?Closure $callback = null, string $hint = ''): array|Progress
+    {
+        $progress = new Progress($label, $steps, $hint);
+
+        if ($callback !== null) {
+            return $progress->map($callback);
+        }
+
+        return $progress;
+    }
+}
+
+if (! function_exists(\Laravel\Prompts\form::class)) {
+    function form(): FormBuilder
+    {
+        return new FormBuilder();
+    }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -5,7 +5,7 @@ namespace Laravel\Prompts;
 use Closure;
 use Illuminate\Support\Collection;
 
-if (! function_exists(\Laravel\Prompts\text::class)) {
+if (! function_exists('\Laravel\Prompts\text')) {
     /**
      * Prompt the user for text input.
      */
@@ -15,7 +15,7 @@ if (! function_exists(\Laravel\Prompts\text::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\textarea::class)) {
+if (! function_exists('\Laravel\Prompts\textarea')) {
     /**
      * Prompt the user for multiline text input.
      */
@@ -25,7 +25,7 @@ if (! function_exists(\Laravel\Prompts\textarea::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\password::class)) {
+if (! function_exists('\Laravel\Prompts\password')) {
     /**
      * Prompt the user for input, hiding the value.
      */
@@ -35,7 +35,7 @@ if (! function_exists(\Laravel\Prompts\password::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\select::class)) {
+if (! function_exists('\Laravel\Prompts\select')) {
     /**
      * Prompt the user to select an option.
      *
@@ -48,7 +48,7 @@ if (! function_exists(\Laravel\Prompts\select::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\multiselect::class)) {
+if (! function_exists('\Laravel\Prompts\multiselect')) {
     /**
      * Prompt the user to select multiple options.
      *
@@ -62,7 +62,7 @@ if (! function_exists(\Laravel\Prompts\multiselect::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\confirm::class)) {
+if (! function_exists('\Laravel\Prompts\confirm')) {
     /**
      * Prompt the user to confirm an action.
      */
@@ -72,7 +72,7 @@ if (! function_exists(\Laravel\Prompts\confirm::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\pause::class)) {
+if (! function_exists('\Laravel\Prompts\pause')) {
     /**
      * Prompt the user to continue or cancel after pausing.
      */
@@ -82,7 +82,7 @@ if (! function_exists(\Laravel\Prompts\pause::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\suggest::class)) {
+if (! function_exists('\Laravel\Prompts\suggest')) {
     /**
      * Prompt the user for text input with auto-completion.
      *
@@ -94,7 +94,7 @@ if (! function_exists(\Laravel\Prompts\suggest::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\search::class)) {
+if (! function_exists('\Laravel\Prompts\search')) {
     /**
      * Allow the user to search for an option.
      *
@@ -107,7 +107,7 @@ if (! function_exists(\Laravel\Prompts\search::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\multisearch::class)) {
+if (! function_exists('\Laravel\Prompts\multisearch')) {
     /**
      * Allow the user to search for multiple option.
      *
@@ -120,7 +120,7 @@ if (! function_exists(\Laravel\Prompts\multisearch::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\spin::class)) {
+if (! function_exists('\Laravel\Prompts\spin')) {
     /**
      * Render a spinner while the given callback is executing.
      *
@@ -135,7 +135,7 @@ if (! function_exists(\Laravel\Prompts\spin::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\note::class)) {
+if (! function_exists('\Laravel\Prompts\note')) {
     /**
      * Display a note.
      */
@@ -145,7 +145,7 @@ if (! function_exists(\Laravel\Prompts\note::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\error::class)) {
+if (! function_exists('\Laravel\Prompts\error')) {
     /**
      * Display an error.
      */
@@ -155,7 +155,7 @@ if (! function_exists(\Laravel\Prompts\error::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\warning::class)) {
+if (! function_exists('\Laravel\Prompts\warning')) {
     /**
      * Display a warning.
      */
@@ -165,7 +165,7 @@ if (! function_exists(\Laravel\Prompts\warning::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\alert::class)) {
+if (! function_exists('\Laravel\Prompts\alert')) {
     /**
      * Display an alert.
      */
@@ -175,7 +175,7 @@ if (! function_exists(\Laravel\Prompts\alert::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\info::class)) {
+if (! function_exists('\Laravel\Prompts\info')) {
     /**
      * Display an informational message.
      */
@@ -185,7 +185,7 @@ if (! function_exists(\Laravel\Prompts\info::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\intro::class)) {
+if (! function_exists('\Laravel\Prompts\intro')) {
     /**
      * Display an introduction.
      */
@@ -195,7 +195,7 @@ if (! function_exists(\Laravel\Prompts\intro::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\outro::class)) {
+if (! function_exists('\Laravel\Prompts\outro')) {
     /**
      * Display a closing message.
      */
@@ -205,7 +205,7 @@ if (! function_exists(\Laravel\Prompts\outro::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\table::class)) {
+if (! function_exists('\Laravel\Prompts\table')) {
     /**
      * Display a table.
      *
@@ -218,7 +218,7 @@ if (! function_exists(\Laravel\Prompts\table::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\progress::class)) {
+if (! function_exists('\Laravel\Prompts\progress')) {
     /**
      * Display a progress bar.
      *
@@ -241,7 +241,7 @@ if (! function_exists(\Laravel\Prompts\progress::class)) {
     }
 }
 
-if (! function_exists(\Laravel\Prompts\form::class)) {
+if (! function_exists('\Laravel\Prompts\form')) {
     function form(): FormBuilder
     {
         return new FormBuilder();


### PR DESCRIPTION
To make packages like `symfony/var-dumper` available globally you prepend the global Composer `autoload.php` like so:

```
// php.ini

auto_prepend_file = ${HOME}/.composer/vendor/autoload.php
```
<img width="1333" alt="image" src="https://github.com/laravel/prompts/assets/32384907/4d04fced-d62f-4fa6-9698-743bb06a4c5e">

From: https://symfony.com/doc/current/components/var_dumper.html

To reproduce, at least these must be installed.

```
// composer

laravel/installer (global)
symfony/var-dumper (global)
laravel/framework (project)
phpstan/phpstan (project)
```

Then run PhpStan in a project.

```
// cli

$ vendor/bin/phpstan analyse Common
```

Result.

```
Fatal error: Cannot redeclare Laravel\Prompts\text() (previously declared in ~/.composer/vendor/laravel/prompts/src/helpers.php:11) in XXX/vendor/laravel/prompts/src/helpers.php on line 13

Call Stack:
0.0325    1260304   1. {main}() XXX/vendor/bin/phpstan:0
0.0325    1261384   2. include('XXX/vendor/phpstan/phpstan/phpstan') XXX/vendor/bin/phpstan:119
0.0754    4122912   3. require('phar://XXX/vendor/phpstan/phpstan/phpstan.phar/bin/phpstan') XXX/vendor/phpstan/phpstan/phpstan:8
0.0754    4123296   4. _PHPStan_7961f7ae1\{closure:phar://XXX/vendor/phpstan/phpstan/phpstan.phar/bin/phpstan:13-125}() phar://XXX/vendor/phpstan/phpstan/phpstan.phar/bin/phpstan:125
0.1766   36372104   5. require_once('XXX/vendor/autoload.php') phar://XXX/vendor/phpstan/phpstan/phpstan.phar/bin/phpstan:66
0.1766   36378600   6. ComposerAutoloaderInit9c491b8531eec05ba41a11d9276a5749::getLoader() XXX/vendor/autoload.php:25
0.1838   39023408   7. {closure:XXX/vendor/composer/autoload_real.php:37-43}($fileIdentifier = '47e1160838b5e5a10346ac4084b58c23', $file = 'XXX/vendor/composer/../laravel/prompts/src/helpers.php') XXX/vendor/composer/autoload_real.php:45
```

### Notes
- I did a Composer global update, and installed phpstan in the same time. Didn't dig deeper what causes the bug. But same as with other Laravel `helper.php` functions, I think they should be protected against redeclaration. This PR adds the required checks.
- Tests pass. I don't think it will break something. However, give it a deep second thought please. :)
- Diff here on GH is messed. In PhpStorm it's better.

---

_Amazing_ work here btw, Jess. Thank you! 🫡❤️