### PR TITLE
Extract Looping Mechanisms

### DIFF
--- a/src/Concerns/FakesInputOutput.php
+++ b/src/Concerns/FakesInputOutput.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Prompts\Concerns;
 
+use Closure;
 use Laravel\Prompts\Output\BufferedConsoleOutput;
 use Laravel\Prompts\Terminal;
 use PHPUnit\Framework\Assert;
@@ -29,13 +30,20 @@ trait FakesInputOutput
         $mock->shouldReceive('lines')->byDefault()->andReturn(24);
         $mock->shouldReceive('initDimensions')->byDefault();
 
-        foreach ($keys as $key) {
+        static::fakeKeyPresses($keys, function (string $key) use ($mock) {
             $mock->shouldReceive('read')->once()->andReturn($key);
-        }
+        });
 
         static::$terminal = $mock;
 
         static::setOutput(new BufferedConsoleOutput());
+    }
+
+    public static function fakeKeyPresses(array $keys, Closure $closure): void
+    {
+        foreach ($keys as $key) {
+            $closure($key);
+        }
     }
 
     /**

--- a/src/Concerns/FakesInputOutput.php
+++ b/src/Concerns/FakesInputOutput.php
@@ -39,6 +39,11 @@ trait FakesInputOutput
         static::setOutput(new BufferedConsoleOutput());
     }
 
+    /**
+     * Implementation of the looping mechanism for simulating key presses.
+     *
+     * @param  array<string>  $keys
+     */
     public static function fakeKeyPresses(array $keys, Closure $closure): void
     {
         foreach ($keys as $key) {

--- a/src/Concerns/FakesInputOutput.php
+++ b/src/Concerns/FakesInputOutput.php
@@ -35,7 +35,7 @@ trait FakesInputOutput
 
         static::$terminal = $mock;
 
-        self::setOutput(new BufferedConsoleOutput());
+        static::setOutput(new BufferedConsoleOutput());
     }
 
     /**

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -5,6 +5,7 @@ namespace Laravel\Prompts;
 use Closure;
 use Laravel\Prompts\Exceptions\FormRevertedException;
 use Laravel\Prompts\Output\ConsoleOutput;
+use Laravel\Prompts\Support\Nothing;
 use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
@@ -122,7 +123,7 @@ abstract class Prompt
             $this->hideCursor();
             $this->render();
 
-            while (($key = static::terminal()->read()) !== null) {
+            $result = $this->runLoop(function (string $key): mixed {
                 $continue = $this->handleKeyPress($key);
 
                 $this->render();
@@ -142,10 +143,36 @@ abstract class Prompt
 
                     return $this->value();
                 }
-            }
+
+                // `null` is a valid return value for this loop
+                // so we'll return an instance of Nothing to
+                // indicate that the loop should continue.
+                return new Nothing;
+            });
+
+            return $result;
         } finally {
             $this->clearListeners();
         }
+    }
+
+    public function runLoop(callable $callable): mixed
+    {
+        while(($key = static::terminal()->read()) !== null) {
+            $result = $callable($key);
+
+            if (! $this->is_nothing($result)) {
+                return $result;
+            }
+        }
+    }
+
+    /**
+     * Check if the provided item is an instance of Nothing.
+     */
+    public function is_nothing(mixed $item): bool
+    {
+        return is_object($item) && is_a($item, Nothing::class);
     }
 
     /**

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -179,7 +179,7 @@ abstract class Prompt
      */
     public static function setOutput(OutputInterface $output): void
     {
-        self::$output = $output;
+        static::$output = $output;
     }
 
     /**
@@ -187,7 +187,7 @@ abstract class Prompt
      */
     protected static function output(): OutputInterface
     {
-        return self::$output ??= new ConsoleOutput();
+        return static::$output ??= new ConsoleOutput();
     }
 
     /**

--- a/src/Support/Nothing.php
+++ b/src/Support/Nothing.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Prompts\Support;
+
+/**
+ * Nothing.
+ * 
+ * `null` is a valid return value, so we use `Nothing`
+ * to indicate that a given loop should continue.
+ */
+class Nothing
+{
+    //
+}


### PR DESCRIPTION
I've successfully implemented an asynchronous, non-blocking prompt, which can simply extend our existing abstract prompt, leaving backwards compatibility unaffected. By using a `reactphp` event loop, I'm able to trigger renders and do other operations at any time since reading terminal input is no longer a blocking operation. This can almost certainly remove our reliance on `forking` using the `Process Control` extension in the `Spinner` class, ~~and there's a **slight** chance that it could solve our Windows story (I still have to verify this, so don't quote me)~~. It also happens to enable me to do some **really cool stuff** involving _websockets_ that I'll have ready soon.

However, **none** of that is in _this_ PR.

This PR is exclusively to make my new feature compatible with Laravel Prompts irrespective of its ultimate home (I'm totally fine with it living in my `community prompts` package if that's what has to happen).

- I've updated any references to `self` to `static` when setting or getting the `ConsoleOutput` object so that the `$output` static property is set on the **child**.
- I've extracted the loop for registering keypress mocks into a method that can be overridden in an extending class.
- I've extracted the looping mechanism in the `prompt` method which can now _also_ be overridden in an extending class.
- I've added an empty `Nothing` support class.

Since the `while` loop is now a function, if we were to rely on returning `null` to continue looping, we could no longer return `null` from any prompt. Since `null` is a valid return value, I needed a way to, in effect, check for a `void` return.

**edit**: I checked, and non-blocking i/o still wont work on Windows.