### PR TITLE
Add PendingCommand testing macros trait

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "php": "^8.1",
         "ext-mbstring": "*",
         "composer-runtime-api": "^2.2",
-        "symfony/console": "^6.2|^7.0"
+        "symfony/console": "^6.2|^7.0",
+        "illuminate/testing": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "illuminate/collections": "^10.0|^11.0|^12.0",

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "php": "^8.1",
         "ext-mbstring": "*",
         "composer-runtime-api": "^2.2",
-        "symfony/console": "^6.2|^7.0",
-        "illuminate/testing": "^10.0|^11.0|^12.0"
+        "illuminate/testing": "^10.0|^11.0|^12.0",
+        "symfony/console": "^6.2|^7.0"
     },
     "require-dev": {
         "illuminate/collections": "^10.0|^11.0|^12.0",

--- a/src/Testing/InteractsWithPrompts.php
+++ b/src/Testing/InteractsWithPrompts.php
@@ -3,10 +3,10 @@
 namespace Laravel\Prompts\Testing;
 
 use Illuminate\Support\Collection;
-use Laravel\Prompts\Note;
-use Laravel\Prompts\Table;
-use Laravel\Prompts\Prompt;
 use Illuminate\Testing\PendingCommand;
+use Laravel\Prompts\Note;
+use Laravel\Prompts\Prompt;
+use Laravel\Prompts\Table;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 trait InteractsWithPrompts
@@ -27,10 +27,10 @@ trait InteractsWithPrompts
         };
 
         PendingCommand::macro(
-            'expectsPromptError',
+            'expectsPromptInfo',
             fn (string $message) => $expectOutputFromPrompt->call(
                 $this,
-                new Note($message, 'error')
+                new Note($message, 'info')
             )
         );
 
@@ -43,18 +43,18 @@ trait InteractsWithPrompts
         );
 
         PendingCommand::macro(
-            'expectsPromptAlert',
+            'expectsPromptError',
             fn (string $message) => $expectOutputFromPrompt->call(
                 $this,
-                new Note($message, 'alert')
+                new Note($message, 'error')
             )
         );
 
         PendingCommand::macro(
-            'expectsPromptInfo',
+            'expectsPromptAlert',
             fn (string $message) => $expectOutputFromPrompt->call(
                 $this,
-                new Note($message, 'info')
+                new Note($message, 'alert')
             )
         );
 

--- a/src/Testing/InteractsWithPrompts.php
+++ b/src/Testing/InteractsWithPrompts.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Laravel\Prompts\Testing;
 
 use Illuminate\Support\Collection;

