### PR TITLE
Adds support for conditional steps

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -25,7 +25,17 @@ class FormBuilder
     /**
      * Add a new step.
      */
-    public function add(Closure $step, ?string $name = null, bool $ignoreWhenReverting = false, bool|Closure $condition = true): self
+    public function add(Closure $step, ?string $name = null, bool $ignoreWhenReverting = false): self
+    {
+        $this->steps[] = new FormStep($step, true, $name, $ignoreWhenReverting);
+
+        return $this;
+    }
+
+    /**
+     * Add a new conditional step.
+     */
+    public function addIf(Closure $condition, Closure $step, ?string $name = null, bool $ignoreWhenReverting = false): self
     {
         $this->steps[] = new FormStep($step, $condition, $name, $ignoreWhenReverting);
 

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -25,9 +25,9 @@ class FormBuilder
     /**
      * Add a new step.
      */
-    public function add(Closure $step, ?string $name = null, bool $ignoreWhenReverting = false): self
+    public function add(Closure $step, ?string $name = null, bool $ignoreWhenReverting = false, bool|Closure $condition = true): self
     {
-        $this->steps[] = new FormStep($step, true, $name, $ignoreWhenReverting);
+        $this->steps[] = new FormStep($step, $condition, $name, $ignoreWhenReverting);
 
         return $this;
     }

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -35,7 +35,7 @@ class FormBuilder
     /**
      * Add a new conditional step.
      */
-    public function addIf(Closure $condition, Closure $step, ?string $name = null, bool $ignoreWhenReverting = false): self
+    public function addIf(bool|Closure $condition, Closure $step, ?string $name = null, bool $ignoreWhenReverting = false): self
     {
         $this->steps[] = new FormStep($step, $condition, $name, $ignoreWhenReverting);
 

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -35,7 +35,7 @@ class FormBuilder
     /**
      * Add a new conditional step.
      */
-    public function addIf(bool|Closure $condition, Closure $step, ?string $name = null, bool $ignoreWhenReverting = false): self
+    public function addIf(Closure|bool $condition, Closure $step, ?string $name = null, bool $ignoreWhenReverting = false): self
     {
         $this->steps[] = new FormStep($step, $condition, $name, $ignoreWhenReverting);
 

--- a/tests/Feature/FormTest.php
+++ b/tests/Feature/FormTest.php
@@ -194,7 +194,7 @@ it('can revert steps with conditions', function () {
     $responses = form()
         ->text('What is your name?')
         ->select('What is your language?', ['PHP', 'JS'])
-        ->add(fn ($responses) => text("Which version?"), condition: fn ($responses) => $responses[1] === 'PHP')
+        ->addIf(fn ($responses) => $responses[1] === 'PHP', fn ($responses) => text("Which version?"))
         ->confirm('Are you sure?')
         ->submit();
 
@@ -216,7 +216,7 @@ it('leaves skipped conditional field empty', function () {
     $responses = form()
         ->text('What is your name?')
         ->select('What is your language?', ['PHP', 'JS'])
-        ->add(fn ($responses) => text("Which version?"), condition: fn ($responses) => $responses[1] === 'PHP')
+        ->addIf(fn ($responses) => $responses[1] === 'PHP', fn ($responses) => text("Which version?"))
         ->confirm('Are you sure?')
         ->submit();
 

--- a/tests/Feature/FormTest.php
+++ b/tests/Feature/FormTest.php
@@ -6,6 +6,7 @@ use Laravel\Prompts\Prompt;
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\form;
 use function Laravel\Prompts\outro;
+use function Laravel\Prompts\text;
 
 it('can run multiple steps', function () {
     Prompt::fake([
@@ -178,4 +179,51 @@ it('stops steps at the moment of reverting', function () {
         })->submit();
 
     Prompt::assertOutputDoesntContain('This should not appear!');
+});
+
+it('can revert steps with conditions', function () {
+    Prompt::fake([
+        'L', 'u', 'k', 'e', Key::ENTER, // name
+        Key::DOWN, Key::ENTER, // JS
+        Key::CTRL_U, // revert
+        Key::UP, Key::ENTER, // PHP
+        '8', '.', '3', Key::ENTER, // version
+        Key::ENTER,
+    ]);
+
+    $responses = form()
+        ->text('What is your name?')
+        ->select('What is your language?', ['PHP', 'JS'])
+        ->add(fn ($responses) => text("Which version?"), condition: fn ($responses) => $responses[1] === 'PHP')
+        ->confirm('Are you sure?')
+        ->submit();
+
+    expect($responses)->toBe([
+        'Luke',
+        'PHP',
+        '8.3',
+        true,
+    ]);
+});
+
+it('leaves skipped conditional field empty', function () {
+    Prompt::fake([
+        'L', 'u', 'k', 'e', Key::ENTER, // name
+        Key::DOWN, Key::ENTER, // JS
+        Key::ENTER,
+    ]);
+
+    $responses = form()
+        ->text('What is your name?')
+        ->select('What is your language?', ['PHP', 'JS'])
+        ->add(fn ($responses) => text("Which version?"), condition: fn ($responses) => $responses[1] === 'PHP')
+        ->confirm('Are you sure?')
+        ->submit();
+
+    expect($responses)->toBe([
+        'Luke',
+        'JS',
+        null,
+        true,
+    ]);
 });


### PR DESCRIPTION
In pull request #118 revertable forms is introduced. I found no proper way to make steps conditional to the answer of the previous steps. The `$step` closure seems to be an option. But then reverting does not work.

See the example below:
```php
use function Laravel\Prompts\form;
use function Laravel\Prompts\text;

$responses = form()
    ->text('What is your name?')
    ->select('What is your language?', ['PHP', 'JS'], name: 'language')
    ->add(function ($responses) {
        if ($responses['language'] == 'PHP') {
            return text("Which version?");
        }
    },
        name: 'phpversion',
    )
    ->add(function ($responses) {
        if ($responses['language'] == 'JS') {
            return text("Which os?");
        }
    },
        name: 'os'
    )->confirm('Are you sure?')
    ->submit();
```

![afbeelding](https://github.com/user-attachments/assets/beb4cf9c-bea2-4652-a95a-63ee3455a2ec)

The option `ignoreWhenReverting` seems to be an option, but it that simply skips the step. So conditional forms are hard.

In the example below I rewrote the above example with the suggested change. And now everything seems to work fine.

```php
use function Laravel\Prompts\form;
use function Laravel\Prompts\text;

$responses = form()
    ->text('What is your name?')
    ->select('What is your language?', ['PHP', 'JS'], name: 'language')
    ->add(function () {
            return text("Which version?");
        },
        name: 'phpversion',
        condition: function ($responses) {
            return $responses['language'] == 'PHP';
        }
    )
    ->add(function () {
            return text("Which os?");
        },
        name: 'os',
        condition: function ($responses) {
            return $responses['language'] == 'JS';
        }
    )->confirm('Are you sure?')
    ->submit();
```

![afbeelding](https://github.com/user-attachments/assets/a9d8c01e-c967-4c6b-aa25-1acecd9a1945)