### PR TITLE
Fix TTY handling for prompts using tmux and host php from nix

### DIFF
--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -97,7 +97,7 @@ class Terminal
      */
     protected function exec(string $command): string
     {
-        $process = proc_open($command, [
+        $process = proc_open($command.' < /dev/tty', [
             1 => ['pipe', 'w'],
             2 => ['pipe', 'w'],
         ], $pipes);


### PR DESCRIPTION
Fixes `stty: 'standard input': unable to perform all requested operations` error when running interactive prompts inside terminal multiplexers like tmux.

Without this change if you are under a tmux and try to use a command with prompt e.g
```
❱ php artisan db:table

 ┌ Which table would you like to inspect? ──────────────────────┐
 │ public.cache_locks                                           │
 └──────────────────────────────────────────────────────────────┘


   RuntimeException

  stty: 'standard input': unable to perform all requested operations

  at laravel-prompts/src/Terminal.php:117
    113▕         $stderr = stream_get_contents($pipes[2]);
    114▕         $code = proc_close($process);
    115▕
    116▕         if ($code !== 0 || $stdout === false) {
  ➜ 117▕             throw new RuntimeException(trim($stderr ?: "Unknown error (code: $code)"), $code);
    118▕         }
    119▕
    120▕         return $stdout;
    121▕     }

  1   laravel-prompts/src/Terminal.php:55
      Laravel\Prompts\Terminal::exec("stty 6902:3:4b00:5cb:4:ff:ff:7f:17:15:12:ff:3:1c:1a:19:11:13:16:f:1:0:14:ff
")

  2   laravel-prompts/src/Prompt.php:446
      Laravel\Prompts\Terminal::restoreTty()
```

## Problem
When Laravel Prompts runs inside tmux or screen, the `stty` commands executed via `proc_open()` fail because the inherited stdin doesn't properly reference the controlling terminal through the PTY layer.
## Solution
Explicitly redirect stdin from `/dev/tty` when executing stty commands. The `/dev/tty` device always refers to the controlling terminal, bypassing any PTY indirection.