--- a/src/Testing/InteractsWithPrompts.php
+++ b/src/Testing/InteractsWithPrompts.php
@@ -14,24 +14,16 @@ use Symfony\Component\Console\Output\BufferedOutput;
 trait InteractsWithPrompts
 {
     /**
-     * This method is automatically called from the setUpTraits method of InteractsWithTestCaseLifecycle
-     * to use the trait and allow for the macros to be set up -
-     *
-     * PHPUnit: add the following to your Test class
-     *   use \Laravel\Prompts\Testing\InteractsWithPrompts;
-     *
-     * Pest: add the following to your test file
-     *   uses()->use(\Laravel\Prompts\Testing\InteractsWithPrompts::class);
+     * This method is automatically called from the setUpTraits method of InteractsWithTestCaseLifecycle.
      */
     public function setUpInteractsWithPrompts(): void
     {
         $expectOutputFromPrompt = function (Prompt $prompt) {
             $prompt->setOutput($output = new BufferedOutput);
+
             $prompt->display();
 
-            $tableOutput = trim($output->fetch());
-
-            $this->expectsOutputToContain($tableOutput);
+            $this->expectsOutputToContain(trim($output->fetch()));
 
             return $this;
         };

--- a/src/Testing/InteractsWithPrompts.php
+++ b/src/Testing/InteractsWithPrompts.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Prompts\Testing;
 
+use Illuminate\Support\Collection;
 use Laravel\Prompts\Note;
 use Laravel\Prompts\Table;
 use Laravel\Prompts\Prompt;
@@ -25,8 +26,6 @@ trait InteractsWithPrompts
     public function setUpInteractsWithPrompts(): void
     {
         $expectOutputFromPrompt = function (Prompt $prompt) {
-            /** @var PendingCommand $this */
-
             $prompt->setOutput($output = new BufferedOutput);
             $prompt->display();
 
@@ -87,7 +86,7 @@ trait InteractsWithPrompts
 
         PendingCommand::macro(
             'expectsPromptTable',
-            fn (array $headers, array $rows) => $expectOutputFromPrompt->call(
+            fn (array|Collection $headers, array|Collection|null $rows = null) => $expectOutputFromPrompt->call(
                 $this,
                 new Table($headers, $rows)
             )

--- a/src/Testing/InteractsWithPrompts.php
+++ b/src/Testing/InteractsWithPrompts.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Prompts\Testing;
+
+use Laravel\Prompts\Note;
+use Laravel\Prompts\Table;
+use Laravel\Prompts\Prompt;
+use Illuminate\Testing\PendingCommand;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+trait InteractsWithPrompts
+{
+    /**
+     * This method is automatically called from the setUpTraits method of InteractsWithTestCaseLifecycle
+     * to use the trait and allow for the macros to be set up -
+     *
+     * PHPUnit: add the following to your Test class
+     *   use \Laravel\Prompts\Testing\InteractsWithPrompts;
+     *
+     * Pest: add the following to your test file
+     *   uses()->use(\Laravel\Prompts\Testing\InteractsWithPrompts::class);
+     */
+    public function setUpInteractsWithPrompts(): void
+    {
+        $expectOutputFromPrompt = function (Prompt $prompt) {
+            /** @var PendingCommand $this */
+
+            $prompt->setOutput($output = new BufferedOutput);
+            $prompt->display();
+
+            $tableOutput = trim($output->fetch());
+
+            $this->expectsOutputToContain($tableOutput);
+
+            return $this;
+        };
+
+        PendingCommand::macro(
+            'expectsPromptError',
+            fn (string $message) => $expectOutputFromPrompt->call(
+                $this,
+                new Note($message, 'error')
+            )
+        );
+
+        PendingCommand::macro(
+            'expectsPromptWarning',
+            fn (string $message) => $expectOutputFromPrompt->call(
+                $this,
+                new Note($message, 'warning')
+            )
+        );
+
+        PendingCommand::macro(
+            'expectsPromptAlert',
+            fn (string $message) => $expectOutputFromPrompt->call(
+                $this,
+                new Note($message, 'alert')
+            )
+        );
+
+        PendingCommand::macro(
+            'expectsPromptInfo',
+            fn (string $message) => $expectOutputFromPrompt->call(
+                $this,
+                new Note($message, 'info')
+            )
+        );
+
+        PendingCommand::macro(
+            'expectsPromptIntro',
+            fn (string $message) => $expectOutputFromPrompt->call(
+                $this,
+                new Note($message, 'intro')
+            )
+        );
+
+        PendingCommand::macro(
+            'expectsPromptOutro',
+            fn (string $message) => $expectOutputFromPrompt->call(
+                $this,
+                new Note($message, 'outro')
+            )
+        );
+
+        PendingCommand::macro(
+            'expectsPromptTable',
+            fn (array $headers, array $rows) => $expectOutputFromPrompt->call(
+                $this,
+                new Table($headers, $rows)
+            )
+        );
+    }
+}


### PR DESCRIPTION
## Description

This new trait adds output testing against the PendingCommand from the core framework.

Adding this trait to your userland tests (Pest or PHPUnit) will allow calls through to the test methods on the PendingCommand (see examples/usage below)

## Notes

So far this only works for regular output data and the other downside is that it can only check for a full table match

### Usage

with this example command:
```php
<?php

namespace App\Console\Commands;

use Illuminate\Console\Command;
use function Laravel\Prompts\info;
use function Laravel\Prompts\alert;
use function Laravel\Prompts\error;
use function Laravel\Prompts\outro;
use function Laravel\Prompts\table;
use function Laravel\Prompts\warning;

class PromptTest extends Command
{
    /**
     * The name and signature of the console command.
     *
     * @inheritdoc
     */
    protected $signature = 'app:prompt-test';

    /**
     * The console command description.
     *
     * @inheritdoc
     */
    protected $description = 'test prompt';

    /**
     * Execute the console command.
     */
    public function handle(): void
    {
        outro('Test Prompt - outro');

        info('Test Prompt - information');

        alert('Test Prompt - information ALERT!');

        table(
            headers: ['ABC', 'DEF', 'GHI'],
            rows: [
                ['123', '456', '789'],
                ['234', '567', '890'],
            ]
        );

        warning('Test Prompt - warning');

        error('Test Prompt - error');

        outro('Test Prompt - outro');
    }
}

``` 

for PHPUnit:
```php
<?php

namespace Tests\Unit;

use Tests\TestCase;
use Laravel\Prompts\Testing\InteractsWithPrompts;

class MyCommandTest extends TestCase
{
    use InteractsWithPrompts;

    public function testCommand(): void
    {
        $this->artisan('app:prompt-test')
            ->expectsPromptIntro('Test Prompt - intro')
            ->expectsPromptTable(
                headers: ['ABC', 'DEF', 'GHI'],
                rows: [
                    ['123', '456', '789'],
                    ['234', '567', '890'],
                ]
            )
            ->assertExitCode(0);
    }
}
```

for Pest (`MyCommandTest.php`)
```php
<?php

use Tests\Traits\InteractsWithPrompts;

use function Pest\Laravel\artisan;

uses()->use(InteractsWithPrompts::class);

test('command prompts', function () {
    artisan('app:prompt-test')
        ->expectsPromptOutro('Test Prompt - outro')
        ->expectsPromptInfo('Test Prompt - information')
        ->expectsPromptTable(
            headers: ['ABC', 'DEF', 'GHI'],
            rows: [
                ['123', '456', '789'],
                ['234', '567', '890'],
            ]
        )
        ->assertExitCode(0);
});

``` 