### PR TITLE
fix: NoteRenderer padding for multibyte characters

### DIFF
--- a/src/Themes/Default/NoteRenderer.php
+++ b/src/Themes/Default/NoteRenderer.php
@@ -17,10 +17,10 @@ class NoteRenderer extends Renderer
             case 'intro':
             case 'outro':
                 $lines = array_map(fn ($line) => " {$line} ", $lines);
-                $longest = max(array_map(fn ($line) => strlen($line), $lines));
+                $longest = max(array_map(fn ($line) => mb_strlen($line), $lines));
 
                 foreach ($lines as $line) {
-                    $line = str_pad($line, $longest, ' ');
+                    $line = mb_str_pad($line, $longest, ' ');
                     $this->line(" {$this->bgCyan($this->black($line))}");
                 }
 


### PR DESCRIPTION
Replace strlen and str_pad with mb_strlen and mb_str_pad to prevent visual glitches when using Cyrillic or other non-ASCII characters.