### PR TITLE
Add transformation support

### DIFF
--- a/playground/text.php
+++ b/playground/text.php
@@ -13,6 +13,7 @@ $email = text(
         default => null,
     },
     hint: 'We will never share your email address with anyone else.',
+    transform: fn ($value) => strtolower($value),
 );
 
 var_dump($email);

--- a/playground/textarea.php
+++ b/playground/textarea.php
@@ -4,11 +4,11 @@ use function Laravel\Prompts\textarea;
 
 require __DIR__.'/../vendor/autoload.php';
 
-$email = textarea(
+$story = textarea(
     label: 'Tell me a story',
     placeholder: 'Weave me a tale',
 );
 
-var_dump($email);
+var_dump($story);
 
 echo str_repeat(PHP_EOL, 5);

--- a/src/ConfirmPrompt.php
+++ b/src/ConfirmPrompt.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Prompts;
 
+use Closure;
+
 class ConfirmPrompt extends Prompt
 {
     /**
@@ -20,6 +22,7 @@ class ConfirmPrompt extends Prompt
         public bool|string $required = false,
         public mixed $validate = null,
         public string $hint = '',
+        public ?Closure $transform = null,
     ) {
         $this->confirmed = $default;
 

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -78,7 +78,7 @@ class FormBuilder
     /**
      * Prompt the user for text input.
      */
-    public function text(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null): self
+    public function text(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null): self
     {
         return $this->runPrompt(text(...), get_defined_vars());
     }
@@ -86,7 +86,7 @@ class FormBuilder
     /**
      * Prompt the user for multiline text input.
      */
-    public function textarea(string $label, string $placeholder = '', string $default = '', bool|string $required = false, ?Closure $validate = null, string $hint = '', int $rows = 5, ?string $name = null): self
+    public function textarea(string $label, string $placeholder = '', string $default = '', bool|string $required = false, ?Closure $validate = null, string $hint = '', int $rows = 5, ?string $name = null, ?Closure $transform = null): self
     {
         return $this->runPrompt(textarea(...), get_defined_vars());
     }
@@ -94,7 +94,7 @@ class FormBuilder
     /**
      * Prompt the user for input, hiding the value.
      */
-    public function password(string $label, string $placeholder = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null): self
+    public function password(string $label, string $placeholder = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null): self
     {
         return $this->runPrompt(password(...), get_defined_vars());
     }
@@ -105,7 +105,7 @@ class FormBuilder
      * @param  array<int|string, string>|Collection<int|string, string>  $options
      * @param  true|string  $required
      */
-    public function select(string $label, array|Collection $options, int|string|null $default = null, int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?string $name = null): self
+    public function select(string $label, array|Collection $options, int|string|null $default = null, int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?string $name = null, ?Closure $transform = null): self
     {
         return $this->runPrompt(select(...), get_defined_vars());
     }
@@ -116,7 +116,7 @@ class FormBuilder
      * @param  array<int|string, string>|Collection<int|string, string>  $options
      * @param  array<int|string>|Collection<int, int|string>  $default
      */
-    public function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null): self
+    public function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null, ?Closure $transform = null): self
     {
         return $this->runPrompt(multiselect(...), get_defined_vars());
     }
@@ -124,7 +124,7 @@ class FormBuilder
     /**
      * Prompt the user to confirm an action.
      */
-    public function confirm(string $label, bool $default = true, string $yes = 'Yes', string $no = 'No', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null): self
+    public function confirm(string $label, bool $default = true, string $yes = 'Yes', string $no = 'No', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null): self
     {
         return $this->runPrompt(confirm(...), get_defined_vars());
     }
@@ -142,7 +142,7 @@ class FormBuilder
      *
      * @param  array<string>|Collection<int, string>|Closure(string): array<string>  $options
      */
-    public function suggest(string $label, array|Collection|Closure $options, string $placeholder = '', string $default = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null): self
+    public function suggest(string $label, array|Collection|Closure $options, string $placeholder = '', string $default = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null): self
     {
         return $this->runPrompt(suggest(...), get_defined_vars());
     }
