### PR TITLE
Fix: Select Default Falsy

### DIFF
--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -38,7 +38,7 @@ class SelectPrompt extends Prompt
 
         $this->options = $options instanceof Collection ? $options->all() : $options;
 
-        if ($this->default) {
+        if ($this->default !== null) {
             if (array_is_list($this->options)) {
                 $this->initializeScrolling(array_search($this->default, $this->options) ?: 0);
             } else {

--- a/tests/Feature/SelectPromptTest.php
+++ b/tests/Feature/SelectPromptTest.php
@@ -371,7 +371,7 @@ it('handles falsy default', function () {
     Prompt::fake([Key::ENTER]);
 
     $result = select(
-        label: 'How many stars would you like to give',
+        label: 'How many stars would you like to give?',
         options: [
             '3',
             '2',

--- a/tests/Feature/SelectPromptTest.php
+++ b/tests/Feature/SelectPromptTest.php
@@ -366,3 +366,20 @@ it('supports custom validation', function () {
 
     Prompt::validateUsing(fn () => null);
 });
+
+it('handles falsy default', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = select(
+        label: 'How many stars would you like to give',
+        options: [
+            '3',
+            '2',
+            '1',
+            '0',
+        ],
+        default: '0',
+    );
+
+    expect($result)->toBe('0');
+});


### PR DESCRIPTION
Hey, currently falsy default values do not function as expected for select inputs.

Consider the following example (included as a test):

```php
$result = select(
    label: 'How many stars would you like to give?',
    options: ['3', '2', '1', '0'],
    default: '0',
);
```

I'd expect the highlighted option to be 0, but currently it is 3. This is because 0 is falsy - failing the `if($this->default)` check and resulting in the first option being highlighted by default.

My proposed fix for this, is to change the check to `if($this->default !== null)`, allowing the following non-null falsy values to be used as defaults.

If this is merged, I'm happy to also look into other inputs that this may affect.