### PR TITLE
Allow for dynamic secondary info on select-type prompts

### DIFF
--- a/src/Concerns/HasInfo.php
+++ b/src/Concerns/HasInfo.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Prompts\Concerns;
+
+use Closure;
+
+trait HasInfo
+{
+    /**
+     * Get the resolved info text.
+     */
+    public function infoText(): string
+    {
+        if ($this->info instanceof Closure) {
+            return ($this->info)($this->highlightedValue()) ?? '';
+        }
+
+        return $this->info;
+    }
+}

--- a/src/MultiSearchPrompt.php
+++ b/src/MultiSearchPrompt.php
@@ -7,6 +7,7 @@ use Laravel\Prompts\Support\Utils;
 
 class MultiSearchPrompt extends Prompt
 {
+    use Concerns\HasInfo;
     use Concerns\Scrolling;
     use Concerns\Truncation;
     use Concerns\TypedValue;
@@ -44,6 +45,7 @@ class MultiSearchPrompt extends Prompt
         public mixed $validate = null,
         public string $hint = '',
         public ?Closure $transform = null,
+        public string|Closure $info = '',
     ) {
         $this->trackTypedValue(submit: false, ignore: fn ($key) => Key::oneOf([Key::SPACE, Key::HOME, Key::END, Key::CTRL_A, Key::CTRL_E], $key) && $this->highlighted !== null);
 
@@ -61,6 +63,22 @@ class MultiSearchPrompt extends Prompt
             Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW => $this->highlighted = null,
             default => $this->search(),
         });
