### PR TITLE
Fix incorrect rendering of nested Symfony style tags in prompts

### DIFF
--- a/src/Themes/Default/Concerns/InteractsWithStrings.php
+++ b/src/Themes/Default/Concerns/InteractsWithStrings.php
@@ -38,8 +38,12 @@ trait InteractsWithStrings
         // Strip Symfony named style tags.
         $text = preg_replace("/<(info|comment|question|error)>(.*?)<\/\\1>/", '$2', $text);
 
-        // Strip Symfony inline style tags.
-        return preg_replace("/<(?:(?:[fb]g|options)=[a-z,;]+)+>(.*?)<\/>/i", '$1', $text);
+        // Strip Symfony inline style tags (apply repeatedly to handle nested tags).
+        do {
+            $text = preg_replace("/<(?:(?:[fb]g|options)=[a-z,;]+)+>(.*?)<\/>/i", '$1', $text, -1, $count);
+        } while ($count > 0);
+
+        return $text;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Fixes nested `<fg>` tags (e.g., `<fg=green>text <fg=yellow>name</>?</>`) rendering incorrectly in select prompt titles and other prompts
- The `stripEscapeSequences` method used a non-greedy regex that only matched the innermost tag pair, leaving residual tags that corrupted width calculations
- Now applies the Symfony inline style tag regex repeatedly until all nested levels are stripped

## Test plan
- [ ] Use `select()` with a nested foreground tag in the title: `select("<fg=green>Your action, <fg=yellow>UserName</>?</>", $options)`
- [ ] Verify the title renders correctly without visual artifacts
- [ ] Verify non-nested tags still work correctly
- [ ] Verify deeply nested tags (3+ levels) are handled

Fixes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)