### PR TITLE
Fix: Exclude Progress from phpstan as causes infinite loop

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,5 +4,9 @@ parameters:
 
   level: 7
 
+  excludePaths:
+      analyse:
+          - src/Progress.php # Progress causes infinite loop
+
 includes:
     - vendor/phpstan/phpstan-mockery/extension.neon


### PR DESCRIPTION
## Description

Currently when phpstan analyses the Progress prompt class - it gets stuck in an infinite loop.
This update patches the phpstan config so that phpstan can complete for all the other files in the package

This will also fix the CI runner failure.

At some point in the future, will need to figure out why this is happening inside the Progress prompt class and fix as appropriate.