### PR TITLE
feat: Add option for showing ETA in progress bar

### DIFF
--- a/src/Progress.php
+++ b/src/Progress.php
@@ -53,6 +53,10 @@ class Progress extends Prompt
         }
 
         $this->startTime = microtime(true);
+
+        if ($this->showEstimatedTime && $this->hint === '') {
+            $this->hint = 'Estimated time remaining: Calculating...';
+        }
     }
 
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -314,8 +314,9 @@ if (! function_exists('\Laravel\Prompts\progress')) {
         iterable|int $steps,
         ?Closure $callback = null,
         string $hint = '',
+        bool $showEstimatedTime = false,
     ): array|Progress {
-        $progress = new Progress($label, $steps, $hint);
+        $progress = new Progress($label, $steps, $hint, $showEstimatedTime);
 
         if ($callback !== null) {
             return $progress->map($callback);

--- a/tests/Feature/ProgressTest.php
+++ b/tests/Feature/ProgressTest.php
@@ -185,3 +185,30 @@ it("can show estimated time remaining", function () {
     Prompt::assertOutputContains('Calculating...');
     Prompt::assertOutputContains('Estimated time remaining');
 });
+
+it("can override hint and show estimated time remaining", function () {
+    Prompt::fake();
+
+    $states = [
+        'Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado',
+    ];
+
+    $progress = progress(
+        label: 'Adding States',
+        steps: $states,
+        hint: 'Custom hint',
+        showEstimatedTime: true
+    );
+
+    $progress->start();
+
+    foreach ($states as $state) {
+        usleep(1000);
+        $progress->advance();
+    }
+
+    $progress->finish();
+
+    Prompt::assertOutputContains('Custom hint');
+    Prompt::assertOutputContains('Estimated time remaining');
+});

--- a/tests/Feature/ProgressTest.php
+++ b/tests/Feature/ProgressTest.php
@@ -186,7 +186,7 @@ it("can show estimated time remaining", function () {
     Prompt::assertOutputContains('Estimated time remaining');
 });
 
-it("can override hint and show estimated time remaining", function () {
+it("can show hint on start and show estimated time remaining", function () {
     Prompt::fake();
 
     $states = [

--- a/tests/Feature/ProgressTest.php
+++ b/tests/Feature/ProgressTest.php
@@ -159,3 +159,29 @@ it('can update the label and hint in manual mode', function () {
         Prompt::assertOutputContains(strtolower($state));
     }
 });
+
+it("can show estimated time remaining", function () {
+    Prompt::fake();
+
+    $states = [
+        'Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado',
+    ];
+
+    $progress = progress(
+        label: 'Adding States',
+        steps: $states,
+        showEstimatedTime: true
+    );
+
+    $progress->start();
+
+    foreach ($states as $state) {
+        usleep(1000);
+        $progress->advance();
+    }
+
+    $progress->finish();
+
+    Prompt::assertOutputContains('Calculating...');
+    Prompt::assertOutputContains('Estimated time remaining');
+});


### PR DESCRIPTION
This PR introduces a new `$showEstimatedTime` option to the `Progress` class. When enabled, the progress bar dynamically calculates and displays the estimated time remaining (ETA) in the `hint` area during execution.

### Usage

```php
use function Laravel\Prompts\progress;

$progress = progress(
    label: 'Performing task',
    steps: 100,
    showEstimatedTime: true
);
```

### Output

![Preview](https://github.com/user-attachments/assets/06d253ad-6dba-48e2-98c0-4b5167d36b21)