### PR TITLE
Pass name to the FormStep.

### DIFF
--- a/src/FormStep.php
+++ b/src/FormStep.php
@@ -30,7 +30,7 @@ class FormStep
             return null;
         }
 
-        return ($this->step)($responses, $previousResponse);
+        return ($this->step)($responses, $previousResponse, $this->name);
     }
 
     /**


### PR DESCRIPTION
When working with forms, there is sometimes a need to wrap some logic for a prompt property into a function and pass a name of the current step to this function for context.

Consider an example, where a default value may need to be taken from a command CLI arguments and/or environment variables, so we wrap this into `getDefault($name, $fallbackValue)` function and assign the result to the `default` property.

When working with small forms, it is easy to copy/paste the name of the step from a last argument of `add()` method to this function.

However, when working with large forms containing many steps, each of which has most of the properties filled-in with multi-line callbacks, there is a chance of accidentally forgetting to update the name passed to the `getDefault()`.

The proposed change is to add the current name of the step as a 3rd argument to the closure allowing to pass it as a variable to any of the functions used within this closure.


Before suggested change:
```php
    $responses = form()
      ->add(fn ($responses) => text(
        label: 'Q1',
        default: getDefault('q1', 'A1'),
      ), 'q1')
      ->add(fn ($responses) => text(
        label: 'Q2',
        default: getDefault('q2', 'A2'),
      ), 'q1')
      ->add(fn ($responses) => text(
        label: 'Q3',
        default: getDefault('q3', 'A3'),
      ), 'q3')
      ->submit();
```

After suggested change:

```php
    $responses = form()
      ->add(fn ($responses, $previousResponses, $name) => text(
        label: 'Q1',
        default: getDefault($name, 'A1'),
      ), 'q1')
      ->add(fn ($responses, $previousResponses, $name) => text(
        label: 'Q2',
        default: getDefault($name, 'A2'),
      ), 'q1')
      ->add(fn ($responses, $previousResponses, $name) => text(
        label: 'Q3',
        default: getDefault($name, 'A3'),
      ), 'q3')
      ->submit();
```
