### PR TITLE
Fix for increase/decrease without a min/max specified

### DIFF
--- a/src/NumberPrompt.php
+++ b/src/NumberPrompt.php
@@ -68,7 +68,7 @@ class NumberPrompt extends Prompt
     protected function increaseValue(): void
     {
         if ($this->typedValue === '') {
-            $this->typedValue = (string) $this->min;
+            $this->typedValue = (string) ($this->min === PHP_INT_MIN ? 1 : $this->min);
             $this->cursorPosition++;
 
             return;
@@ -91,7 +91,7 @@ class NumberPrompt extends Prompt
     protected function decreaseValue(): void
     {
         if ($this->typedValue === '') {
-            $this->typedValue = (string) $this->max;
+            $this->typedValue = (string) ($this->max === PHP_INT_MAX ? 0 : $this->max);
             $this->cursorPosition++;
 
             return;


### PR DESCRIPTION
When you don't specify a `min` or `max`, pressing the up or down arrow would default to `PHP_INT_MIN` or `PHP_INT_MAX` which is not very helpful. This fixes the issue with sensible defaults.