@@ -153,7 +153,7 @@ class FormBuilder
      * @param  Closure(string): array<int|string, string>  $options
      * @param  true|string  $required
      */
-    public function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?string $name = null): self
+    public function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?string $name = null, ?Closure $transform = null): self
     {
         return $this->runPrompt(search(...), get_defined_vars());
     }
@@ -163,7 +163,7 @@ class FormBuilder
      *
      * @param  Closure(string): array<int|string, string>  $options
      */
-    public function multisearch(string $label, Closure $options, string $placeholder = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null): self
+    public function multisearch(string $label, Closure $options, string $placeholder = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null, ?Closure $transform = null): self
     {
         return $this->runPrompt(multisearch(...), get_defined_vars());
     }

--- a/src/MultiSearchPrompt.php
+++ b/src/MultiSearchPrompt.php
@@ -42,6 +42,7 @@ class MultiSearchPrompt extends Prompt
         public bool|string $required = false,
         public mixed $validate = null,
         public string $hint = '',
+        public ?Closure $transform = null,
     ) {
         $this->trackTypedValue(submit: false, ignore: fn ($key) => Key::oneOf([Key::SPACE, Key::HOME, Key::END, Key::CTRL_A, Key::CTRL_E], $key) && $this->highlighted !== null);
 

--- a/src/MultiSelectPrompt.php
+++ b/src/MultiSelectPrompt.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Prompts;
 
+use Closure;
 use Illuminate\Support\Collection;
 
 class MultiSelectPrompt extends Prompt
@@ -43,6 +44,7 @@ class MultiSelectPrompt extends Prompt
         public bool|string $required = false,
         public mixed $validate = null,
         public string $hint = '',
+        public ?Closure $transform = null,
     ) {
         $this->options = $options instanceof Collection ? $options->all() : $options;
         $this->default = $default instanceof Collection ? $default->all() : $default;

--- a/src/PasswordPrompt.php
+++ b/src/PasswordPrompt.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Prompts;
 
+use Closure;
+
 class PasswordPrompt extends Prompt
 {
     use Concerns\TypedValue;
@@ -15,6 +17,7 @@ class PasswordPrompt extends Prompt
         public bool|string $required = false,
         public mixed $validate = null,
         public string $hint = '',
+        public ?Closure $transform = null,
     ) {
         $this->trackTypedValue();
     }

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -345,6 +345,9 @@ abstract class Prompt
         return call_user_func($this->transform, $value);
     }
 
+    /**
+     * Get the transformed value of the prompt.
+     */
     protected function transformedValue(): mixed
     {
         return $this->transform($this->value());

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -51,6 +51,11 @@ abstract class Prompt
     public bool|string $required;
 
     /**
+     * The transformation callback.
+     */
+    public ?Closure $transform = null;
+
+    /**
      * The validator callback or rules.
      */
     public mixed $validate;
@@ -140,7 +145,7 @@ abstract class Prompt
                         throw new FormRevertedException();
                     }
 
