### PR TITLE
Fix spacing before progress bars

### DIFF
--- a/src/Progress.php
+++ b/src/Progress.php
@@ -112,9 +112,9 @@ class Progress extends Prompt
             });
         }
 
-        $this->state = 'active';
         $this->hideCursor();
         $this->render();
+        $this->state = 'active';
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue where progress bars would not render a blank line before their output, leading to inconsistent spacing between prompts.

The prompt render method has different logic when rendering the first/initial frame compared with subsequent frames that need to erase previous output before re-rendering, however the prompt state was being advanced prior to the initial render, causing the initial render to behave like a subsequent re-render.

This addresses #195, however that issue seems to state that there should be no blank line between prompts, whereas this fix addresses the inconsistency by ensuring there is a blank line.

## Before

(Note the text prompts are just there for comparison)

<img width="742" height="893" alt="image" src="https://github.com/user-attachments/assets/bd87e5b0-9f05-4ef8-b327-12737dad06e6" />


## After

<img width="742" height="980" alt="image" src="https://github.com/user-attachments/assets/9c00625d-9062-44b7-a054-2265ebe5fc03" />