+    }
+
+    /**
+     * Get the value of the highlighted option.
+     */
+    public function highlightedValue(): int|string|null
+    {
+        if ($this->highlighted === null || ! is_array($this->matches)) {
+            return null;
+        }
+
+        if ($this->isList()) {
+            return $this->matches[$this->highlighted] ?? null;
+        }
+
+        return array_keys($this->matches)[$this->highlighted] ?? null;
     }
 
     /**

--- a/src/MultiSelectPrompt.php
+++ b/src/MultiSelectPrompt.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 
 class MultiSelectPrompt extends Prompt
 {
+    use Concerns\HasInfo;
     use Concerns\Scrolling;
 
     /**
@@ -45,6 +46,7 @@ class MultiSelectPrompt extends Prompt
         public mixed $validate = null,
         public string $hint = '',
         public ?Closure $transform = null,
+        public string|Closure $info = '',
     ) {
         $this->options = $options instanceof Collection ? $options->all() : $options;
         $this->default = $default instanceof Collection ? $default->all() : $default;
@@ -62,6 +64,22 @@ class MultiSelectPrompt extends Prompt
             Key::ENTER => $this->submit(),
             default => null,
         });
+    }
+
+    /**
+     * Get the value of the highlighted option.
+     */
+    public function highlightedValue(): int|string|null
+    {
+        if ($this->highlighted === null) {
+            return null;
+        }
+
+        if (array_is_list($this->options)) {
+            return $this->options[$this->highlighted] ?? null;
+        }
+
+        return array_keys($this->options)[$this->highlighted] ?? null;
     }
 
     /**

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -7,6 +7,7 @@ use InvalidArgumentException;
 
 class SearchPrompt extends Prompt
 {
+    use Concerns\HasInfo;
     use Concerns\Scrolling;
     use Concerns\Truncation;
     use Concerns\TypedValue;
@@ -32,6 +33,7 @@ class SearchPrompt extends Prompt
         public string $hint = '',
         public bool|string $required = true,
         public ?Closure $transform = null,
+        public string|Closure $info = '',
     ) {
         if ($this->required === false) {
             throw new InvalidArgumentException('Argument [required] must be true or a string.');
@@ -50,6 +52,14 @@ class SearchPrompt extends Prompt
             Key::oneOf([Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_B, Key::CTRL_F], $key) => $this->highlighted = null,
             default => $this->search(),
         });
+    }
+
+    /**
+     * Get the value of the highlighted option.
+     */
+    public function highlightedValue(): int|string|null
+    {
+        return $this->value();
     }
 
     /**

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 
 class SelectPrompt extends Prompt
 {
+    use Concerns\HasInfo;
     use Concerns\Scrolling;
 
     /**
@@ -31,6 +32,7 @@ class SelectPrompt extends Prompt
         public string $hint = '',
         public bool|string $required = true,
         public ?Closure $transform = null,
+        public string|Closure $info = '',
     ) {
         if ($this->required === false) {
             throw new InvalidArgumentException('Argument [required] must be true or a string.');
@@ -58,6 +60,18 @@ class SelectPrompt extends Prompt
             Key::ENTER => $this->submit(),
             default => null,
         });
+    }
+
+    /**
+     * Get the value of the highlighted option.
+     */
+    public function highlightedValue(): int|string|null
+    {
+        if (array_is_list($this->options)) {
+            return $this->options[$this->highlighted] ?? null;
+        }
+
+        return array_keys($this->options)[$this->highlighted] ?? null;
     }
 
     /**

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 
 class SuggestPrompt extends Prompt
 {
+    use Concerns\HasInfo;
     use Concerns\Scrolling;
     use Concerns\Truncation;
     use Concerns\TypedValue;
@@ -40,6 +41,7 @@ class SuggestPrompt extends Prompt
         public mixed $validate = null,
         public string $hint = '',
         public ?Closure $transform = null,
+        public string|Closure $info = '',
     ) {
         $this->options = $options instanceof Collection ? $options->all() : $options;
 
@@ -60,6 +62,18 @@ class SuggestPrompt extends Prompt
         });
 
         $this->trackTypedValue($default, ignore: fn ($key) => Key::oneOf([Key::HOME, Key::END, Key::CTRL_A, Key::CTRL_E], $key) && $this->highlighted !== null);
+    }
+
+    /**
+     * Get the value of the highlighted option.
+     */
+    public function highlightedValue(): ?string
+    {
+        if ($this->highlighted === null) {
+            return null;
+        }
+
+        return $this->matches()[$this->highlighted] ?? null;
     }
 
     /**

--- a/src/Themes/Default/Concerns/DrawsBoxes.php
+++ b/src/Themes/Default/Concerns/DrawsBoxes.php
@@ -47,6 +47,10 @@ trait DrawsBoxes
             }
         }
 
+        if ($info) {
+            $info = $this->truncate($info, $width - 1);
+        }
+
         $this->line($this->{$color}(' └'.str_repeat(
             '─', $info ? ($width - mb_strwidth($this->stripEscapeSequences($info))) : ($width + 2)
         ).($info ? " {$info} " : '').'┘'));

--- a/src/Themes/Default/MultiSearchPromptRenderer.php
+++ b/src/Themes/Default/MultiSearchPromptRenderer.php
@@ -153,7 +153,7 @@ class MultiSearchPromptRenderer extends Renderer implements Scrolling
      */
     protected function getInfoText(MultiSearchPrompt $prompt): string
     {
-        $info = count($prompt->value()).' selected';
+        $selected = count($prompt->value()).' selected';
 
         $hiddenCount = count($prompt->value()) - count(array_filter(
             $prompt->matches(),
@@ -162,10 +162,12 @@ class MultiSearchPromptRenderer extends Renderer implements Scrolling
         ));
 
         if ($hiddenCount > 0) {
-            $info .= " ($hiddenCount hidden)";
+            $selected .= " ($hiddenCount hidden)";
         }
 
-        return $info;
+        $parts = array_filter([$prompt->infoText(), $selected]);
+
+        return implode(' · ', $parts);
     }
 
     /**

--- a/src/Themes/Default/MultiSelectPromptRenderer.php
+++ b/src/Themes/Default/MultiSelectPromptRenderer.php
@@ -43,7 +43,7 @@ class MultiSelectPromptRenderer extends Renderer implements Scrolling
                 ->box(
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $this->renderOptions($prompt),
-                    info: count($prompt->options) > $prompt->scroll ? (count($prompt->value()).' selected') : '',
+                    info: $this->getInfoText($prompt),
                 )
                 ->when(
                     $prompt->hint,
@@ -108,6 +108,19 @@ class MultiSelectPromptRenderer extends Renderer implements Scrolling
             fn ($label) => $this->truncate($label, $prompt->terminal()->cols() - 6),
             $prompt->labels()
         ));
+    }
+
+    /**
+     * Render the info text.
+     */
+    protected function getInfoText(MultiSelectPrompt $prompt): string
+    {
+        $parts = array_filter([
+            $prompt->infoText(),
+            count($prompt->options) > $prompt->scroll ? (count($prompt->value()).' selected') : '',
+        ]);
+
+        return implode(' · ', $parts);
     }
 
     /**

--- a/src/Themes/Default/SearchPromptRenderer.php
+++ b/src/Themes/Default/SearchPromptRenderer.php
@@ -46,6 +46,7 @@ class SearchPromptRenderer extends Renderer implements Scrolling
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $this->valueWithCursorAndSearchIcon($prompt, $maxWidth),
                     $this->renderOptions($prompt),
+                    info: $prompt->infoText(),
                 )
                 ->hint($prompt->hint),
 
@@ -54,6 +55,7 @@ class SearchPromptRenderer extends Renderer implements Scrolling
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $prompt->valueWithCursor($maxWidth),
                     $this->renderOptions($prompt),
+                    info: $prompt->infoText(),
                 )
                 ->when(
                     $prompt->hint,

--- a/src/Themes/Default/SelectPromptRenderer.php
+++ b/src/Themes/Default/SelectPromptRenderer.php
@@ -44,6 +44,7 @@ class SelectPromptRenderer extends Renderer implements Scrolling
                 ->box(
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $this->renderOptions($prompt),
+                    info: $prompt->infoText(),
                 )
                 ->when(
                     $prompt->hint,

--- a/src/Themes/Default/SuggestPromptRenderer.php
+++ b/src/Themes/Default/SuggestPromptRenderer.php
@@ -46,6 +46,7 @@ class SuggestPromptRenderer extends Renderer implements Scrolling
                     $this->cyan($this->truncate($prompt->label, $prompt->terminal()->cols() - 6)),
                     $this->valueWithCursorAndArrow($prompt, $maxWidth),
                     $this->renderOptions($prompt),
+                    info: $prompt->infoText(),
                 )
                 ->when(
                     $prompt->hint,

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -82,6 +82,7 @@ if (! function_exists('\Laravel\Prompts\select')) {
         string $hint = '',
         bool|string $required = true,
         ?Closure $transform = null,
+        string|Closure $info = '',
     ): int|string {
         return (new SelectPrompt(...get_defined_vars()))->prompt();
     }
@@ -104,6 +105,7 @@ if (! function_exists('\Laravel\Prompts\multiselect')) {
         mixed $validate = null,
         string $hint = 'Use the space bar to select options.',
         ?Closure $transform = null,
+        string|Closure $info = '',
     ): array {
         return (new MultiSelectPrompt(...get_defined_vars()))->prompt();
     }
@@ -163,6 +165,7 @@ if (! function_exists('\Laravel\Prompts\suggest')) {
         mixed $validate = null,
         string $hint = '',
         ?Closure $transform = null,
+        string|Closure $info = '',
     ): string {
         return (new SuggestPrompt(...get_defined_vars()))->prompt();
     }
@@ -184,6 +187,7 @@ if (! function_exists('\Laravel\Prompts\search')) {
         string $hint = '',
         bool|string $required = true,
         ?Closure $transform = null,
+        string|Closure $info = '',
     ): int|string {
         return (new SearchPrompt(...get_defined_vars()))->prompt();
     }
@@ -205,6 +209,7 @@ if (! function_exists('\Laravel\Prompts\multisearch')) {
         mixed $validate = null,
         string $hint = 'Use the space bar to select options.',
         ?Closure $transform = null,
+        string|Closure $info = '',
     ): array {
         return (new MultiSearchPrompt(...get_defined_vars()))->prompt();
     }


### PR DESCRIPTION
This PR adds the ability to add secondary info on select-type prompts. The new `info` param receives either a string or closure and returns a `string` or `null`, displaying info relevant to the highlighted item on the lower right of the box.


https://github.com/user-attachments/assets/814cc968-af52-49a0-8a50-011944db0230

