### PR TITLE
Exclude `phpunit.xml` from Git export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,6 @@
 .gitignore export-ignore
 .styleci.yml export-ignore
 CHANGELOG.md export-ignore
-phpunit.xml.dist export-ignore
+phpunit.xml export-ignore
 phpstan.neon.dist export-ignore
 UPGRADE.md export-ignore


### PR DESCRIPTION
Hey all! This PR proposes a small change to the `.gitattributes` file.

Over the weekend, I learned about the `.gitattributes` file (I can't believe I hadn't heard of it before haha!). So I was searching through some packages to see what types of files are typically mentioned in them. When I saw the `laravel/prompts` file, I noticed a mention of `phpunit.xml.dist` but the file is called `phpunit.xml`.

As a result, this means the `phpunit.xml` file is included in the export when installing the package.

I'm not sure whether this is intentional or maybe something that was just missed off by mistake. And I don't think it matters too much in the grand scheme of things either. But I thought I'd PR the change just in case it was a typo 😄