### PR TITLE
Allow re-rendering during progress callback

### DIFF
--- a/src/Progress.php
+++ b/src/Progress.php
@@ -141,9 +141,13 @@ class Progress extends Prompt
     /**
      * Update the label.
      */
-    public function label(string $label): static
+    public function label(string $label, bool $force = false): static
     {
         $this->label = $label;
+
+        if ($force) {
+            $this->render();
+        }
 
         return $this;
     }
@@ -151,9 +155,13 @@ class Progress extends Prompt
     /**
      * Update the hint.
      */
-    public function hint(string $hint): static
+    public function hint(string $hint, bool $force = false): static
     {
         $this->hint = $hint;
+
+        if ($force) {
+            $this->render();
+        }
 
         return $this;
     }

--- a/src/Progress.php
+++ b/src/Progress.php
@@ -139,15 +139,19 @@ class Progress extends Prompt
     }
 
     /**
+     * Force the progress bar to re-render.
+     */
+    public function render(): void
+    {
+        parent::render();
+    }
+
+    /**
      * Update the label.
      */
-    public function label(string $label, bool $force = false): static
+    public function label(string $label): static
     {
         $this->label = $label;
-
-        if ($force) {
-            $this->render();
-        }
 
         return $this;
     }
@@ -155,13 +159,9 @@ class Progress extends Prompt
     /**
      * Update the hint.
      */
-    public function hint(string $hint, bool $force = false): static
+    public function hint(string $hint): static
     {
         $this->hint = $hint;
-
-        if ($force) {
-            $this->render();
-        }
 
         return $this;
     }


### PR DESCRIPTION
This PR allows developers to update the `progress` label and hint at any point during their callback by calling the `render` method on the `Progress` class. Previously, a re-render only occurred between each step, so updating the label or hint to reflect what was about to happen was not possible.

```php
progress(
    label: 'Uploading...',
    steps: [
        'file1.zip',
        'file2.zip',
        'file3.zip',
    ],
    callback: function ($step, $progress) {
        $progress
            ->label("Uploading {$step}...")
            ->hint(rand(5, 10).'MB')
            ->render();

        sleep(5);

        // It doesn't make sense to call `render` here because the prompt will already
        // re-render to update the progress bar once this callback is completed.
        $progress->label("Uploaded {$step}");
    },
);
```

Additional render calls on each iteration can add up to a meaningful delay over a lot of iterations, so I don't think it makes sense to always force a re-render on every call to the `label` or `hint` methods.

Fixes #153 