### PR TITLE
[ BugFix ] Handle Failed Terminal Read Gracefully

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" backupStaticProperties="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" backupStaticProperties="true" failOnWarning="true">
   <testsuites>
     <testsuite name="Test Suite">
       <directory suffix="Test.php">./tests</directory>

--- a/src/Concerns/TypedValue.php
+++ b/src/Concerns/TypedValue.php
@@ -28,7 +28,9 @@ trait TypedValue
         }
 
         $this->on('key', function ($key) use ($submit, $ignore, $allowNewLine) {
-            if ($key[0] === "\e" || in_array($key, [Key::CTRL_B, Key::CTRL_F, Key::CTRL_A, Key::CTRL_E])) {
+            if ($key !== '' &&
+                ($key[0] === "\e" || in_array($key, [Key::CTRL_B, Key::CTRL_F, Key::CTRL_A, Key::CTRL_E]))
+            ) {
                 if ($ignore !== null && $ignore($key)) {
                     return;
                 }

--- a/src/Concerns/TypedValue.php
+++ b/src/Concerns/TypedValue.php
@@ -27,7 +27,7 @@ trait TypedValue
             $this->cursorPosition = mb_strlen($this->typedValue);
         }
 
-        $this->on('key', function ($key) use ($submit, $ignore, $allowNewLine) {
+        $this->on('key', function (string $key) use ($submit, $ignore, $allowNewLine): void {
             if ($key !== '' &&
                 ($key[0] === "\e" || in_array($key, [Key::CTRL_B, Key::CTRL_F, Key::CTRL_A, Key::CTRL_E]))
             ) {

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -167,6 +167,15 @@ abstract class Prompt
     public function runLoop(callable $callable): mixed
     {
         while (($key = static::terminal()->read()) !== null) {
+            /**
+             * If $key is an empty string, Terminal::read
+             * has failed. We can continue to the next
+             * iteration of the loop, and try again.
+             */
+            if ($key === '') {
+                continue;
+            }
+
             $result = $callable($key);
 
             if ($result instanceof Result) {

--- a/tests/Feature/TextPromptTest.php
+++ b/tests/Feature/TextPromptTest.php
@@ -159,3 +159,11 @@ it('allows customizing the cancellation', function () {
 
     text('What is your name?');
 })->throws(Exception::class, 'Cancelled.');
+
+it('handles a failed terminal read gracefully', function () {
+    Prompt::fake(['', Key::ENTER]);
+
+    $result = text('What is your name?');
+
+    expect($result)->toBe('');
+});


### PR DESCRIPTION
In `Terminal::read()` if the result of `fread(STDIN)` is `false`, indicating an error, we return an **empty string**.

This can be a problem. While this issue is rare, it does appear to be temporary (maybe some sort of race condition?)

The problem is that `Concerns/TypedValue::trackTypedValue()` **expects** the string `$key` passed to the 'on key' listener to not be empty as it expects to be able to read `$key[0]`. By checking that `$key` is not empty we can eliminate a repeated `E_WARNING: Uninitialized string offset 0` from overwhelming the terminal output when encountered inside of a loop.

I've also added a safeguard in the prompt looping mechanism to `continue` onto the next iteration if this is encountered.

I haven't found a good way to make a test actually fail when a warning is encountered, but this configuration change shows the warning pretty clearly. And at least it _is_ covered by a test, even if it's not returning a non-zero exitcode.