### PR TITLE
Ignore PHPstan error

### DIFF
--- a/src/Themes/Default/Concerns/DrawsScrollbars.php
+++ b/src/Themes/Default/Concerns/DrawsScrollbars.php
@@ -20,7 +20,7 @@ trait DrawsScrollbars
 
         $scrollPosition = $this->scrollPosition($firstVisible, $height, $total);
 
-        return $visible
+        return $visible // @phpstan-ignore return.type
             ->values()
             ->map(fn ($line) => $this->pad($line, $width))
             ->map(fn ($line, $index) => match ($index) {


### PR DESCRIPTION
This fixes a new PHPStan error that should never occur in practice. The `preg_replace` calls on the lines below should always return a string. Ideally it would throw an exception on failure instead of null, but I don't want to pull in the "safe" library just to fix this.
