### PR TITLE
Fix textarea helper method signature.

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -19,7 +19,7 @@ if (! function_exists('\Laravel\Prompts\textarea')) {
     /**
      * Prompt the user for multiline text input.
      */
-    function textarea(string $label, string $placeholder = '', string $default = '', bool|string $required = false, ?Closure $validate = null, string $hint = '', int $rows = 5, ?Closure $transform = null): string
+    function textarea(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', int $rows = 5, ?Closure $transform = null): string
     {
         return (new TextareaPrompt(...func_get_args()))->prompt();
     }


### PR DESCRIPTION
The `textarea` helper function currently has the wrong signature.

The signature previously (incorrectly) typed the `$validate` parameter as a nullable `Closure`. The upstream signature declares the parameter as a nullable `mixed`, same as the other prompt types.

What does this fix? It allows us to use all of the types of validation for textarea prompts (using the helpers).

I don't believe we need tests since we are just piping the data through to an object which supports this value.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
