### PR TITLE
Feature: Add box() display element (Issue #220)

### DIFF
--- a/src/Box.php
+++ b/src/Box.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Laravel\Prompts;
+
+class Box extends Prompt
+{
+    /**
+     * Create a new Box instance.
+     */
+    public function __construct(
+        public string $message,
+        public string $title = '',
+        public string $footer = '',
+        public string $color = 'gray',
+        public string $info = '',
+    ) {
+        //
+    }
+
+    /**
+     * Display the box.
+     */
+    public function display(): void
+    {
+        $this->prompt();
+    }
+
+    /**
+     * Display the box.
+     */
+    public function prompt(): bool
+    {
+        $this->capturePreviousNewLines();
+
+        if (static::shouldFallback()) {
+            return $this->fallback();
+        }
+
+        $this->state = 'submit';
+
+        static::output()->write($this->renderTheme());
+
+        return true;
+    }
+
+    /**
+     * Get the value of the prompt.
+     */
+    public function value(): bool
+    {
+        return true;
+    }
+}

--- a/src/Concerns/Themes.php
+++ b/src/Concerns/Themes.php
@@ -3,6 +3,7 @@
 namespace Laravel\Prompts\Concerns;
 
 use InvalidArgumentException;
+use Laravel\Prompts\Box;
 use Laravel\Prompts\Clear;
 use Laravel\Prompts\ConfirmPrompt;
 use Laravel\Prompts\Grid;
@@ -23,6 +24,7 @@ use Laravel\Prompts\Table;
 use Laravel\Prompts\Task;
 use Laravel\Prompts\TextareaPrompt;
 use Laravel\Prompts\TextPrompt;
+use Laravel\Prompts\Themes\Default\BoxRenderer;
 use Laravel\Prompts\Themes\Default\ClearRenderer;
 use Laravel\Prompts\Themes\Default\ConfirmPromptRenderer;
 use Laravel\Prompts\Themes\Default\GridRenderer;
@@ -72,6 +74,7 @@ trait Themes
             SuggestPrompt::class => SuggestPromptRenderer::class,
             Spinner::class => SpinnerRenderer::class,
             Note::class => NoteRenderer::class,
+            Box::class => BoxRenderer::class,
             Table::class => TableRenderer::class,
             Progress::class => ProgressRenderer::class,
             Clear::class => ClearRenderer::class,

--- a/src/Themes/Default/BoxRenderer.php
+++ b/src/Themes/Default/BoxRenderer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Laravel\Prompts\Themes\Default;
+
+use Laravel\Prompts\Box;
+
+class BoxRenderer extends Renderer
+{
+    use Concerns\DrawsBoxes;
+
+    /**
+     * Render the box.
+     */
+    public function __invoke(Box $box): string
+    {
+        $this->box(
+            $box->title,
+            $box->message,
+            $box->footer,
+            $box->color,
+            $box->info,
+        );
+
+        return $this;
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -235,6 +235,16 @@ if (! function_exists('\Laravel\Prompts\note')) {
     }
 }
 
+if (! function_exists('\Laravel\Prompts\box')) {
+    /**
+     * Display a box.
+     */
+    function box(string $message, string $title = '', string $footer = '', string $color = 'gray', string $info = ''): void
+    {
+        (new Box($message, $title, $footer, $color, $info))->display();
+    }
+}
+
 if (! function_exists('\Laravel\Prompts\error')) {
     /**
      * Display an error.

--- a/tests/Feature/BoxTest.php
+++ b/tests/Feature/BoxTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Laravel\Prompts\Prompt;
+
+use function Laravel\Prompts\box;
+
+it('renders a simple box', function () {
+    Prompt::fake();
+
+    box('Hello World.');
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌──────────────────────────────────────────────────────────────┐
+         │ Hello World.                                                 │
+         └──────────────────────────────────────────────────────────────┘
+        OUTPUT);
+});
+
+it('renders a full box', function () {
+    Prompt::fake();
+
+    box(
+        message: "Route cache .......... cleared\nConfig cache ......... cleared\nView cache ........... cleared",
+        title: 'Cache Status',
+        footer: 'Completed in 0.42s',
+        color: 'green',
+        info: 'v1.2',
+    );
+
+    Prompt::assertStrippedOutputContains(<<<'OUTPUT'
+         ┌ Cache Status ────────────────────────────────────────────────┐
+         │ Route cache .......... cleared                               │
+         │ Config cache ......... cleared                               │
+         │ View cache ........... cleared                               │
+         ├──────────────────────────────────────────────────────────────┤
+         │ Completed in 0.42s                                           │
+         └──────────────────────────────────────────────────────── v1.2 ┘
+        OUTPUT);
+});


### PR DESCRIPTION
This PR exposes the internal `DrawsBoxes` trait as a user-facing `box()` output primitive as proposed in issue #220.
- Add Box model extending Prompt
- Added `Box` model extending `Prompt`
- Added `BoxRenderer`
- Added `box()` helper function
- Added `BoxTest.php` to verify strict output mapping

**Note**:  I haven't created a PR for the documentation updates  for [https://laravel.com/docs/12.x/prompts#available-prompts](https://laravel.com/docs/12.x/prompts#available-prompts). If this is a critical requirement for merging, please let me know and I will submit them immediately.