-                    return $this->value();
+                    return $this->transformedValue();
                 }
             }
         } finally {
@@ -277,7 +282,7 @@ abstract class Prompt
      */
     protected function submit(): void
     {
-        $this->validate($this->value());
+        $this->validate($this->transformedValue());
 
         if ($this->state !== 'error') {
             $this->state = 'submit';
@@ -322,10 +327,27 @@ abstract class Prompt
         }
 
         if ($this->validated) {
-            $this->validate($this->value());
+            $this->validate($this->transformedValue());
         }
 
         return true;
+    }
+
+    /**
+     * Transform the input.
+     */
+    private function transform(mixed $value): mixed
+    {
+        if (is_null($this->transform)) {
+            return $value;
+        }
+
+        return call_user_func($this->transform, $value);
+    }
+
+    protected function transformedValue(): mixed
+    {
+        return $this->transform($this->value());
     }
 
     /**

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -31,6 +31,7 @@ class SearchPrompt extends Prompt
         public mixed $validate = null,
         public string $hint = '',
         public bool|string $required = true,
+        public ?Closure $transform = null,
     ) {
         if ($this->required === false) {
             throw new InvalidArgumentException('Argument [required] must be true or a string.');

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -2,8 +2,9 @@
 
 namespace Laravel\Prompts;
 
-use Illuminate\Support\Collection;
+use Closure;
 use InvalidArgumentException;
+use Illuminate\Support\Collection;
 
 class SelectPrompt extends Prompt
 {
@@ -29,6 +30,7 @@ class SelectPrompt extends Prompt
         public mixed $validate = null,
         public string $hint = '',
         public bool|string $required = true,
+        public ?Closure $transform = null,
     ) {
         if ($this->required === false) {
             throw new InvalidArgumentException('Argument [required] must be true or a string.');

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -3,8 +3,8 @@
 namespace Laravel\Prompts;
 
 use Closure;
-use InvalidArgumentException;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 
 class SelectPrompt extends Prompt
 {

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -39,6 +39,7 @@ class SuggestPrompt extends Prompt
         public bool|string $required = false,
         public mixed $validate = null,
         public string $hint = '',
+        public ?Closure $transform = null,
     ) {
         $this->options = $options instanceof Collection ? $options->all() : $options;
 

--- a/src/TextPrompt.php
+++ b/src/TextPrompt.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Prompts;
 
+use Closure;
+
 class TextPrompt extends Prompt
 {
     use Concerns\TypedValue;
@@ -16,6 +18,7 @@ class TextPrompt extends Prompt
         public bool|string $required = false,
         public mixed $validate = null,
         public string $hint = '',
+        public ?Closure $transform = null,
     ) {
         $this->trackTypedValue($default);
     }

--- a/src/TextareaPrompt.php
+++ b/src/TextareaPrompt.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Prompts;
 
+use Closure;
+
 class TextareaPrompt extends Prompt
 {
     use Concerns\Scrolling;
@@ -24,6 +26,7 @@ class TextareaPrompt extends Prompt
         public mixed $validate = null,
         public string $hint = '',
         int $rows = 5,
+        public ?Closure $transform = null,
     ) {
         $this->scroll = $rows;
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -21,7 +21,7 @@ if (! function_exists('\Laravel\Prompts\textarea')) {
      */
     function textarea(string $label, string $placeholder = '', string $default = '', bool|string $required = false, ?Closure $validate = null, string $hint = '', int $rows = 5, ?Closure $transform = null): string
     {
-        return (new TextareaPrompt($label, $placeholder, $default, $required, $validate, $hint, $rows, $transform))->prompt();
+        return (new TextareaPrompt(...func_get_args()))->prompt();
     }
 }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -9,7 +9,7 @@ if (! function_exists('\Laravel\Prompts\text')) {
     /**
      * Prompt the user for text input.
      */
-    function text(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = ''): string
+    function text(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?Closure $transform = null): string
     {
         return (new TextPrompt(...func_get_args()))->prompt();
     }
@@ -19,9 +19,9 @@ if (! function_exists('\Laravel\Prompts\textarea')) {
     /**
      * Prompt the user for multiline text input.
      */
-    function textarea(string $label, string $placeholder = '', string $default = '', bool|string $required = false, ?Closure $validate = null, string $hint = '', int $rows = 5): string
+    function textarea(string $label, string $placeholder = '', string $default = '', bool|string $required = false, ?Closure $validate = null, string $hint = '', int $rows = 5, ?Closure $transform = null): string
     {
-        return (new TextareaPrompt($label, $placeholder, $default, $required, $validate, $hint, $rows))->prompt();
+        return (new TextareaPrompt($label, $placeholder, $default, $required, $validate, $hint, $rows, $transform))->prompt();
     }
 }
 
@@ -29,7 +29,7 @@ if (! function_exists('\Laravel\Prompts\password')) {
     /**
      * Prompt the user for input, hiding the value.
      */
-    function password(string $label, string $placeholder = '', bool|string $required = false, mixed $validate = null, string $hint = ''): string
+    function password(string $label, string $placeholder = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?Closure $transform = null): string
     {
         return (new PasswordPrompt(...func_get_args()))->prompt();
     }
@@ -42,7 +42,7 @@ if (! function_exists('\Laravel\Prompts\select')) {
      * @param  array<int|string, string>|Collection<int|string, string>  $options
      * @param  true|string  $required
      */
-    function select(string $label, array|Collection $options, int|string|null $default = null, int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true): int|string
+    function select(string $label, array|Collection $options, int|string|null $default = null, int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?Closure $transform = null): int|string
     {
         return (new SelectPrompt(...func_get_args()))->prompt();
     }
@@ -56,7 +56,7 @@ if (! function_exists('\Laravel\Prompts\multiselect')) {
      * @param  array<int|string>|Collection<int, int|string>  $default
      * @return array<int|string>
      */
-    function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.'): array
+    function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?Closure $transform = null): array
     {
         return (new MultiSelectPrompt(...func_get_args()))->prompt();
     }
@@ -66,7 +66,7 @@ if (! function_exists('\Laravel\Prompts\confirm')) {
     /**
      * Prompt the user to confirm an action.
      */
-    function confirm(string $label, bool $default = true, string $yes = 'Yes', string $no = 'No', bool|string $required = false, mixed $validate = null, string $hint = ''): bool
+    function confirm(string $label, bool $default = true, string $yes = 'Yes', string $no = 'No', bool|string $required = false, mixed $validate = null, string $hint = '', ?Closure $transform = null): bool
     {
         return (new ConfirmPrompt(...func_get_args()))->prompt();
     }
@@ -88,7 +88,7 @@ if (! function_exists('\Laravel\Prompts\suggest')) {
      *
      * @param  array<string>|Collection<int, string>|Closure(string): array<string>  $options
      */
-    function suggest(string $label, array|Collection|Closure $options, string $placeholder = '', string $default = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = ''): string
+    function suggest(string $label, array|Collection|Closure $options, string $placeholder = '', string $default = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = '', ?Closure $transform = null): string
     {
         return (new SuggestPrompt(...func_get_args()))->prompt();
     }
@@ -101,7 +101,7 @@ if (! function_exists('\Laravel\Prompts\search')) {
      * @param  Closure(string): array<int|string, string>  $options
      * @param  true|string  $required
      */
-    function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true): int|string
+    function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?Closure $transform = null): int|string
     {
         return (new SearchPrompt(...func_get_args()))->prompt();
     }
@@ -114,7 +114,7 @@ if (! function_exists('\Laravel\Prompts\multisearch')) {
      * @param  Closure(string): array<int|string, string>  $options
      * @return array<int|string>
      */
-    function multisearch(string $label, Closure $options, string $placeholder = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.'): array
+    function multisearch(string $label, Closure $options, string $placeholder = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?Closure $transform = null): array
     {
         return (new MultiSearchPrompt(...func_get_args()))->prompt();
     }

--- a/tests/Feature/ConfirmPromptTest.php
+++ b/tests/Feature/ConfirmPromptTest.php
@@ -65,6 +65,17 @@ it('allows the labels to be changed', function () {
     Prompt::assertOutputContains('No, gracias');
 });
 
+it('transforms values', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = confirm(
+        label: 'Are you sure?',
+        transform: fn ($value) => ! $value,
+    );
+
+    expect($result)->toBeFalse();
+});
+
 it('validates', function () {
     Prompt::fake([Key::ENTER, 'y', Key::ENTER]);
 

--- a/tests/Feature/MultiSearchPromptTest.php
+++ b/tests/Feature/MultiSearchPromptTest.php
@@ -252,6 +252,22 @@ it('supports no default results', function ($options, $expected) {
     ],
 ]);
 
+it('transforms values', function () {
+    Prompt::fake([Key::DOWN, Key::CTRL_A, Key::ENTER]);
+
+    $result = multisearch(
+        label: 'What are your favorite colors?',
+        options: fn () => [
+            'red' => 'Red',
+            'green' => 'Green',
+            'blue' => 'Blue',
+        ],
+        transform: fn ($value) => array_map('strtoupper', $value),
+    );
+
+    expect($result)->toBe(['RED', 'GREEN', 'BLUE']);
+});
+
 it('validates', function () {
     Prompt::fake(['a', Key::DOWN, Key::SPACE, Key::ENTER, Key::DOWN, Key::SPACE, Key::ENTER]);
 

--- a/tests/Feature/MultiSelectPromptTest.php
+++ b/tests/Feature/MultiSelectPromptTest.php
@@ -104,6 +104,22 @@ it('accepts collections', function () {
     expect($result)->toBe(['Green']);
 });
 
+it('transforms values', function () {
+    Prompt::fake([Key::DOWN, Key::SPACE, Key::DOWN, Key::SPACE, Key::ENTER]);
+
+    $result = multiselect(
+        label: 'What are your favorite colors?',
+        options: [
+            'red' => 'Red',
+            'green' => 'Green',
+            'blue' => 'Blue',
+        ],
+        transform: fn ($value) => array_map('strtoupper', $value),
+    );
+
+    expect($result)->toBe(['GREEN', 'BLUE']);
+});
+
 it('validates', function () {
     Prompt::fake([Key::ENTER, Key::SPACE, Key::ENTER]);
 

--- a/tests/Feature/PasswordPromptTest.php
+++ b/tests/Feature/PasswordPromptTest.php
@@ -15,6 +15,19 @@ it('returns the input', function () {
     expect($result)->toBe('pass');
 });
 
+it('transforms values', function () {
+    Prompt::fake(['p', 'a', 's', 's', 'w', 'o', 'r', 'd', Key::ENTER]);
+
+    $dontUseInProduction = md5('password');
+
+    $result = password(
+        label: 'What is the password?',
+        transform: fn ($value) => md5($value)
+    );
+
+    expect($result)->toBe($dontUseInProduction);
+});
+
 it('validates', function () {
     Prompt::fake(['p', 'a', 's', Key::ENTER, 's', Key::ENTER]);
 

--- a/tests/Feature/SearchPromptTest.php
+++ b/tests/Feature/SearchPromptTest.php
@@ -97,6 +97,25 @@ it('returns the key when an associative array is passed', function () {
     expect($result)->toBe(3);
 });
 
+it('transforms values', function () {
+    Prompt::fake(['u', 'e', Key::DOWN, Key::ENTER]);
+
+    $result = search(
+        label: 'What is your favorite color?',
+        options: fn (string $value) => array_filter(
+            [
+                'red' => 'Red',
+                'green' => 'Green',
+                'blue' => 'Blue',
+            ],
+            fn ($option) => str_contains(strtolower($option), $value),
+        ),
+        transform: fn ($value) => strtoupper($value),
+    );
+
+    expect($result)->toBe('BLUE');
+});
+
 it('validates', function () {
     Prompt::fake([Key::DOWN, Key::ENTER, Key::DOWN, Key::ENTER]);
 

--- a/tests/Feature/SelectPromptTest.php
+++ b/tests/Feature/SelectPromptTest.php
@@ -99,6 +99,22 @@ it('accepts default values when the options are keys with labels', function () {
     expect($result)->toBe('green');
 });
 
+it('transforms values', function () {
+    Prompt::fake([Key::DOWN, Key::ENTER]);
+
+    $result = select(
+        label: 'What is your favorite color?',
+        options: [
+            'Red',
+            'Green',
+            'Blue',
+        ],
+        transform: fn ($value) => strtolower($value),
+    );
+
+    expect($result)->toBe('green');
+});
+
 it('validates', function () {
     Prompt::fake([Key::ENTER, Key::DOWN, Key::ENTER]);
 

--- a/tests/Feature/SuggestPromptTest.php
+++ b/tests/Feature/SuggestPromptTest.php
@@ -118,6 +118,18 @@ it('accepts a callback returning a collection', function () {
     expect($result)->toBe('Blue');
 });
 
+it('transforms values', function () {
+    Prompt::fake([Key::SPACE, 'J', 'e', 's', 's', Key::TAB, Key::ENTER]);
+
+    $result = suggest(
+        label: 'What is your name?',
+        options: ['Jess'],
+        transform: fn ($value) => trim($value),
+    );
+
+    expect($result)->toBe('Jess');
+});
+
 it('validates', function () {
     Prompt::fake([Key::ENTER, 'X', Key::ENTER]);
 

--- a/tests/Feature/TextPromptTest.php
+++ b/tests/Feature/TextPromptTest.php
@@ -1,11 +1,11 @@
 <?php
 
-use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\TextPrompt;
 
 use function Laravel\Prompts\text;
+use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 
 afterEach(function () {
     Prompt::cancelUsing(null);
@@ -25,6 +25,17 @@ it('accepts a default value', function () {
     $result = text(
         label: 'What is your name?',
         default: 'Jess'
+    );
+
+    expect($result)->toBe('Jess');
+});
+
+it('transforms values', function () {
+    Prompt::fake([Key::SPACE, 'J', 'e', 's', 's', Key::TAB, Key::ENTER]);
+
+    $result = text(
+        label: 'What is your name?',
+        transform: fn ($value) => trim($value),
     );
 
     expect($result)->toBe('Jess');

--- a/tests/Feature/TextPromptTest.php
+++ b/tests/Feature/TextPromptTest.php
@@ -1,11 +1,11 @@
 <?php
 
+use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\TextPrompt;
 
 use function Laravel\Prompts\text;
-use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 
 afterEach(function () {
     Prompt::cancelUsing(null);

--- a/tests/Feature/TextareaPromptTest.php
+++ b/tests/Feature/TextareaPromptTest.php
@@ -26,6 +26,17 @@ it('accepts a default value', function () {
     expect($result)->toBe("Jess\nJoe");
 });
 
+it('transforms values', function () {
+    Prompt::fake([Key::SPACE, 'J', 'e', 's', 's', Key::SPACE, Key::CTRL_D]);
+
+    $result = textarea(
+        label: 'What is your name?',
+        transform: fn ($value) => trim($value),
+    );
+
+    expect($result)->toBe('Jess');
+});
+
 it('validates', function () {
     Prompt::fake(['J', 'e', 's', Key::CTRL_D, 's', Key::CTRL_D]);
 


### PR DESCRIPTION
I thought it would be nice to be able to make changes to input **before** it gets validated.

## Problem

Suppose you want to trim user input before it's validated. We start off with a basic prompt to ask for a username:

<pre>$username = text(
    label: 'Please select a username:',
    required: true,
);</pre>

If I enter `string(8) "        "` (8 spaces), that's a totally valid username. This could of course be solved with validation, so let's add a validation rule to make sure that the username, when trimmed, is at least 4 characters:

<pre>$username = text(
    label: 'Please select a username:',
    required: true,
    validate: fn (string $value) => strlen(trim($value)) < 4 ? 'Too short!' : '',
);</pre>

And enter `string(8) "   ssss  "` (2 spaces, and the letter `s` 4 times, followed by 2 more spaces). The validation logic above trims the string and agrees that `string(4) "ssss"` is a valid username. However, that's not the input we entered...

The `trim` function was called inside the validation logic, which means the value of `$username` will still be `string(8) "  ssss  "`. This could be resolved with more advanced validation logic, like not allowing a string to start and end with a space etc., but this can become unmanageable pretty fast.

We could of course wrap all of the code above in a `trim()`:
<pre>$username = trim(text(
    ...
));</pre>

but now I have repeated myself and have to remember to change the code every time the validation logic changes. This can be tedious when working with large form sets, especially if there are multiple developers working on the same codebase.

## Solution

In this PR, I have added a `transform` option, which accepts a `Closure` and can be used like this:

<pre>$username = text(
    label: 'Please select a username:',
    transform: fn ($value) => trim($value),
    validate: fn (string $value) => strlen($value) < 4 ? 'Too short!' : '',
);</pre>

This will alter the value before validation takes place, which means I don't need to repeat myself, and I know for sure that the value that is assigned to `$username` is the same value that was being validated.

This could be super useful not only for trimming strings, but also to filter out other kinds of unwanted characters, like spaces in a phone number or hyphens in a UUID. It can also be used with the `Str` helpers:

<pre>use Illuminate\Support\Str;

$slug = text(
    label: 'Please enter a slug for your blog post:',
    transform: fn ($value) => Str::slug($value),
    validate: ...
);</pre>

All input types are supported and I've added tests for each type. Let me know what you think!

Thank you