### PR TITLE
Fix for non-closure original validation in `number` prompt

### DIFF
--- a/src/NumberPrompt.php
+++ b/src/NumberPrompt.php
@@ -52,15 +52,15 @@ class NumberPrompt extends Prompt
 
             if (is_numeric($value)) {
                 if ($value < $this->min) {
-                    return 'Must be at least ' . $this->min;
+                    return 'Must be at least '.$this->min;
                 }
 
                 if ($value > $this->max) {
-                    return 'Must be less than ' . $this->max;
+                    return 'Must be less than '.$this->max;
                 }
             }
 
-            if (!$validate && !isset(static::$validateUsing)) {
+            if (! $validate && ! isset(static::$validateUsing)) {
                 return null;
             }
 

--- a/tests/Feature/NumberPromptTest.php
+++ b/tests/Feature/NumberPromptTest.php
@@ -99,7 +99,7 @@ it('falls through to the original validation', function () {
     $result = number(
         label: 'How many items do you want to buy?',
         max: 99,
-        validate: fn($value) => $value !== 99 ? 'Must be 99' : null,
+        validate: fn ($value) => $value !== 99 ? 'Must be 99' : null,
     );
 
     expect($result)->toBe(99);
@@ -132,7 +132,7 @@ it('falls through to the original validation with validation using', function ()
 
     Prompt::assertOutputContains('Must be 99');
 
-    Prompt::validateUsing(fn() => null);
+    Prompt::validateUsing(fn () => null);
 });
 
 it('starts with the minimum value when the up arrow is pressed and value is empty', function () {
@@ -287,7 +287,7 @@ it('validates the default value when non-interactive', function () {
 })->throws(NonInteractiveValidationException::class, 'Required.');
 
 it('allows customizing the cancellation', function () {
-    Prompt::cancelUsing(fn() => throw new Exception('Cancelled.'));
+    Prompt::cancelUsing(fn () => throw new Exception('Cancelled.'));
     Prompt::fake([Key::CTRL_C]);
 
     number(label: 'How many items do you want to buy?');


### PR DESCRIPTION
When using Laravel's built-in validation the `number` prompt wasn't falling back correctly, this fixes that scenario.