### PR TITLE
Fix default values not being passed

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -11,7 +11,7 @@ if (! function_exists('\Laravel\Prompts\text')) {
      */
     function text(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?Closure $transform = null): string
     {
-        return (new TextPrompt(...func_get_args()))->prompt();
+        return (new TextPrompt(...get_defined_vars()))->prompt();
     }
 }
 
@@ -21,7 +21,7 @@ if (! function_exists('\Laravel\Prompts\textarea')) {
      */
     function textarea(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', int $rows = 5, ?Closure $transform = null): string
     {
-        return (new TextareaPrompt(...func_get_args()))->prompt();
+        return (new TextareaPrompt(...get_defined_vars()))->prompt();
     }
 }
 
@@ -31,7 +31,7 @@ if (! function_exists('\Laravel\Prompts\password')) {
      */
     function password(string $label, string $placeholder = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?Closure $transform = null): string
     {
-        return (new PasswordPrompt(...func_get_args()))->prompt();
+        return (new PasswordPrompt(...get_defined_vars()))->prompt();
     }
 }
 
@@ -44,7 +44,7 @@ if (! function_exists('\Laravel\Prompts\select')) {
      */
     function select(string $label, array|Collection $options, int|string|null $default = null, int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?Closure $transform = null): int|string
     {
-        return (new SelectPrompt(...func_get_args()))->prompt();
+        return (new SelectPrompt(...get_defined_vars()))->prompt();
     }
 }
 
@@ -58,7 +58,7 @@ if (! function_exists('\Laravel\Prompts\multiselect')) {
      */
     function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?Closure $transform = null): array
     {
-        return (new MultiSelectPrompt(...func_get_args()))->prompt();
+        return (new MultiSelectPrompt(...get_defined_vars()))->prompt();
     }
 }
 
@@ -68,7 +68,7 @@ if (! function_exists('\Laravel\Prompts\confirm')) {
      */
     function confirm(string $label, bool $default = true, string $yes = 'Yes', string $no = 'No', bool|string $required = false, mixed $validate = null, string $hint = '', ?Closure $transform = null): bool
     {
-        return (new ConfirmPrompt(...func_get_args()))->prompt();
+        return (new ConfirmPrompt(...get_defined_vars()))->prompt();
     }
 }
 
@@ -78,7 +78,7 @@ if (! function_exists('\Laravel\Prompts\pause')) {
      */
     function pause(string $message = 'Press enter to continue...'): bool
     {
-        return (new PausePrompt(...func_get_args()))->prompt();
+        return (new PausePrompt(...get_defined_vars()))->prompt();
     }
 }
 
@@ -100,7 +100,7 @@ if (! function_exists('\Laravel\Prompts\suggest')) {
      */
     function suggest(string $label, array|Collection|Closure $options, string $placeholder = '', string $default = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = '', ?Closure $transform = null): string
     {
-        return (new SuggestPrompt(...func_get_args()))->prompt();
+        return (new SuggestPrompt(...get_defined_vars()))->prompt();
     }
 }
 
@@ -113,7 +113,7 @@ if (! function_exists('\Laravel\Prompts\search')) {
      */
     function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?Closure $transform = null): int|string
     {
-        return (new SearchPrompt(...func_get_args()))->prompt();
+        return (new SearchPrompt(...get_defined_vars()))->prompt();
     }
 }
 
@@ -126,7 +126,7 @@ if (! function_exists('\Laravel\Prompts\multisearch')) {
      */
     function multisearch(string $label, Closure $options, string $placeholder = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?Closure $transform = null): array
     {
-        return (new MultiSearchPrompt(...func_get_args()))->prompt();
+        return (new MultiSearchPrompt(...get_defined_vars()))->prompt();
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue introduced in #102 where default arguments from the helper functions are not passed to the Prompt instance because `func_get_args` only includes passed arguments.

Fixes #172
