### PR TITLE
Add page up & down key inputs

### DIFF
--- a/src/Key.php
+++ b/src/Key.php
@@ -8,9 +8,13 @@ class Key
 
     const SHIFT_UP = "\e[1;2A";
 
+    const PAGE_UP = "\e[5~";
+
     const DOWN = "\e[B";
 
     const SHIFT_DOWN = "\e[1;2B";
+
+    const PAGE_DOWN = "\e[6~";
 
     const RIGHT = "\e[C";
 


### PR DESCRIPTION
This pull request includes updates to the `Key` class in add new key constants for navigation.

Key constants added:

* `PAGE_UP` constant with the value `"\e[5~"`
* `PAGE_DOWN` constant with the value `"\e[6~"`

These escape sequences align with the most common VT100/ANSI emulation in modern terminal environments and are particularly useful for handling Page Up/Down navigation. For reference please GNU documentation on input translation in [emulation of the VT100](https://www.gnu.org/software/screen/manual/html_node/Input-Translation.html)
