### PR TITLE
Fix false-y check on `default` prompt value

### DIFF
--- a/src/Concerns/TypedValue.php
+++ b/src/Concerns/TypedValue.php
@@ -23,7 +23,7 @@ trait TypedValue
     {
         $this->typedValue = $default;
 
-        if ($this->typedValue) {
+        if (strlen($this->typedValue) > 0) {
             $this->cursorPosition = mb_strlen($this->typedValue);
         }
 


### PR DESCRIPTION
This fixes a bug that places the cursor in the incorrect position when the default value is something false-y (e.g. `0`).