### PR TITLE
Render spinner statically when --no-ansi flag is used

### DIFF
--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -47,7 +47,7 @@ class Spinner extends Prompt
     {
         $this->capturePreviousNewLines();
 
-        if (! function_exists('pcntl_fork')) {
+        if (! function_exists('pcntl_fork') || ! static::output()->isDecorated()) {
             return $this->renderStatically($callback);
         }
 


### PR DESCRIPTION
## Summary
- Fixes spinner animation spamming console output when `--no-ansi` flag is passed
- Checks `isDecorated()` on the output instance and falls back to static rendering when ANSI output is disabled
- Affects CI/CD environments (GitHub Actions, Forge deployments) where `--no-ansi` is commonly used

## Test plan
- [ ] Run a command using `spin()` with `--no-ansi` flag and verify static output (no animation frames)
- [ ] Run the same command without the flag and verify animation still works normally
- [ ] Verify behavior in a CI/CD pipeline where ANSI is disabled

Fixes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)