### PR TITLE
FIX: update phpstan to latest and remove ignored file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
     },
     "require-dev": {
         "illuminate/collections": "^10.0|^11.0|^12.0",
-        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan": "^1.12.28",
         "pestphp/pest": "^2.3|^3.4",
         "mockery/mockery": "^1.5",
-        "phpstan/phpstan-mockery": "^1.1"
+        "phpstan/phpstan-mockery": "^1.1.3"
     },
     "conflict": {
         "illuminate/console": ">=10.17.0 <10.25.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,9 +4,5 @@ parameters:
 
   level: 7
 
-  excludePaths:
-      analyse:
-          - src/Progress.php # Progress causes infinite loop
-
 includes:
     - vendor/phpstan/phpstan-mockery/extension.neon

--- a/src/Progress.php
+++ b/src/Progress.php
@@ -34,10 +34,12 @@ class Progress extends Prompt
      */
     public function __construct(public string $label, public iterable|int $steps, public string $hint = '')
     {
-        $this->total = match (true) { // @phpstan-ignore assign.propertyType
+        /** @phpstan-ignore assign.propertyType (PHPStan doesn't parse that we convert from iterable to int in the below match) */
+        $this->total = match (true) {
             is_int($this->steps) => $this->steps,
             is_countable($this->steps) => count($this->steps),
             is_iterable($this->steps) => iterator_count($this->steps),
+            /** @phpstan-ignore match.unreachable (Technically we shouldn't be able to reach the default as should be int|countable|iterable ) */
             default => throw new InvalidArgumentException('Unable to count steps.'),
         };
 
@@ -53,6 +55,7 @@ class Progress extends Prompt
      *
      * @param  Closure((TSteps is int ? int : value-of<TSteps>), $this): TReturn  $callback
      * @return array<TReturn>
+     * @throws Throwable
      */
     public function map(Closure $callback): array
     {


### PR DESCRIPTION
## Details

In previous [PR](https://github.com/laravel/prompts/pull/197) the Progress prompts file was added to alleviate that PHPStan was getting into an infinite loop and crashing - preventing CI from completing the static analysis.

After this was merged, I went to PHPStan and filed the issue with details from the Progress file. - see issue [PHPStan - Path in match causes infinite loop ( iterator|int type definition )](https://github.com/phpstan/phpstan/issues/13218 
)

This issue has now been fixed in PHPStan with new releases 1.12.28 and 2.1.15. 

This PR updates PHPStan to minimum supported requirement of 1.12.28 and removes the Progress prompt file from being ignored by PHPStan.
