### PR TITLE
Add skipUsing argument to short-circuit interactive prompts

### DIFF
--- a/src/AutoCompletePrompt.php
+++ b/src/AutoCompletePrompt.php
@@ -39,7 +39,10 @@ class AutoCompletePrompt extends Prompt
         public mixed $validate = null,
         public string $hint = '',
         public ?Closure $transform = null,
+        mixed $skipWhen = null,
     ) {
+        parent::__construct($skipWhen);
+
         $this->options = $options instanceof Collection ? $options->all() : $options;
 
         $this->on('key', function ($key) {

--- a/src/AutoCompletePrompt.php
+++ b/src/AutoCompletePrompt.php
@@ -39,9 +39,9 @@ class AutoCompletePrompt extends Prompt
         public mixed $validate = null,
         public string $hint = '',
         public ?Closure $transform = null,
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ) {
-        parent::__construct($skipWhen);
+        parent::__construct($skipUsing);
 
         $this->options = $options instanceof Collection ? $options->all() : $options;
 

--- a/src/ConfirmPrompt.php
+++ b/src/ConfirmPrompt.php
@@ -23,7 +23,10 @@ class ConfirmPrompt extends Prompt
         public mixed $validate = null,
         public string $hint = '',
         public ?Closure $transform = null,
+        mixed $skipWhen = null,
     ) {
+        parent::__construct($skipWhen);
+
         $this->confirmed = $default;
 
         $this->on('key', fn ($key) => match ($key) {
@@ -49,5 +52,23 @@ class ConfirmPrompt extends Prompt
     public function label(): string
     {
         return $this->confirmed ? $this->yes : $this->no;
+    }
+
+    /**
+     * Coerce a pre-supplied skip value into a boolean.
+     */
+    protected function coerceSkipped(mixed $value): mixed
+    {
+        if (is_bool($value) || $value === null) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            $parsed = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+            return $parsed ?? $value;
+        }
+
+        return (bool) $value;
     }
 }

--- a/src/ConfirmPrompt.php
+++ b/src/ConfirmPrompt.php
@@ -23,9 +23,9 @@ class ConfirmPrompt extends Prompt
         public mixed $validate = null,
         public string $hint = '',
         public ?Closure $transform = null,
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ) {
-        parent::__construct($skipWhen);
+        parent::__construct($skipUsing);
 
         $this->confirmed = $default;
 

--- a/src/ConfirmPrompt.php
+++ b/src/ConfirmPrompt.php
@@ -59,14 +59,18 @@ class ConfirmPrompt extends Prompt
      */
     protected function coerceSkipped(mixed $value): mixed
     {
-        if (is_bool($value) || $value === null) {
+        if (is_bool($value)) {
             return $value;
         }
 
         if (is_string($value)) {
             $parsed = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
 
-            return $parsed ?? $value;
+            if ($parsed === null) {
+                $this->throwSkippedValidation('Must be a boolean.');
+            }
+
+            return $parsed;
         }
 
         return (bool) $value;

--- a/src/DataTablePrompt.php
+++ b/src/DataTablePrompt.php
@@ -54,7 +54,10 @@ class DataTablePrompt extends Prompt
         public mixed $validate = null,
         public ?Closure $transform = null,
         public ?Closure $filter = null,
+        mixed $skipWhen = null,
     ) {
+        parent::__construct($skipWhen);
+
         if ($rows === null) {
             $rows = $headers;
             $headers = [];

--- a/src/DataTablePrompt.php
+++ b/src/DataTablePrompt.php
@@ -54,9 +54,9 @@ class DataTablePrompt extends Prompt
         public mixed $validate = null,
         public ?Closure $transform = null,
         public ?Closure $filter = null,
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ) {
-        parent::__construct($skipWhen);
+        parent::__construct($skipUsing);
 
         if ($rows === null) {
             $rows = $headers;

--- a/src/DataTablePrompt.php
+++ b/src/DataTablePrompt.php
@@ -238,6 +238,22 @@ class DataTablePrompt extends Prompt
     }
 
     /**
+     * Coerce a pre-supplied skip value into one of the available row keys.
+     */
+    protected function coerceSkipped(mixed $value): mixed
+    {
+        $keys = array_keys($this->rows);
+
+        $index = array_search($value, $keys);
+
+        if ($index === false) {
+            $this->throwSkippedValidation('Invalid selection.');
+        }
+
+        return $keys[$index];
+    }
+
+    /**
      * Get the selected row for display purposes.
      *
      * @return array<int, string>|null

--- a/src/Exceptions/SkippedValueValidationException.php
+++ b/src/Exceptions/SkippedValueValidationException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Prompts\Exceptions;
+
+class SkippedValueValidationException extends NonInteractiveValidationException
+{
+    //
+}

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -88,7 +88,7 @@ class FormBuilder
     /**
      * Prompt the user for text input.
      */
-    public function text(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null): self
+    public function text(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
     {
         return $this->runPrompt(text(...), get_defined_vars());
     }
@@ -96,7 +96,7 @@ class FormBuilder
     /**
      * Prompt the user for multiline text input.
      */
-    public function textarea(string $label, string $placeholder = '', string $default = '', bool|string $required = false, ?Closure $validate = null, string $hint = '', int $rows = 5, ?string $name = null, ?Closure $transform = null): self
+    public function textarea(string $label, string $placeholder = '', string $default = '', bool|string $required = false, ?Closure $validate = null, string $hint = '', int $rows = 5, ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
     {
         return $this->runPrompt(textarea(...), get_defined_vars());
     }
@@ -104,7 +104,7 @@ class FormBuilder
     /**
      * Prompt the user for input, hiding the value.
      */
-    public function password(string $label, string $placeholder = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null): self
+    public function password(string $label, string $placeholder = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
     {
         return $this->runPrompt(password(...), get_defined_vars());
     }
@@ -115,7 +115,7 @@ class FormBuilder
      * @param  array<int|string, string>|Collection<int|string, string>  $options
      * @param  true|string  $required
      */
-    public function select(string $label, array|Collection $options, int|string|null $default = null, int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?string $name = null, ?Closure $transform = null): self
+    public function select(string $label, array|Collection $options, int|string|null $default = null, int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
     {
         return $this->runPrompt(select(...), get_defined_vars());
     }
@@ -126,7 +126,7 @@ class FormBuilder
      * @param  array<int|string, string>|Collection<int|string, string>  $options
      * @param  array<int|string>|Collection<int, int|string>  $default
      */
-    public function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null, ?Closure $transform = null): self
+    public function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
     {
         return $this->runPrompt(multiselect(...), get_defined_vars());
     }
@@ -134,7 +134,7 @@ class FormBuilder
     /**
      * Prompt the user to confirm an action.
      */
-    public function confirm(string $label, bool $default = true, string $yes = 'Yes', string $no = 'No', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null): self
+    public function confirm(string $label, bool $default = true, string $yes = 'Yes', string $no = 'No', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
     {
         return $this->runPrompt(confirm(...), get_defined_vars());
     }
@@ -152,7 +152,7 @@ class FormBuilder
      *
      * @param  array<string>|Collection<int, string>|Closure(string): array<string>  $options
      */
-    public function suggest(string $label, array|Collection|Closure $options, string $placeholder = '', string $default = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null): self
+    public function suggest(string $label, array|Collection|Closure $options, string $placeholder = '', string $default = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
     {
         return $this->runPrompt(suggest(...), get_defined_vars());
     }
@@ -163,7 +163,7 @@ class FormBuilder
      * @param  Closure(string): array<int|string, string>  $options
      * @param  true|string  $required
      */
-    public function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?string $name = null, ?Closure $transform = null): self
+    public function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
     {
         return $this->runPrompt(search(...), get_defined_vars());
     }
@@ -173,7 +173,7 @@ class FormBuilder
      *
      * @param  Closure(string): array<int|string, string>  $options
      */
-    public function multisearch(string $label, Closure $options, string $placeholder = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null, ?Closure $transform = null): self
+    public function multisearch(string $label, Closure $options, string $placeholder = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
     {
         return $this->runPrompt(multisearch(...), get_defined_vars());
     }

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -88,7 +88,7 @@ class FormBuilder
     /**
      * Prompt the user for text input.
      */
-    public function text(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
+    public function text(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null, mixed $skipUsing = null): self
     {
         return $this->runPrompt(text(...), get_defined_vars());
     }
@@ -96,7 +96,7 @@ class FormBuilder
     /**
      * Prompt the user for multiline text input.
      */
-    public function textarea(string $label, string $placeholder = '', string $default = '', bool|string $required = false, ?Closure $validate = null, string $hint = '', int $rows = 5, ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
+    public function textarea(string $label, string $placeholder = '', string $default = '', bool|string $required = false, ?Closure $validate = null, string $hint = '', int $rows = 5, ?string $name = null, ?Closure $transform = null, mixed $skipUsing = null): self
     {
         return $this->runPrompt(textarea(...), get_defined_vars());
     }
@@ -104,7 +104,7 @@ class FormBuilder
     /**
      * Prompt the user for input, hiding the value.
      */
-    public function password(string $label, string $placeholder = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
+    public function password(string $label, string $placeholder = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null, mixed $skipUsing = null): self
     {
         return $this->runPrompt(password(...), get_defined_vars());
     }
@@ -115,7 +115,7 @@ class FormBuilder
      * @param  array<int|string, string>|Collection<int|string, string>  $options
      * @param  true|string  $required
      */
-    public function select(string $label, array|Collection $options, int|string|null $default = null, int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
+    public function select(string $label, array|Collection $options, int|string|null $default = null, int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?string $name = null, ?Closure $transform = null, mixed $skipUsing = null): self
     {
         return $this->runPrompt(select(...), get_defined_vars());
     }
@@ -126,7 +126,7 @@ class FormBuilder
      * @param  array<int|string, string>|Collection<int|string, string>  $options
      * @param  array<int|string>|Collection<int, int|string>  $default
      */
-    public function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
+    public function multiselect(string $label, array|Collection $options, array|Collection $default = [], int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null, ?Closure $transform = null, mixed $skipUsing = null): self
     {
         return $this->runPrompt(multiselect(...), get_defined_vars());
     }
@@ -134,7 +134,7 @@ class FormBuilder
     /**
      * Prompt the user to confirm an action.
      */
-    public function confirm(string $label, bool $default = true, string $yes = 'Yes', string $no = 'No', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
+    public function confirm(string $label, bool $default = true, string $yes = 'Yes', string $no = 'No', bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null, mixed $skipUsing = null): self
     {
         return $this->runPrompt(confirm(...), get_defined_vars());
     }
@@ -152,7 +152,7 @@ class FormBuilder
      *
      * @param  array<string>|Collection<int, string>|Closure(string): array<string>  $options
      */
-    public function suggest(string $label, array|Collection|Closure $options, string $placeholder = '', string $default = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
+    public function suggest(string $label, array|Collection|Closure $options, string $placeholder = '', string $default = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = '', ?string $name = null, ?Closure $transform = null, mixed $skipUsing = null): self
     {
         return $this->runPrompt(suggest(...), get_defined_vars());
     }
@@ -163,7 +163,7 @@ class FormBuilder
      * @param  Closure(string): array<int|string, string>  $options
      * @param  true|string  $required
      */
-    public function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
+    public function search(string $label, Closure $options, string $placeholder = '', int $scroll = 5, mixed $validate = null, string $hint = '', bool|string $required = true, ?string $name = null, ?Closure $transform = null, mixed $skipUsing = null): self
     {
         return $this->runPrompt(search(...), get_defined_vars());
     }
@@ -173,7 +173,7 @@ class FormBuilder
      *
      * @param  Closure(string): array<int|string, string>  $options
      */
-    public function multisearch(string $label, Closure $options, string $placeholder = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null, ?Closure $transform = null, mixed $skipWhen = null): self
+    public function multisearch(string $label, Closure $options, string $placeholder = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null, ?Closure $transform = null, mixed $skipUsing = null): self
     {
         return $this->runPrompt(multisearch(...), get_defined_vars());
     }

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -279,9 +279,9 @@ class FormBuilder
         // A skipped step resolves instantly, so reverting onto it would only bounce forward again.
         $skipUsing = $arguments['skipUsing'] ?? null;
 
-        if ($ignoreWhenReverting === false && $skipUsing !== null) {
+        if ($ignoreWhenReverting === false && $skipUsing !== null && $skipUsing !== false) {
             $ignoreWhenReverting = $skipUsing instanceof Closure
-                ? fn () => $skipUsing() !== null
+                ? fn () => ! in_array($skipUsing(), [null, false], true)
                 : true;
         }
 

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -276,6 +276,11 @@ class FormBuilder
      */
     protected function runPrompt(callable $prompt, array $arguments, bool $ignoreWhenReverting = false): self
     {
+        // A statically skipped step resolves instantly, so reverting onto it would only bounce forward again.
+        $skipUsing = $arguments['skipUsing'] ?? null;
+
+        $ignoreWhenReverting = $ignoreWhenReverting || ($skipUsing !== null && ! $skipUsing instanceof Closure);
+
         return $this->add(function (array $responses, mixed $previousResponse) use ($prompt, $arguments) {
             unset($arguments['name']);
 

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -25,7 +25,7 @@ class FormBuilder
     /**
      * Add a new step.
      */
-    public function add(Closure $step, ?string $name = null, bool $ignoreWhenReverting = false): self
+    public function add(Closure $step, ?string $name = null, bool|Closure $ignoreWhenReverting = false): self
     {
         $this->steps[] = new FormStep($step, true, $name, $ignoreWhenReverting);
 
@@ -276,10 +276,14 @@ class FormBuilder
      */
     protected function runPrompt(callable $prompt, array $arguments, bool $ignoreWhenReverting = false): self
     {
-        // A statically skipped step resolves instantly, so reverting onto it would only bounce forward again.
+        // A skipped step resolves instantly, so reverting onto it would only bounce forward again.
         $skipUsing = $arguments['skipUsing'] ?? null;
 
-        $ignoreWhenReverting = $ignoreWhenReverting || ($skipUsing !== null && ! $skipUsing instanceof Closure);
+        if ($ignoreWhenReverting === false && $skipUsing !== null) {
+            $ignoreWhenReverting = $skipUsing instanceof Closure
+                ? fn () => $skipUsing() !== null
+                : true;
+        }
 
         return $this->add(function (array $responses, mixed $previousResponse) use ($prompt, $arguments) {
             unset($arguments['name']);

--- a/src/FormStep.php
+++ b/src/FormStep.php
@@ -8,15 +8,21 @@ class FormStep
 {
     protected readonly Closure $condition;
 
+    protected readonly Closure $ignoreWhenReverting;
+
     public function __construct(
         protected readonly Closure $step,
         bool|Closure $condition,
         public readonly ?string $name,
-        protected readonly bool $ignoreWhenReverting,
+        bool|Closure $ignoreWhenReverting,
     ) {
         $this->condition = is_bool($condition)
             ? fn () => $condition
             : $condition;
+
+        $this->ignoreWhenReverting = is_bool($ignoreWhenReverting)
+            ? fn () => $ignoreWhenReverting
+            : $ignoreWhenReverting;
     }
 
     /**
@@ -54,6 +60,6 @@ class FormStep
             return true;
         }
 
-        return $this->ignoreWhenReverting;
+        return ($this->ignoreWhenReverting)();
     }
 }

--- a/src/MultiSearchPrompt.php
+++ b/src/MultiSearchPrompt.php
@@ -46,7 +46,10 @@ class MultiSearchPrompt extends Prompt
         public string $hint = '',
         public ?Closure $transform = null,
         public string|Closure $info = '',
+        mixed $skipWhen = null,
     ) {
+        parent::__construct($skipWhen);
+
         $this->trackTypedValue(submit: false, ignore: fn ($key) => Key::oneOf([Key::SPACE, Key::HOME, Key::END, Key::CTRL_A, Key::CTRL_E], $key) && $this->highlighted !== null);
 
         $this->initializeScrolling(null);

--- a/src/MultiSearchPrompt.php
+++ b/src/MultiSearchPrompt.php
@@ -69,6 +69,18 @@ class MultiSearchPrompt extends Prompt
     }
 
     /**
+     * Coerce a pre-supplied skip value into an array.
+     */
+    protected function coerceSkipped(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            $this->throwSkippedValidation('Must be an array of options.');
+        }
+
+        return $value;
+    }
+
+    /**
      * Get the value of the highlighted option.
      */
     public function highlightedValue(): int|string|null

--- a/src/MultiSearchPrompt.php
+++ b/src/MultiSearchPrompt.php
@@ -69,7 +69,7 @@ class MultiSearchPrompt extends Prompt
     }
 
     /**
-     * Coerce a pre-supplied skip value into an array.
+     * Coerce a pre-supplied skip value into an array; closure-based options cannot be membership-checked.
      */
     protected function coerceSkipped(mixed $value): mixed
     {

--- a/src/MultiSearchPrompt.php
+++ b/src/MultiSearchPrompt.php
@@ -46,9 +46,9 @@ class MultiSearchPrompt extends Prompt
         public string $hint = '',
         public ?Closure $transform = null,
         public string|Closure $info = '',
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ) {
-        parent::__construct($skipWhen);
+        parent::__construct($skipUsing);
 
         $this->trackTypedValue(submit: false, ignore: fn ($key) => Key::oneOf([Key::SPACE, Key::HOME, Key::END, Key::CTRL_A, Key::CTRL_E], $key) && $this->highlighted !== null);
 

--- a/src/MultiSelectPrompt.php
+++ b/src/MultiSelectPrompt.php
@@ -47,7 +47,10 @@ class MultiSelectPrompt extends Prompt
         public string $hint = '',
         public ?Closure $transform = null,
         public string|Closure $info = '',
+        mixed $skipWhen = null,
     ) {
+        parent::__construct($skipWhen);
+
         $this->options = $options instanceof Collection ? $options->all() : $options;
         $this->default = $default instanceof Collection ? $default->all() : $default;
         $this->values = $this->default;

--- a/src/MultiSelectPrompt.php
+++ b/src/MultiSelectPrompt.php
@@ -47,9 +47,9 @@ class MultiSelectPrompt extends Prompt
         public string $hint = '',
         public ?Closure $transform = null,
         public string|Closure $info = '',
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ) {
-        parent::__construct($skipWhen);
+        parent::__construct($skipUsing);
 
         $this->options = $options instanceof Collection ? $options->all() : $options;
         $this->default = $default instanceof Collection ? $default->all() : $default;

--- a/src/MultiSelectPrompt.php
+++ b/src/MultiSelectPrompt.php
@@ -154,6 +154,32 @@ class MultiSelectPrompt extends Prompt
     }
 
     /**
+     * Coerce a pre-supplied skip value into an array of available options.
+     */
+    protected function coerceSkipped(mixed $value): mixed
+    {
+        if ($value instanceof Collection) {
+            $value = $value->all();
+        }
+
+        if (! is_array($value)) {
+            $this->throwSkippedValidation('Must be an array of options.');
+        }
+
+        $values = array_is_list($this->options) ? array_values($this->options) : array_keys($this->options);
+
+        return array_map(function ($item) use ($values) {
+            $index = array_search($item, $values);
+
+            if ($index === false) {
+                $this->throwSkippedValidation('Invalid option.');
+            }
+
+            return $values[$index];
+        }, $value);
+    }
+
+    /**
      * Toggle the highlighted entry.
      */
     protected function toggleHighlighted(): void

--- a/src/NumberPrompt.php
+++ b/src/NumberPrompt.php
@@ -23,7 +23,10 @@ class NumberPrompt extends Prompt
         public ?int $min = null,
         public ?int $max = null,
         public ?int $step = null,
+        mixed $skipWhen = null,
     ) {
+        parent::__construct($skipWhen);
+
         $this->trackTypedValue($default);
 
         $this->step = max(1, $this->step ?? 1);
@@ -125,6 +128,18 @@ class NumberPrompt extends Prompt
         }
 
         return $this->typedValue;
+    }
+
+    /**
+     * Coerce a pre-supplied skip value into an int when numeric.
+     */
+    protected function coerceSkipped(mixed $value): mixed
+    {
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+
+        return $value;
     }
 
     /**

--- a/src/NumberPrompt.php
+++ b/src/NumberPrompt.php
@@ -23,9 +23,9 @@ class NumberPrompt extends Prompt
         public ?int $min = null,
         public ?int $max = null,
         public ?int $step = null,
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ) {
-        parent::__construct($skipWhen);
+        parent::__construct($skipUsing);
 
         $this->trackTypedValue($default);
 

--- a/src/PasswordPrompt.php
+++ b/src/PasswordPrompt.php
@@ -18,7 +18,10 @@ class PasswordPrompt extends Prompt
         public mixed $validate = null,
         public string $hint = '',
         public ?Closure $transform = null,
+        mixed $skipWhen = null,
     ) {
+        parent::__construct($skipWhen);
+
         $this->trackTypedValue();
     }
 

--- a/src/PasswordPrompt.php
+++ b/src/PasswordPrompt.php
@@ -18,9 +18,9 @@ class PasswordPrompt extends Prompt
         public mixed $validate = null,
         public string $hint = '',
         public ?Closure $transform = null,
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ) {
-        parent::__construct($skipWhen);
+        parent::__construct($skipUsing);
 
         $this->trackTypedValue();
     }

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -4,6 +4,7 @@ namespace Laravel\Prompts;
 
 use Closure;
 use Laravel\Prompts\Exceptions\FormRevertedException;
+use Laravel\Prompts\Exceptions\SkippedValueValidationException;
 use Laravel\Prompts\Output\ConsoleOutput;
 use Laravel\Prompts\Support\Result;
 use RuntimeException;
@@ -62,6 +63,11 @@ abstract class Prompt
     public mixed $validate;
 
     /**
+     * A pre-resolved value that short-circuits the prompt when not null.
+     */
+    public mixed $skipWhen = null;
+
+    /**
      * The cancellation callback.
      */
     protected static ?Closure $cancelUsing;
@@ -91,6 +97,11 @@ abstract class Prompt
      */
     protected static Terminal $terminal;
 
+    public function __construct(mixed $skipWhen = null)
+    {
+        $this->skipWhen = $skipWhen;
+    }
+
     /**
      * Get the value of the prompt.
      */
@@ -102,6 +113,10 @@ abstract class Prompt
     public function prompt(): mixed
     {
         try {
+            if ($this->skipWhen !== null) {
+                return $this->resolveSkipped();
+            }
+
             $this->capturePreviousNewLines();
 
             if (static::shouldFallback()) {
@@ -391,15 +406,25 @@ abstract class Prompt
     {
         $this->validated = true;
 
-        if ($this->required !== false && $this->isInvalidWhenRequired($value)) {
-            $this->state = 'error';
-            $this->error = is_string($this->required) && strlen($this->required) > 0 ? $this->required : 'Required.';
+        $error = $this->performValidation($value);
 
-            return;
+        if ($error !== null) {
+            $this->state = 'error';
+            $this->error = $error;
+        }
+    }
+
+    /**
+     * Return the validation error for the given value, if any.
+     */
+    private function performValidation(mixed $value): ?string
+    {
+        if ($this->required !== false && $this->isInvalidWhenRequired($value)) {
+            return is_string($this->required) && strlen($this->required) > 0 ? $this->required : 'Required.';
         }
 
         if (! isset($this->validate) && ! isset(static::$validateUsing)) {
-            return;
+            return null;
         }
 
         $error = match (true) {
@@ -412,10 +437,7 @@ abstract class Prompt
             throw new RuntimeException('The validator must return a string or null.');
         }
 
-        if (is_string($error) && strlen($error) > 0) {
-            $this->state = 'error';
-            $this->error = $error;
-        }
+        return is_string($error) && strlen($error) > 0 ? $error : null;
     }
 
     /**
@@ -424,6 +446,35 @@ abstract class Prompt
     protected function isInvalidWhenRequired(mixed $value): bool
     {
         return $value === '' || $value === [] || $value === false || $value === null;
+    }
+
+    /**
+     * Coerce a pre-supplied skip value.
+     */
+    protected function coerceSkipped(mixed $value): mixed
+    {
+        return $value;
+    }
+
+    /**
+     * Resolve the pre-supplied skip value.
+     */
+    protected function resolveSkipped(): mixed
+    {
+        $this->state = 'initial';
+        $this->error = '';
+
+        $value = $this->transform($this->coerceSkipped($this->skipWhen));
+
+        $error = $this->performValidation($value);
+
+        if ($error !== null) {
+            $label = property_exists($this, 'label') && $this->label !== '' ? "{$this->label}: " : '';
+
+            throw new SkippedValueValidationException("{$label}{$error}");
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -63,7 +63,7 @@ abstract class Prompt
     public mixed $validate;
 
     /**
-     * A pre-resolved value, or a resolver closure, that short-circuits the prompt when it yields a non-null value.
+     * A pre-resolved value, or a resolver closure, that short-circuits the prompt when it yields a value other than null or false.
      */
     public mixed $skipUsing = null;
 
@@ -115,7 +115,7 @@ abstract class Prompt
         try {
             $skipped = $this->skipUsing instanceof Closure ? ($this->skipUsing)() : $this->skipUsing;
 
-            if ($skipped !== null) {
+            if ($skipped !== null && $skipped !== false) {
                 return $this->resolveSkipped($skipped);
             }
 

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -63,9 +63,9 @@ abstract class Prompt
     public mixed $validate;
 
     /**
-     * A pre-resolved value that short-circuits the prompt when not null.
+     * A pre-resolved value, or a resolver closure, that short-circuits the prompt when it yields a non-null value.
      */
-    public mixed $skipWhen = null;
+    public mixed $skipUsing = null;
 
     /**
      * The cancellation callback.
@@ -97,9 +97,9 @@ abstract class Prompt
      */
     protected static Terminal $terminal;
 
-    public function __construct(mixed $skipWhen = null)
+    public function __construct(mixed $skipUsing = null)
     {
-        $this->skipWhen = $skipWhen;
+        $this->skipUsing = $skipUsing;
     }
 
     /**
@@ -113,8 +113,10 @@ abstract class Prompt
     public function prompt(): mixed
     {
         try {
-            if ($this->skipWhen !== null) {
-                return $this->resolveSkipped();
+            $skipped = $this->skipUsing instanceof Closure ? ($this->skipUsing)() : $this->skipUsing;
+
+            if ($skipped !== null) {
+                return $this->resolveSkipped($skipped);
             }
 
             $this->capturePreviousNewLines();
@@ -459,22 +461,27 @@ abstract class Prompt
     /**
      * Resolve the pre-supplied skip value.
      */
-    protected function resolveSkipped(): mixed
+    protected function resolveSkipped(mixed $value): mixed
     {
-        $this->state = 'initial';
-        $this->error = '';
-
-        $value = $this->transform($this->coerceSkipped($this->skipWhen));
+        $value = $this->transform($this->coerceSkipped($value));
 
         $error = $this->performValidation($value);
 
         if ($error !== null) {
-            $label = property_exists($this, 'label') && $this->label !== '' ? "{$this->label}: " : '';
-
-            throw new SkippedValueValidationException("{$label}{$error}");
+            $this->throwSkippedValidation($error);
         }
 
         return $value;
+    }
+
+    /**
+     * Throw a validation exception for an invalid skip value.
+     */
+    protected function throwSkippedValidation(string $error): never
+    {
+        $label = property_exists($this, 'label') && $this->label !== '' ? "{$this->label}: " : '';
+
+        throw new SkippedValueValidationException("{$label}{$error}");
     }
 
     /**

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -34,7 +34,10 @@ class SearchPrompt extends Prompt
         public bool|string $required = true,
         public ?Closure $transform = null,
         public string|Closure $info = '',
+        mixed $skipWhen = null,
     ) {
+        parent::__construct($skipWhen);
+
         if ($this->required === false) {
             throw new InvalidArgumentException('Argument [required] must be true or a string.');
         }

--- a/src/SearchPrompt.php
+++ b/src/SearchPrompt.php
@@ -34,9 +34,9 @@ class SearchPrompt extends Prompt
         public bool|string $required = true,
         public ?Closure $transform = null,
         public string|Closure $info = '',
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ) {
-        parent::__construct($skipWhen);
+        parent::__construct($skipUsing);
 
         if ($this->required === false) {
             throw new InvalidArgumentException('Argument [required] must be true or a string.');

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -33,7 +33,10 @@ class SelectPrompt extends Prompt
         public bool|string $required = true,
         public ?Closure $transform = null,
         public string|Closure $info = '',
+        mixed $skipWhen = null,
     ) {
+        parent::__construct($skipWhen);
+
         if ($this->required === false) {
             throw new InvalidArgumentException('Argument [required] must be true or a string.');
         }

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -122,4 +122,20 @@ class SelectPrompt extends Prompt
     {
         return $value === null;
     }
+
+    /**
+     * Coerce a pre-supplied skip value into one of the available options.
+     */
+    protected function coerceSkipped(mixed $value): mixed
+    {
+        $values = array_is_list($this->options) ? array_values($this->options) : array_keys($this->options);
+
+        $index = array_search($value, $values);
+
+        if ($index === false) {
+            $this->throwSkippedValidation('Invalid option.');
+        }
+
+        return $values[$index];
+    }
 }

--- a/src/SelectPrompt.php
+++ b/src/SelectPrompt.php
@@ -33,9 +33,9 @@ class SelectPrompt extends Prompt
         public bool|string $required = true,
         public ?Closure $transform = null,
         public string|Closure $info = '',
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ) {
-        parent::__construct($skipWhen);
+        parent::__construct($skipUsing);
 
         if ($this->required === false) {
             throw new InvalidArgumentException('Argument [required] must be true or a string.');

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -42,7 +42,10 @@ class SuggestPrompt extends Prompt
         public string $hint = '',
         public ?Closure $transform = null,
         public string|Closure $info = '',
+        mixed $skipWhen = null,
     ) {
+        parent::__construct($skipWhen);
+
         $this->options = $options instanceof Collection ? $options->all() : $options;
 
         $this->initializeScrolling(null);

--- a/src/SuggestPrompt.php
+++ b/src/SuggestPrompt.php
@@ -42,9 +42,9 @@ class SuggestPrompt extends Prompt
         public string $hint = '',
         public ?Closure $transform = null,
         public string|Closure $info = '',
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ) {
-        parent::__construct($skipWhen);
+        parent::__construct($skipUsing);
 
         $this->options = $options instanceof Collection ? $options->all() : $options;
 

--- a/src/TextPrompt.php
+++ b/src/TextPrompt.php
@@ -19,7 +19,10 @@ class TextPrompt extends Prompt
         public mixed $validate = null,
         public string $hint = '',
         public ?Closure $transform = null,
+        mixed $skipWhen = null,
     ) {
+        parent::__construct($skipWhen);
+
         $this->trackTypedValue($default);
     }
 

--- a/src/TextPrompt.php
+++ b/src/TextPrompt.php
@@ -19,9 +19,9 @@ class TextPrompt extends Prompt
         public mixed $validate = null,
         public string $hint = '',
         public ?Closure $transform = null,
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ) {
-        parent::__construct($skipWhen);
+        parent::__construct($skipUsing);
 
         $this->trackTypedValue($default);
     }

--- a/src/TextareaPrompt.php
+++ b/src/TextareaPrompt.php
@@ -31,7 +31,10 @@ class TextareaPrompt extends Prompt
         public string $hint = '',
         int $rows = 5,
         public ?Closure $transform = null,
+        mixed $skipWhen = null,
     ) {
+        parent::__construct($skipWhen);
+
         $this->scroll = $rows;
 
         $this->initializeScrolling();

--- a/src/TextareaPrompt.php
+++ b/src/TextareaPrompt.php
@@ -31,9 +31,9 @@ class TextareaPrompt extends Prompt
         public string $hint = '',
         int $rows = 5,
         public ?Closure $transform = null,
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ) {
-        parent::__construct($skipWhen);
+        parent::__construct($skipUsing);
 
         $this->scroll = $rows;
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -17,6 +17,7 @@ if (! function_exists('\Laravel\Prompts\text')) {
         mixed $validate = null,
         string $hint = '',
         ?Closure $transform = null,
+        mixed $skipWhen = null,
     ): string {
         return (new TextPrompt(...get_defined_vars()))->prompt();
     }
@@ -37,6 +38,7 @@ if (! function_exists('\Laravel\Prompts\autocomplete')) {
         mixed $validate = null,
         string $hint = '',
         ?Closure $transform = null,
+        mixed $skipWhen = null,
     ): string {
         return (new AutoCompletePrompt(...get_defined_vars()))->prompt();
     }
@@ -46,7 +48,7 @@ if (! function_exists('\Laravel\Prompts\number')) {
     /**
      * Prompt the user for number input.
      */
-    function number(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?int $min = null, ?int $max = null, ?int $step = null): int|string
+    function number(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?int $min = null, ?int $max = null, ?int $step = null, mixed $skipWhen = null): int|string
     {
         return (new NumberPrompt(...get_defined_vars()))->prompt();
     }
@@ -65,6 +67,7 @@ if (! function_exists('\Laravel\Prompts\textarea')) {
         string $hint = '',
         int $rows = 5,
         ?Closure $transform = null,
+        mixed $skipWhen = null,
     ): string {
         return (new TextareaPrompt(...get_defined_vars()))->prompt();
     }
@@ -81,6 +84,7 @@ if (! function_exists('\Laravel\Prompts\password')) {
         mixed $validate = null,
         string $hint = '',
         ?Closure $transform = null,
+        mixed $skipWhen = null,
     ): string {
         return (new PasswordPrompt(...get_defined_vars()))->prompt();
     }
@@ -103,6 +107,7 @@ if (! function_exists('\Laravel\Prompts\select')) {
         bool|string $required = true,
         ?Closure $transform = null,
         string|Closure $info = '',
+        mixed $skipWhen = null,
     ): int|string {
         return (new SelectPrompt(...get_defined_vars()))->prompt();
     }
@@ -126,6 +131,7 @@ if (! function_exists('\Laravel\Prompts\multiselect')) {
         string $hint = 'Use the space bar to select options.',
         ?Closure $transform = null,
         string|Closure $info = '',
+        mixed $skipWhen = null,
     ): array {
         return (new MultiSelectPrompt(...get_defined_vars()))->prompt();
     }
@@ -144,6 +150,7 @@ if (! function_exists('\Laravel\Prompts\confirm')) {
         mixed $validate = null,
         string $hint = '',
         ?Closure $transform = null,
+        mixed $skipWhen = null,
     ): bool {
         return (new ConfirmPrompt(...get_defined_vars()))->prompt();
     }
@@ -186,6 +193,7 @@ if (! function_exists('\Laravel\Prompts\suggest')) {
         string $hint = '',
         ?Closure $transform = null,
         string|Closure $info = '',
+        mixed $skipWhen = null,
     ): string {
         return (new SuggestPrompt(...get_defined_vars()))->prompt();
     }
@@ -208,6 +216,7 @@ if (! function_exists('\Laravel\Prompts\search')) {
         bool|string $required = true,
         ?Closure $transform = null,
         string|Closure $info = '',
+        mixed $skipWhen = null,
     ): int|string {
         return (new SearchPrompt(...get_defined_vars()))->prompt();
     }
@@ -230,6 +239,7 @@ if (! function_exists('\Laravel\Prompts\multisearch')) {
         string $hint = 'Use the space bar to select options.',
         ?Closure $transform = null,
         string|Closure $info = '',
+        mixed $skipWhen = null,
     ): array {
         return (new MultiSearchPrompt(...get_defined_vars()))->prompt();
     }
@@ -447,6 +457,7 @@ if (! function_exists('\Laravel\Prompts\datatable')) {
         mixed $validate = null,
         ?Closure $transform = null,
         ?Closure $filter = null,
+        mixed $skipWhen = null,
     ): mixed {
         return (new DataTablePrompt(
             headers: $headers,
@@ -458,6 +469,7 @@ if (! function_exists('\Laravel\Prompts\datatable')) {
             validate: $validate,
             transform: $transform,
             filter: $filter,
+            skipWhen: $skipWhen,
         ))->prompt();
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -17,7 +17,7 @@ if (! function_exists('\Laravel\Prompts\text')) {
         mixed $validate = null,
         string $hint = '',
         ?Closure $transform = null,
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ): string {
         return (new TextPrompt(...get_defined_vars()))->prompt();
     }
@@ -38,7 +38,7 @@ if (! function_exists('\Laravel\Prompts\autocomplete')) {
         mixed $validate = null,
         string $hint = '',
         ?Closure $transform = null,
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ): string {
         return (new AutoCompletePrompt(...get_defined_vars()))->prompt();
     }
@@ -48,7 +48,7 @@ if (! function_exists('\Laravel\Prompts\number')) {
     /**
      * Prompt the user for number input.
      */
-    function number(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?int $min = null, ?int $max = null, ?int $step = null, mixed $skipWhen = null): int|string
+    function number(string $label, string $placeholder = '', string $default = '', bool|string $required = false, mixed $validate = null, string $hint = '', ?int $min = null, ?int $max = null, ?int $step = null, mixed $skipUsing = null): int|string
     {
         return (new NumberPrompt(...get_defined_vars()))->prompt();
     }
@@ -67,7 +67,7 @@ if (! function_exists('\Laravel\Prompts\textarea')) {
         string $hint = '',
         int $rows = 5,
         ?Closure $transform = null,
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ): string {
         return (new TextareaPrompt(...get_defined_vars()))->prompt();
     }
@@ -84,7 +84,7 @@ if (! function_exists('\Laravel\Prompts\password')) {
         mixed $validate = null,
         string $hint = '',
         ?Closure $transform = null,
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ): string {
         return (new PasswordPrompt(...get_defined_vars()))->prompt();
     }
@@ -107,7 +107,7 @@ if (! function_exists('\Laravel\Prompts\select')) {
         bool|string $required = true,
         ?Closure $transform = null,
         string|Closure $info = '',
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ): int|string {
         return (new SelectPrompt(...get_defined_vars()))->prompt();
     }
@@ -131,7 +131,7 @@ if (! function_exists('\Laravel\Prompts\multiselect')) {
         string $hint = 'Use the space bar to select options.',
         ?Closure $transform = null,
         string|Closure $info = '',
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ): array {
         return (new MultiSelectPrompt(...get_defined_vars()))->prompt();
     }
@@ -150,7 +150,7 @@ if (! function_exists('\Laravel\Prompts\confirm')) {
         mixed $validate = null,
         string $hint = '',
         ?Closure $transform = null,
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ): bool {
         return (new ConfirmPrompt(...get_defined_vars()))->prompt();
     }
@@ -193,7 +193,7 @@ if (! function_exists('\Laravel\Prompts\suggest')) {
         string $hint = '',
         ?Closure $transform = null,
         string|Closure $info = '',
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ): string {
         return (new SuggestPrompt(...get_defined_vars()))->prompt();
     }
@@ -216,7 +216,7 @@ if (! function_exists('\Laravel\Prompts\search')) {
         bool|string $required = true,
         ?Closure $transform = null,
         string|Closure $info = '',
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ): int|string {
         return (new SearchPrompt(...get_defined_vars()))->prompt();
     }
@@ -239,7 +239,7 @@ if (! function_exists('\Laravel\Prompts\multisearch')) {
         string $hint = 'Use the space bar to select options.',
         ?Closure $transform = null,
         string|Closure $info = '',
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ): array {
         return (new MultiSearchPrompt(...get_defined_vars()))->prompt();
     }
@@ -457,7 +457,7 @@ if (! function_exists('\Laravel\Prompts\datatable')) {
         mixed $validate = null,
         ?Closure $transform = null,
         ?Closure $filter = null,
-        mixed $skipWhen = null,
+        mixed $skipUsing = null,
     ): mixed {
         return (new DataTablePrompt(
             headers: $headers,
@@ -469,7 +469,7 @@ if (! function_exists('\Laravel\Prompts\datatable')) {
             validate: $validate,
             transform: $transform,
             filter: $filter,
-            skipWhen: $skipWhen,
+            skipUsing: $skipUsing,
         ))->prompt();
     }
 }

--- a/tests/Feature/AutoCompletePromptTest.php
+++ b/tests/Feature/AutoCompletePromptTest.php
@@ -2,6 +2,7 @@
 
 use Laravel\Prompts\AutoCompletePrompt;
 use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
+use Laravel\Prompts\Exceptions\SkippedValueValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 
@@ -233,3 +234,26 @@ it('supports custom validation', function () {
 
     Prompt::validateUsing(fn () => null);
 });
+
+it('skips the prompt when skipWhen is provided', function () {
+    Prompt::fake([]);
+
+    $result = autocomplete(
+        label: 'Pick',
+        options: ['Alpha', 'Beta'],
+        skipWhen: 'Alpha',
+    );
+
+    expect($result)->toBe('Alpha');
+});
+
+it('throws when a skipWhen value is invalid', function () {
+    Prompt::fake([]);
+
+    autocomplete(
+        label: 'Pick',
+        options: ['Alpha'],
+        required: true,
+        skipWhen: '',
+    );
+})->throws(SkippedValueValidationException::class, 'Required.');

--- a/tests/Feature/AutoCompletePromptTest.php
+++ b/tests/Feature/AutoCompletePromptTest.php
@@ -235,25 +235,25 @@ it('supports custom validation', function () {
     Prompt::validateUsing(fn () => null);
 });
 
-it('skips the prompt when skipWhen is provided', function () {
+it('skips the prompt when skipUsing is provided', function () {
     Prompt::fake([]);
 
     $result = autocomplete(
         label: 'Pick',
         options: ['Alpha', 'Beta'],
-        skipWhen: 'Alpha',
+        skipUsing: 'Alpha',
     );
 
     expect($result)->toBe('Alpha');
 });
 
-it('throws when a skipWhen value is invalid', function () {
+it('throws when a skipUsing value is invalid', function () {
     Prompt::fake([]);
 
     autocomplete(
         label: 'Pick',
         options: ['Alpha'],
         required: true,
-        skipWhen: '',
+        skipUsing: '',
     );
 })->throws(SkippedValueValidationException::class, 'Required.');

--- a/tests/Feature/ConfirmPromptTest.php
+++ b/tests/Feature/ConfirmPromptTest.php
@@ -2,6 +2,7 @@
 
 use Laravel\Prompts\ConfirmPrompt;
 use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
+use Laravel\Prompts\Exceptions\SkippedValueValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 
@@ -147,3 +148,45 @@ it('supports custom validation', function () {
 
     Prompt::validateUsing(fn () => null);
 });
+
+it('skips the prompt when skipWhen is true', function () {
+    Prompt::fake([]);
+
+    $result = confirm(label: 'Are you sure?', skipWhen: true);
+
+    expect($result)->toBeTrue();
+});
+
+it('skips the prompt when skipWhen is false', function () {
+    Prompt::fake([]);
+
+    $result = confirm(label: 'Are you sure?', skipWhen: false);
+
+    expect($result)->toBeFalse();
+});
+
+it('throws when a skipWhen value fails validation', function () {
+    Prompt::fake([]);
+
+    confirm(
+        label: 'Are you sure?',
+        validate: fn ($value) => $value === false ? 'Must agree.' : null,
+        skipWhen: false,
+    );
+})->throws(SkippedValueValidationException::class, 'Must agree.');
+
+it('coerces truthy string skipWhen values to bool', function (string $input) {
+    Prompt::fake([]);
+
+    $result = confirm(label: 'Are you sure?', skipWhen: $input);
+
+    expect($result)->toBeTrue();
+})->with(['1', 'true', 'yes', 'on', 'TRUE', 'Yes']);
+
+it('coerces falsy string skipWhen values to bool', function (string $input) {
+    Prompt::fake([]);
+
+    $result = confirm(label: 'Are you sure?', skipWhen: $input);
+
+    expect($result)->toBeFalse();
+})->with(['0', 'false', 'no', 'off', 'FALSE', 'No']);

--- a/tests/Feature/ConfirmPromptTest.php
+++ b/tests/Feature/ConfirmPromptTest.php
@@ -190,3 +190,9 @@ it('coerces falsy string skipUsing values to bool', function (string $input) {
 
     expect($result)->toBeFalse();
 })->with(['0', 'false', 'no', 'off', 'FALSE', 'No']);
+
+it('throws when a skipUsing string is not a boolean', function (string $input) {
+    Prompt::fake([]);
+
+    confirm(label: 'Are you sure?', skipUsing: $input);
+})->with(['maybe', 'y', 'n'])->throws(SkippedValueValidationException::class, 'Must be a boolean.');

--- a/tests/Feature/ConfirmPromptTest.php
+++ b/tests/Feature/ConfirmPromptTest.php
@@ -149,44 +149,44 @@ it('supports custom validation', function () {
     Prompt::validateUsing(fn () => null);
 });
 
-it('skips the prompt when skipWhen is true', function () {
+it('skips the prompt when skipUsing is true', function () {
     Prompt::fake([]);
 
-    $result = confirm(label: 'Are you sure?', skipWhen: true);
+    $result = confirm(label: 'Are you sure?', skipUsing: true);
 
     expect($result)->toBeTrue();
 });
 
-it('skips the prompt when skipWhen is false', function () {
+it('skips the prompt when skipUsing is false', function () {
     Prompt::fake([]);
 
-    $result = confirm(label: 'Are you sure?', skipWhen: false);
+    $result = confirm(label: 'Are you sure?', skipUsing: false);
 
     expect($result)->toBeFalse();
 });
 
-it('throws when a skipWhen value fails validation', function () {
+it('throws when a skipUsing value fails validation', function () {
     Prompt::fake([]);
 
     confirm(
         label: 'Are you sure?',
         validate: fn ($value) => $value === false ? 'Must agree.' : null,
-        skipWhen: false,
+        skipUsing: false,
     );
 })->throws(SkippedValueValidationException::class, 'Must agree.');
 
-it('coerces truthy string skipWhen values to bool', function (string $input) {
+it('coerces truthy string skipUsing values to bool', function (string $input) {
     Prompt::fake([]);
 
-    $result = confirm(label: 'Are you sure?', skipWhen: $input);
+    $result = confirm(label: 'Are you sure?', skipUsing: $input);
 
     expect($result)->toBeTrue();
 })->with(['1', 'true', 'yes', 'on', 'TRUE', 'Yes']);
 
-it('coerces falsy string skipWhen values to bool', function (string $input) {
+it('coerces falsy string skipUsing values to bool', function (string $input) {
     Prompt::fake([]);
 
-    $result = confirm(label: 'Are you sure?', skipWhen: $input);
+    $result = confirm(label: 'Are you sure?', skipUsing: $input);
 
     expect($result)->toBeFalse();
 })->with(['0', 'false', 'no', 'off', 'FALSE', 'No']);

--- a/tests/Feature/ConfirmPromptTest.php
+++ b/tests/Feature/ConfirmPromptTest.php
@@ -157,12 +157,12 @@ it('skips the prompt when skipUsing is true', function () {
     expect($result)->toBeTrue();
 });
 
-it('skips the prompt when skipUsing is false', function () {
-    Prompt::fake([]);
+it('treats a false skipUsing value as not provided', function () {
+    Prompt::fake([Key::ENTER]);
 
     $result = confirm(label: 'Are you sure?', skipUsing: false);
 
-    expect($result)->toBeFalse();
+    expect($result)->toBeTrue();
 });
 
 it('throws when a skipUsing value fails validation', function () {
@@ -171,7 +171,7 @@ it('throws when a skipUsing value fails validation', function () {
     confirm(
         label: 'Are you sure?',
         validate: fn ($value) => $value === false ? 'Must agree.' : null,
-        skipUsing: false,
+        skipUsing: 'no',
     );
 })->throws(SkippedValueValidationException::class, 'Must agree.');
 

--- a/tests/Feature/DataTablePromptTest.php
+++ b/tests/Feature/DataTablePromptTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Laravel\Prompts\Exceptions\SkippedValueValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 
@@ -539,3 +540,28 @@ it('maintains fixed visual height', function () {
         expect($dataLineCount)->toBe(5);
     }
 });
+
+it('skips the prompt when skipWhen is provided', function () {
+    Prompt::fake([]);
+
+    $result = datatable(
+        label: 'Select a user',
+        headers: ['Name'],
+        rows: [['Alice'], ['Bob']],
+        skipWhen: 1,
+    );
+
+    expect($result)->toBe(1);
+});
+
+it('throws when a skipWhen value is invalid', function () {
+    Prompt::fake([]);
+
+    datatable(
+        label: 'Select a user',
+        headers: ['Name'],
+        rows: [['Alice']],
+        validate: fn ($value) => $value === 0 ? null : 'Invalid selection.',
+        skipWhen: 99,
+    );
+})->throws(SkippedValueValidationException::class, 'Invalid selection.');

--- a/tests/Feature/DataTablePromptTest.php
+++ b/tests/Feature/DataTablePromptTest.php
@@ -554,14 +554,13 @@ it('skips the prompt when skipUsing is provided', function () {
     expect($result)->toBe(1);
 });
 
-it('throws when a skipUsing value is invalid', function () {
+it('throws when a skipUsing value is not an available row', function () {
     Prompt::fake([]);
 
     datatable(
         label: 'Select a user',
         headers: ['Name'],
         rows: [['Alice']],
-        validate: fn ($value) => $value === 0 ? null : 'Invalid selection.',
         skipUsing: 99,
     );
 })->throws(SkippedValueValidationException::class, 'Invalid selection.');

--- a/tests/Feature/DataTablePromptTest.php
+++ b/tests/Feature/DataTablePromptTest.php
@@ -541,20 +541,20 @@ it('maintains fixed visual height', function () {
     }
 });
 
-it('skips the prompt when skipWhen is provided', function () {
+it('skips the prompt when skipUsing is provided', function () {
     Prompt::fake([]);
 
     $result = datatable(
         label: 'Select a user',
         headers: ['Name'],
         rows: [['Alice'], ['Bob']],
-        skipWhen: 1,
+        skipUsing: 1,
     );
 
     expect($result)->toBe(1);
 });
 
-it('throws when a skipWhen value is invalid', function () {
+it('throws when a skipUsing value is invalid', function () {
     Prompt::fake([]);
 
     datatable(
@@ -562,6 +562,6 @@ it('throws when a skipWhen value is invalid', function () {
         headers: ['Name'],
         rows: [['Alice']],
         validate: fn ($value) => $value === 0 ? null : 'Invalid selection.',
-        skipWhen: 99,
+        skipUsing: 99,
     );
 })->throws(SkippedValueValidationException::class, 'Invalid selection.');

--- a/tests/Feature/FormTest.php
+++ b/tests/Feature/FormTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Laravel\Prompts\Exceptions\SkippedValueValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 
@@ -227,3 +228,41 @@ it('leaves skipped conditional field empty', function () {
         true,
     ]);
 });
+
+it('skips every form step when skipWhen is provided on each', function () {
+    Prompt::fake([]);
+
+    $responses = form()
+        ->text('What is your name?', skipWhen: 'Taylor')
+        ->select('What is your language?', ['PHP', 'JS'], skipWhen: 'PHP')
+        ->confirm('Are you sure?', skipWhen: true)
+        ->submit();
+
+    expect($responses)->toBe([
+        'Taylor',
+        'PHP',
+        true,
+    ]);
+});
+
+it('only prompts the steps without skipWhen', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $responses = form()
+        ->text('What is your name?', skipWhen: 'Taylor')
+        ->confirm('Are you sure?')
+        ->submit();
+
+    expect($responses)->toBe([
+        'Taylor',
+        true,
+    ]);
+});
+
+it('throws from a form step with an invalid skipWhen value', function () {
+    Prompt::fake([]);
+
+    form()
+        ->text('What is your name?', required: true, skipWhen: '')
+        ->submit();
+})->throws(SkippedValueValidationException::class, 'Required.');

--- a/tests/Feature/FormTest.php
+++ b/tests/Feature/FormTest.php
@@ -229,13 +229,13 @@ it('leaves skipped conditional field empty', function () {
     ]);
 });
 
-it('skips every form step when skipWhen is provided on each', function () {
+it('skips every form step when skipUsing is provided on each', function () {
     Prompt::fake([]);
 
     $responses = form()
-        ->text('What is your name?', skipWhen: 'Taylor')
-        ->select('What is your language?', ['PHP', 'JS'], skipWhen: 'PHP')
-        ->confirm('Are you sure?', skipWhen: true)
+        ->text('What is your name?', skipUsing: 'Taylor')
+        ->select('What is your language?', ['PHP', 'JS'], skipUsing: 'PHP')
+        ->confirm('Are you sure?', skipUsing: true)
         ->submit();
 
     expect($responses)->toBe([
@@ -245,11 +245,11 @@ it('skips every form step when skipWhen is provided on each', function () {
     ]);
 });
 
-it('only prompts the steps without skipWhen', function () {
+it('only prompts the steps without skipUsing', function () {
     Prompt::fake([Key::ENTER]);
 
     $responses = form()
-        ->text('What is your name?', skipWhen: 'Taylor')
+        ->text('What is your name?', skipUsing: 'Taylor')
         ->confirm('Are you sure?')
         ->submit();
 
@@ -259,10 +259,10 @@ it('only prompts the steps without skipWhen', function () {
     ]);
 });
 
-it('throws from a form step with an invalid skipWhen value', function () {
+it('throws from a form step with an invalid skipUsing value', function () {
     Prompt::fake([]);
 
     form()
-        ->text('What is your name?', required: true, skipWhen: '')
+        ->text('What is your name?', required: true, skipUsing: '')
         ->submit();
 })->throws(SkippedValueValidationException::class, 'Required.');

--- a/tests/Feature/FormTest.php
+++ b/tests/Feature/FormTest.php
@@ -282,3 +282,19 @@ it('reverts past skipped steps to the previous prompt', function () {
         '',
     ]);
 });
+
+it('reverts past closure-skipped steps to the previous prompt', function () {
+    Prompt::fake(['A', Key::ENTER, Key::CTRL_U, 'B', Key::ENTER, Key::ENTER]);
+
+    $responses = form()
+        ->text('First?')
+        ->text('Second?', skipUsing: fn () => 'Skipped')
+        ->text('Third?')
+        ->submit();
+
+    expect($responses)->toBe([
+        'AB',
+        'Skipped',
+        '',
+    ]);
+});

--- a/tests/Feature/FormTest.php
+++ b/tests/Feature/FormTest.php
@@ -266,3 +266,19 @@ it('throws from a form step with an invalid skipUsing value', function () {
         ->text('What is your name?', required: true, skipUsing: '')
         ->submit();
 })->throws(SkippedValueValidationException::class, 'Required.');
+
+it('reverts past skipped steps to the previous prompt', function () {
+    Prompt::fake(['A', Key::ENTER, Key::CTRL_U, 'B', Key::ENTER, Key::ENTER]);
+
+    $responses = form()
+        ->text('First?')
+        ->text('Second?', skipUsing: 'Skipped')
+        ->text('Third?')
+        ->submit();
+
+    expect($responses)->toBe([
+        'AB',
+        'Skipped',
+        '',
+    ]);
+});

--- a/tests/Feature/MultiSearchPromptTest.php
+++ b/tests/Feature/MultiSearchPromptTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Laravel\Prompts\Exceptions\SkippedValueValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\MultiSearchPrompt;
 use Laravel\Prompts\Prompt;
@@ -384,3 +385,26 @@ it('supports selecting all options', function () {
 
     expect($result)->toBe([]);
 });
+
+it('skips the prompt when skipWhen is provided', function () {
+    Prompt::fake([]);
+
+    $result = multisearch(
+        label: 'Search',
+        options: fn () => ['a' => 'A', 'b' => 'B'],
+        skipWhen: ['a', 'b'],
+    );
+
+    expect($result)->toBe(['a', 'b']);
+});
+
+it('throws when a skipWhen value fails validation', function () {
+    Prompt::fake([]);
+
+    multisearch(
+        label: 'Search',
+        options: fn () => ['a' => 'A'],
+        required: true,
+        skipWhen: [],
+    );
+})->throws(SkippedValueValidationException::class, 'Required.');

--- a/tests/Feature/MultiSearchPromptTest.php
+++ b/tests/Feature/MultiSearchPromptTest.php
@@ -408,3 +408,13 @@ it('throws when a skipUsing value fails validation', function () {
         skipUsing: [],
     );
 })->throws(SkippedValueValidationException::class, 'Required.');
+
+it('throws when skipUsing is not an array', function () {
+    Prompt::fake([]);
+
+    multisearch(
+        label: 'Search',
+        options: fn () => ['a' => 'A'],
+        skipUsing: 'a',
+    );
+})->throws(SkippedValueValidationException::class, 'Must be an array of options.');

--- a/tests/Feature/MultiSearchPromptTest.php
+++ b/tests/Feature/MultiSearchPromptTest.php
@@ -386,25 +386,25 @@ it('supports selecting all options', function () {
     expect($result)->toBe([]);
 });
 
-it('skips the prompt when skipWhen is provided', function () {
+it('skips the prompt when skipUsing is provided', function () {
     Prompt::fake([]);
 
     $result = multisearch(
         label: 'Search',
         options: fn () => ['a' => 'A', 'b' => 'B'],
-        skipWhen: ['a', 'b'],
+        skipUsing: ['a', 'b'],
     );
 
     expect($result)->toBe(['a', 'b']);
 });
 
-it('throws when a skipWhen value fails validation', function () {
+it('throws when a skipUsing value fails validation', function () {
     Prompt::fake([]);
 
     multisearch(
         label: 'Search',
         options: fn () => ['a' => 'A'],
         required: true,
-        skipWhen: [],
+        skipUsing: [],
     );
 })->throws(SkippedValueValidationException::class, 'Required.');

--- a/tests/Feature/MultiSelectPromptTest.php
+++ b/tests/Feature/MultiSelectPromptTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
+use Laravel\Prompts\Exceptions\SkippedValueValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\MultiSelectPrompt;
 use Laravel\Prompts\Prompt;
@@ -307,3 +308,26 @@ it('deselects all when all options are already default', function () {
 
     expect($result)->toBe([]);
 });
+
+it('skips the prompt when skipWhen is provided', function () {
+    Prompt::fake([]);
+
+    $result = multiselect(
+        label: 'Pick some',
+        options: ['red' => 'Red', 'green' => 'Green', 'blue' => 'Blue'],
+        skipWhen: ['red', 'blue'],
+    );
+
+    expect($result)->toBe(['red', 'blue']);
+});
+
+it('throws when a skipWhen value fails validation', function () {
+    Prompt::fake([]);
+
+    multiselect(
+        label: 'Pick some',
+        options: ['red' => 'Red', 'green' => 'Green'],
+        required: true,
+        skipWhen: [],
+    );
+})->throws(SkippedValueValidationException::class, 'Required.');

--- a/tests/Feature/MultiSelectPromptTest.php
+++ b/tests/Feature/MultiSelectPromptTest.php
@@ -309,25 +309,25 @@ it('deselects all when all options are already default', function () {
     expect($result)->toBe([]);
 });
 
-it('skips the prompt when skipWhen is provided', function () {
+it('skips the prompt when skipUsing is provided', function () {
     Prompt::fake([]);
 
     $result = multiselect(
         label: 'Pick some',
         options: ['red' => 'Red', 'green' => 'Green', 'blue' => 'Blue'],
-        skipWhen: ['red', 'blue'],
+        skipUsing: ['red', 'blue'],
     );
 
     expect($result)->toBe(['red', 'blue']);
 });
 
-it('throws when a skipWhen value fails validation', function () {
+it('throws when a skipUsing value fails validation', function () {
     Prompt::fake([]);
 
     multiselect(
         label: 'Pick some',
         options: ['red' => 'Red', 'green' => 'Green'],
         required: true,
-        skipWhen: [],
+        skipUsing: [],
     );
 })->throws(SkippedValueValidationException::class, 'Required.');

--- a/tests/Feature/MultiSelectPromptTest.php
+++ b/tests/Feature/MultiSelectPromptTest.php
@@ -331,3 +331,23 @@ it('throws when a skipUsing value fails validation', function () {
         skipUsing: [],
     );
 })->throws(SkippedValueValidationException::class, 'Required.');
+
+it('throws when skipUsing is not an array', function () {
+    Prompt::fake([]);
+
+    multiselect(
+        label: 'Pick some',
+        options: ['red' => 'Red', 'green' => 'Green'],
+        skipUsing: 'red',
+    );
+})->throws(SkippedValueValidationException::class, 'Must be an array of options.');
+
+it('throws when a skipUsing option is not in the options', function () {
+    Prompt::fake([]);
+
+    multiselect(
+        label: 'Pick some',
+        options: ['red' => 'Red', 'green' => 'Green'],
+        skipUsing: ['red', 'purple'],
+    );
+})->throws(SkippedValueValidationException::class, 'Invalid option.');

--- a/tests/Feature/NumberPromptTest.php
+++ b/tests/Feature/NumberPromptTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
+use Laravel\Prompts\Exceptions\SkippedValueValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\NumberPrompt;
 use Laravel\Prompts\Prompt;
@@ -292,3 +293,25 @@ it('allows customizing the cancellation', function () {
 
     number(label: 'How many items do you want to buy?');
 })->throws(Exception::class, 'Cancelled.');
+
+it('skips the prompt when skipWhen is provided', function () {
+    Prompt::fake([]);
+
+    $result = number(label: 'How many?', skipWhen: 42);
+
+    expect($result)->toBe(42);
+});
+
+it('throws when a skipWhen value is not numeric', function () {
+    Prompt::fake([]);
+
+    number(label: 'How many?', skipWhen: 'abc');
+})->throws(SkippedValueValidationException::class, 'Must be a number');
+
+it('coerces numeric string skipWhen values to int', function () {
+    Prompt::fake([]);
+
+    $result = number(label: 'How many?', skipWhen: '42');
+
+    expect($result)->toBe(42);
+});

--- a/tests/Feature/NumberPromptTest.php
+++ b/tests/Feature/NumberPromptTest.php
@@ -294,24 +294,24 @@ it('allows customizing the cancellation', function () {
     number(label: 'How many items do you want to buy?');
 })->throws(Exception::class, 'Cancelled.');
 
-it('skips the prompt when skipWhen is provided', function () {
+it('skips the prompt when skipUsing is provided', function () {
     Prompt::fake([]);
 
-    $result = number(label: 'How many?', skipWhen: 42);
+    $result = number(label: 'How many?', skipUsing: 42);
 
     expect($result)->toBe(42);
 });
 
-it('throws when a skipWhen value is not numeric', function () {
+it('throws when a skipUsing value is not numeric', function () {
     Prompt::fake([]);
 
-    number(label: 'How many?', skipWhen: 'abc');
+    number(label: 'How many?', skipUsing: 'abc');
 })->throws(SkippedValueValidationException::class, 'Must be a number');
 
-it('coerces numeric string skipWhen values to int', function () {
+it('coerces numeric string skipUsing values to int', function () {
     Prompt::fake([]);
 
-    $result = number(label: 'How many?', skipWhen: '42');
+    $result = number(label: 'How many?', skipUsing: '42');
 
     expect($result)->toBe(42);
 });

--- a/tests/Feature/PasswordPromptTest.php
+++ b/tests/Feature/PasswordPromptTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
+use Laravel\Prompts\Exceptions\SkippedValueValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\PasswordPrompt;
 use Laravel\Prompts\Prompt;
@@ -115,3 +116,17 @@ it('supports custom validation', function () {
 
     Prompt::validateUsing(fn () => null);
 });
+
+it('skips the prompt when skipWhen is provided', function () {
+    Prompt::fake([]);
+
+    $result = password(label: 'What is the password?', skipWhen: 'secret');
+
+    expect($result)->toBe('secret');
+});
+
+it('throws when a skipWhen value is invalid', function () {
+    Prompt::fake([]);
+
+    password(label: 'What is the password?', required: true, skipWhen: '');
+})->throws(SkippedValueValidationException::class, 'Required.');

--- a/tests/Feature/PasswordPromptTest.php
+++ b/tests/Feature/PasswordPromptTest.php
@@ -117,16 +117,16 @@ it('supports custom validation', function () {
     Prompt::validateUsing(fn () => null);
 });
 
-it('skips the prompt when skipWhen is provided', function () {
+it('skips the prompt when skipUsing is provided', function () {
     Prompt::fake([]);
 
-    $result = password(label: 'What is the password?', skipWhen: 'secret');
+    $result = password(label: 'What is the password?', skipUsing: 'secret');
 
     expect($result)->toBe('secret');
 });
 
-it('throws when a skipWhen value is invalid', function () {
+it('throws when a skipUsing value is invalid', function () {
     Prompt::fake([]);
 
-    password(label: 'What is the password?', required: true, skipWhen: '');
+    password(label: 'What is the password?', required: true, skipUsing: '');
 })->throws(SkippedValueValidationException::class, 'Required.');

--- a/tests/Feature/SearchPromptTest.php
+++ b/tests/Feature/SearchPromptTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
+use Laravel\Prompts\Exceptions\SkippedValueValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\SearchPrompt;
@@ -212,3 +213,26 @@ it('supports custom validation', function () {
 
     Prompt::validateUsing(fn () => null);
 });
+
+it('skips the prompt when skipWhen is provided', function () {
+    Prompt::fake([]);
+
+    $result = search(
+        label: 'Search',
+        options: fn () => ['a' => 'A'],
+        skipWhen: 'a',
+    );
+
+    expect($result)->toBe('a');
+});
+
+it('throws when a skipWhen value fails validation', function () {
+    Prompt::fake([]);
+
+    search(
+        label: 'Search',
+        options: fn () => ['a' => 'A'],
+        validate: fn ($value) => $value === 'a' ? null : 'Invalid option.',
+        skipWhen: 'nope',
+    );
+})->throws(SkippedValueValidationException::class, 'Invalid option.');

--- a/tests/Feature/SearchPromptTest.php
+++ b/tests/Feature/SearchPromptTest.php
@@ -214,25 +214,25 @@ it('supports custom validation', function () {
     Prompt::validateUsing(fn () => null);
 });
 
-it('skips the prompt when skipWhen is provided', function () {
+it('skips the prompt when skipUsing is provided', function () {
     Prompt::fake([]);
 
     $result = search(
         label: 'Search',
         options: fn () => ['a' => 'A'],
-        skipWhen: 'a',
+        skipUsing: 'a',
     );
 
     expect($result)->toBe('a');
 });
 
-it('throws when a skipWhen value fails validation', function () {
+it('throws when a skipUsing value fails validation', function () {
     Prompt::fake([]);
 
     search(
         label: 'Search',
         options: fn () => ['a' => 'A'],
         validate: fn ($value) => $value === 'a' ? null : 'Invalid option.',
-        skipWhen: 'nope',
+        skipUsing: 'nope',
     );
 })->throws(SkippedValueValidationException::class, 'Invalid option.');

--- a/tests/Feature/SelectPromptTest.php
+++ b/tests/Feature/SelectPromptTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
+use Laravel\Prompts\Exceptions\SkippedValueValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\SelectPrompt;
@@ -383,3 +384,26 @@ it('handles falsy default', function () {
 
     expect($result)->toBe('0');
 });
+
+it('skips the prompt when skipWhen is provided', function () {
+    Prompt::fake([]);
+
+    $result = select(
+        label: 'Pick one',
+        options: ['red' => 'Red', 'green' => 'Green'],
+        skipWhen: 'green',
+    );
+
+    expect($result)->toBe('green');
+});
+
+it('throws when a skipWhen value is not in the options', function () {
+    Prompt::fake([]);
+
+    select(
+        label: 'Pick one',
+        options: ['red' => 'Red', 'green' => 'Green'],
+        validate: fn ($value) => array_key_exists($value, ['red' => 'Red', 'green' => 'Green']) ? null : 'Invalid option.',
+        skipWhen: 'purple',
+    );
+})->throws(SkippedValueValidationException::class, 'Invalid option.');

--- a/tests/Feature/SelectPromptTest.php
+++ b/tests/Feature/SelectPromptTest.php
@@ -403,7 +403,6 @@ it('throws when a skipUsing value is not in the options', function () {
     select(
         label: 'Pick one',
         options: ['red' => 'Red', 'green' => 'Green'],
-        validate: fn ($value) => array_key_exists($value, ['red' => 'Red', 'green' => 'Green']) ? null : 'Invalid option.',
         skipUsing: 'purple',
     );
 })->throws(SkippedValueValidationException::class, 'Invalid option.');

--- a/tests/Feature/SelectPromptTest.php
+++ b/tests/Feature/SelectPromptTest.php
@@ -385,25 +385,25 @@ it('handles falsy default', function () {
     expect($result)->toBe('0');
 });
 
-it('skips the prompt when skipWhen is provided', function () {
+it('skips the prompt when skipUsing is provided', function () {
     Prompt::fake([]);
 
     $result = select(
         label: 'Pick one',
         options: ['red' => 'Red', 'green' => 'Green'],
-        skipWhen: 'green',
+        skipUsing: 'green',
     );
 
     expect($result)->toBe('green');
 });
 
-it('throws when a skipWhen value is not in the options', function () {
+it('throws when a skipUsing value is not in the options', function () {
     Prompt::fake([]);
 
     select(
         label: 'Pick one',
         options: ['red' => 'Red', 'green' => 'Green'],
         validate: fn ($value) => array_key_exists($value, ['red' => 'Red', 'green' => 'Green']) ? null : 'Invalid option.',
-        skipWhen: 'purple',
+        skipUsing: 'purple',
     );
 })->throws(SkippedValueValidationException::class, 'Invalid option.');

--- a/tests/Feature/SkipUsingTest.php
+++ b/tests/Feature/SkipUsingTest.php
@@ -77,6 +77,14 @@ it('prompts normally when a skipUsing closure returns null', function () {
     expect($result)->toBe('Jess');
 });
 
+it('prompts normally when a skipUsing closure returns false', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = confirm(label: 'Are you sure?', skipUsing: fn () => false);
+
+    expect($result)->toBeTrue();
+});
+
 it('throws when a skipped value fails the required check', function () {
     Prompt::fake([]);
 

--- a/tests/Feature/SkipUsingTest.php
+++ b/tests/Feature/SkipUsingTest.php
@@ -9,10 +9,10 @@ use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
 
-it('short-circuits the prompt when skipWhen is provided', function () {
+it('short-circuits the prompt when skipUsing is provided', function () {
     Prompt::fake([]);
 
-    $result = text(label: 'What is your name?', skipWhen: 'Taylor');
+    $result = text(label: 'What is your name?', skipUsing: 'Taylor');
 
     expect($result)->toBe('Taylor');
 });
@@ -22,7 +22,7 @@ it('runs transform on the skipped value', function () {
 
     $result = text(
         label: 'What is your name?',
-        skipWhen: ' Taylor ',
+        skipUsing: ' Taylor ',
         transform: fn ($value) => trim($value),
     );
 
@@ -34,29 +34,45 @@ it('runs validate on the skipped value', function () {
 
     $result = text(
         label: 'What is your name?',
-        skipWhen: 'ok',
+        skipUsing: 'ok',
         validate: fn ($value) => null,
     );
 
     expect($result)->toBe('ok');
 });
 
-it('gives skipWhen precedence over default', function () {
+it('gives skipUsing precedence over default', function () {
     Prompt::fake([]);
 
     $result = text(
         label: 'What is your name?',
         default: 'Jess',
-        skipWhen: 'Taylor',
+        skipUsing: 'Taylor',
     );
 
     expect($result)->toBe('Taylor');
 });
 
-it('treats skipWhen null as not provided', function () {
+it('treats skipUsing null as not provided', function () {
     Prompt::fake(['J', 'e', 's', 's', Key::ENTER]);
 
-    $result = text(label: 'What is your name?', skipWhen: null);
+    $result = text(label: 'What is your name?', skipUsing: null);
+
+    expect($result)->toBe('Jess');
+});
+
+it('resolves a skipUsing closure lazily', function () {
+    Prompt::fake([]);
+
+    $result = text(label: 'What is your name?', skipUsing: fn () => 'Taylor');
+
+    expect($result)->toBe('Taylor');
+});
+
+it('prompts normally when a skipUsing closure returns null', function () {
+    Prompt::fake(['J', 'e', 's', 's', Key::ENTER]);
+
+    $result = text(label: 'What is your name?', skipUsing: fn () => null);
 
     expect($result)->toBe('Jess');
 });
@@ -64,7 +80,7 @@ it('treats skipWhen null as not provided', function () {
 it('throws when a skipped value fails the required check', function () {
     Prompt::fake([]);
 
-    text(label: 'What is your name?', required: true, skipWhen: '');
+    text(label: 'What is your name?', required: true, skipUsing: '');
 })->throws(SkippedValueValidationException::class, 'Required.');
 
 it('throws when a skipped value fails the validator', function () {
@@ -73,28 +89,28 @@ it('throws when a skipped value fails the validator', function () {
     text(
         label: 'What is your name?',
         validate: fn ($value) => $value !== 'Jess' ? 'Invalid name.' : null,
-        skipWhen: 'Taylor',
+        skipUsing: 'Taylor',
     );
 })->throws(SkippedValueValidationException::class, 'Invalid name.');
 
-it('keeps skipWhen backwards-compatible for catches targeting NonInteractiveValidationException', function () {
+it('keeps skipUsing backwards-compatible for catches targeting NonInteractiveValidationException', function () {
     Prompt::fake([]);
 
-    text(label: 'What is your name?', required: true, skipWhen: '');
+    text(label: 'What is your name?', required: true, skipUsing: '');
 })->throws(NonInteractiveValidationException::class);
 
-it('lets skipWhen win over required when the value is present', function () {
+it('lets skipUsing win over required when the value is present', function () {
     Prompt::fake([]);
 
-    $result = text(label: 'What is your name?', required: true, skipWhen: 'Taylor');
+    $result = text(label: 'What is your name?', required: true, skipUsing: 'Taylor');
 
     expect($result)->toBe('Taylor');
 });
 
-it('honors skipWhen in non-interactive mode', function () {
+it('honors skipUsing in non-interactive mode', function () {
     Prompt::interactive(false);
 
-    $result = text(label: 'What is your name?', skipWhen: 'Taylor');
+    $result = text(label: 'What is your name?', skipUsing: 'Taylor');
 
     expect($result)->toBe('Taylor');
 
@@ -105,24 +121,24 @@ it('throws with SkippedValueValidationException in non-interactive mode when inv
     Prompt::interactive(false);
 
     try {
-        text(label: 'What is your name?', required: true, skipWhen: '');
+        text(label: 'What is your name?', required: true, skipUsing: '');
     } finally {
         Prompt::interactive(true);
     }
 })->throws(SkippedValueValidationException::class, 'Required.');
 
-it('short-circuits confirm when skipWhen is provided', function () {
+it('short-circuits confirm when skipUsing is provided', function () {
     Prompt::fake([]);
 
-    $result = confirm(label: 'Continue?', skipWhen: true);
+    $result = confirm(label: 'Continue?', skipUsing: true);
 
     expect($result)->toBeTrue();
 });
 
-it('short-circuits select when skipWhen is provided', function () {
+it('short-circuits select when skipUsing is provided', function () {
     Prompt::fake([]);
 
-    $result = select(label: 'Pick one', options: ['red', 'blue'], skipWhen: 'blue');
+    $result = select(label: 'Pick one', options: ['red', 'blue'], skipUsing: 'blue');
 
     expect($result)->toBe('blue');
 });

--- a/tests/Feature/SkipWhenTest.php
+++ b/tests/Feature/SkipWhenTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
+use Laravel\Prompts\Exceptions\SkippedValueValidationException;
+use Laravel\Prompts\Key;
+use Laravel\Prompts\Prompt;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\text;
+
+it('short-circuits the prompt when skipWhen is provided', function () {
+    Prompt::fake([]);
+
+    $result = text(label: 'What is your name?', skipWhen: 'Taylor');
+
+    expect($result)->toBe('Taylor');
+});
+
+it('runs transform on the skipped value', function () {
+    Prompt::fake([]);
+
+    $result = text(
+        label: 'What is your name?',
+        skipWhen: ' Taylor ',
+        transform: fn ($value) => trim($value),
+    );
+
+    expect($result)->toBe('Taylor');
+});
+
+it('runs validate on the skipped value', function () {
+    Prompt::fake([]);
+
+    $result = text(
+        label: 'What is your name?',
+        skipWhen: 'ok',
+        validate: fn ($value) => null,
+    );
+
+    expect($result)->toBe('ok');
+});
+
+it('gives skipWhen precedence over default', function () {
+    Prompt::fake([]);
+
+    $result = text(
+        label: 'What is your name?',
+        default: 'Jess',
+        skipWhen: 'Taylor',
+    );
+
+    expect($result)->toBe('Taylor');
+});
+
+it('treats skipWhen null as not provided', function () {
+    Prompt::fake(['J', 'e', 's', 's', Key::ENTER]);
+
+    $result = text(label: 'What is your name?', skipWhen: null);
+
+    expect($result)->toBe('Jess');
+});
+
+it('throws when a skipped value fails the required check', function () {
+    Prompt::fake([]);
+
+    text(label: 'What is your name?', required: true, skipWhen: '');
+})->throws(SkippedValueValidationException::class, 'Required.');
+
+it('throws when a skipped value fails the validator', function () {
+    Prompt::fake([]);
+
+    text(
+        label: 'What is your name?',
+        validate: fn ($value) => $value !== 'Jess' ? 'Invalid name.' : null,
+        skipWhen: 'Taylor',
+    );
+})->throws(SkippedValueValidationException::class, 'Invalid name.');
+
+it('keeps skipWhen backwards-compatible for catches targeting NonInteractiveValidationException', function () {
+    Prompt::fake([]);
+
+    text(label: 'What is your name?', required: true, skipWhen: '');
+})->throws(NonInteractiveValidationException::class);
+
+it('lets skipWhen win over required when the value is present', function () {
+    Prompt::fake([]);
+
+    $result = text(label: 'What is your name?', required: true, skipWhen: 'Taylor');
+
+    expect($result)->toBe('Taylor');
+});
+
+it('honors skipWhen in non-interactive mode', function () {
+    Prompt::interactive(false);
+
+    $result = text(label: 'What is your name?', skipWhen: 'Taylor');
+
+    expect($result)->toBe('Taylor');
+
+    Prompt::interactive(true);
+});
+
+it('throws with SkippedValueValidationException in non-interactive mode when invalid', function () {
+    Prompt::interactive(false);
+
+    try {
+        text(label: 'What is your name?', required: true, skipWhen: '');
+    } finally {
+        Prompt::interactive(true);
+    }
+})->throws(SkippedValueValidationException::class, 'Required.');
+
+it('short-circuits confirm when skipWhen is provided', function () {
+    Prompt::fake([]);
+
+    $result = confirm(label: 'Continue?', skipWhen: true);
+
+    expect($result)->toBeTrue();
+});
+
+it('short-circuits select when skipWhen is provided', function () {
+    Prompt::fake([]);
+
+    $result = select(label: 'Pick one', options: ['red', 'blue'], skipWhen: 'blue');
+
+    expect($result)->toBe('blue');
+});

--- a/tests/Feature/SuggestPromptTest.php
+++ b/tests/Feature/SuggestPromptTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
+use Laravel\Prompts\Exceptions\SkippedValueValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\SuggestPrompt;
@@ -232,3 +233,26 @@ it('supports custom validation', function () {
 
     Prompt::validateUsing(fn () => null);
 });
+
+it('skips the prompt when skipWhen is provided', function () {
+    Prompt::fake([]);
+
+    $result = suggest(
+        label: 'Pick',
+        options: ['Alpha', 'Beta'],
+        skipWhen: 'Alpha',
+    );
+
+    expect($result)->toBe('Alpha');
+});
+
+it('throws when a skipWhen value is invalid', function () {
+    Prompt::fake([]);
+
+    suggest(
+        label: 'Pick',
+        options: ['Alpha'],
+        required: true,
+        skipWhen: '',
+    );
+})->throws(SkippedValueValidationException::class, 'Required.');

--- a/tests/Feature/SuggestPromptTest.php
+++ b/tests/Feature/SuggestPromptTest.php
@@ -234,25 +234,25 @@ it('supports custom validation', function () {
     Prompt::validateUsing(fn () => null);
 });
 
-it('skips the prompt when skipWhen is provided', function () {
+it('skips the prompt when skipUsing is provided', function () {
     Prompt::fake([]);
 
     $result = suggest(
         label: 'Pick',
         options: ['Alpha', 'Beta'],
-        skipWhen: 'Alpha',
+        skipUsing: 'Alpha',
     );
 
     expect($result)->toBe('Alpha');
 });
 
-it('throws when a skipWhen value is invalid', function () {
+it('throws when a skipUsing value is invalid', function () {
     Prompt::fake([]);
 
     suggest(
         label: 'Pick',
         options: ['Alpha'],
         required: true,
-        skipWhen: '',
+        skipUsing: '',
     );
 })->throws(SkippedValueValidationException::class, 'Required.');

--- a/tests/Feature/TextPromptTest.php
+++ b/tests/Feature/TextPromptTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
+use Laravel\Prompts\Exceptions\SkippedValueValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\TextPrompt;
@@ -167,3 +168,17 @@ it('handles a failed terminal read gracefully', function () {
 
     expect($result)->toBe('');
 });
+
+it('skips the prompt when skipWhen is provided', function () {
+    Prompt::fake([]);
+
+    $result = text(label: 'What is your name?', skipWhen: 'Taylor');
+
+    expect($result)->toBe('Taylor');
+});
+
+it('throws when a skipWhen value is invalid', function () {
+    Prompt::fake([]);
+
+    text(label: 'What is your name?', required: true, skipWhen: '');
+})->throws(SkippedValueValidationException::class, 'Required.');

--- a/tests/Feature/TextPromptTest.php
+++ b/tests/Feature/TextPromptTest.php
@@ -169,16 +169,16 @@ it('handles a failed terminal read gracefully', function () {
     expect($result)->toBe('');
 });
 
-it('skips the prompt when skipWhen is provided', function () {
+it('skips the prompt when skipUsing is provided', function () {
     Prompt::fake([]);
 
-    $result = text(label: 'What is your name?', skipWhen: 'Taylor');
+    $result = text(label: 'What is your name?', skipUsing: 'Taylor');
 
     expect($result)->toBe('Taylor');
 });
 
-it('throws when a skipWhen value is invalid', function () {
+it('throws when a skipUsing value is invalid', function () {
     Prompt::fake([]);
 
-    text(label: 'What is your name?', required: true, skipWhen: '');
+    text(label: 'What is your name?', required: true, skipUsing: '');
 })->throws(SkippedValueValidationException::class, 'Required.');

--- a/tests/Feature/TextareaPromptTest.php
+++ b/tests/Feature/TextareaPromptTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
+use Laravel\Prompts\Exceptions\SkippedValueValidationException;
 use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\TextareaPrompt;
@@ -256,3 +257,17 @@ it('correctly handles multi-byte strings for the up arrow', function () {
         "ａyoｂ\nｃｄｅｆ\nｇｈｉjklmnnopqrs\ntuvwxyz"
     );
 });
+
+it('skips the prompt when skipWhen is provided', function () {
+    Prompt::fake([]);
+
+    $result = textarea(label: 'What is your story?', skipWhen: "Line one\nLine two");
+
+    expect($result)->toBe("Line one\nLine two");
+});
+
+it('throws when a skipWhen value is invalid', function () {
+    Prompt::fake([]);
+
+    textarea(label: 'What is your story?', required: true, skipWhen: '');
+})->throws(SkippedValueValidationException::class, 'Required.');

--- a/tests/Feature/TextareaPromptTest.php
+++ b/tests/Feature/TextareaPromptTest.php
@@ -258,16 +258,16 @@ it('correctly handles multi-byte strings for the up arrow', function () {
     );
 });
 
-it('skips the prompt when skipWhen is provided', function () {
+it('skips the prompt when skipUsing is provided', function () {
     Prompt::fake([]);
 
-    $result = textarea(label: 'What is your story?', skipWhen: "Line one\nLine two");
+    $result = textarea(label: 'What is your story?', skipUsing: "Line one\nLine two");
 
     expect($result)->toBe("Line one\nLine two");
 });
 
-it('throws when a skipWhen value is invalid', function () {
+it('throws when a skipUsing value is invalid', function () {
     Prompt::fake([]);
 
-    textarea(label: 'What is your story?', required: true, skipWhen: '');
+    textarea(label: 'What is your story?', required: true, skipUsing: '');
 })->throws(SkippedValueValidationException::class, 'Required.');


### PR DESCRIPTION
Interactive prompts currently force callers to wrap every call in an if/else when a command flag should pre-answer the prompt. This adds a `skipUsing` argument to every prompt helper, prompt class, and `FormBuilder` step — passing a value other than `null` or `false` (or a closure that returns one) short-circuits the prompt and returns the value after running it through the existing `transform` + `validate` pipeline. Both `null` and `false` mean "not provided", so unset options and absent boolean flags fall through to the normal interactive prompt; a negative confirm answer can be pre-supplied with a boolean-like string such as `"no"`, `"false"`, or `"0"`.

Pre-supplied values are validated like interactive input, plus a few guarantees interactive use already provides:

- `ConfirmPrompt` coerces boolean-style strings (`"1"`, `"true"`, `"yes"`, `"off"`, …) and rejects anything unparseable instead of guessing.
- `NumberPrompt` coerces numeric strings to integers and runs the usual number/min/max validation.
- `SelectPrompt`, `MultiSelectPrompt`, and `DataTablePrompt` reject values that are not in their options, so skipping can never return a value interactive use could not produce.
- `MultiSelectPrompt` and `MultiSearchPrompt` reject non-array values.

Failures throw a new `SkippedValueValidationException` (extending `NonInteractiveValidationException`, so existing catches keep working) with the prompt label and error, so invalid CLI input fails loudly instead of silently slipping through. Since `search` and `multisearch` options are closures, skipped values there can't be checked against the options — pass `validate` when that matters. A skipped prompt writes no output, matching the existing non-interactive behavior. Form steps that skip are ignored when reverting with CTRL+U — closure resolvers are re-evaluated to decide — so users revert past pre-answered steps to the previous interactive prompt. `pause` is intentionally excluded.

## Example

```php
use function Laravel\Prompts\confirm;
use function Laravel\Prompts\text;

// Wire an Artisan option straight into the prompt — no if/else needed.
$name = text(
    label: 'What is your name?',
    required: true,
    skipUsing: $this->option('name'), // null → prompt; 'Taylor' → returns 'Taylor'
);

// Boolean flags work directly — false means "not provided", like null.
$confirmed = confirm(
    label: 'Continue?',
    skipUsing: $this->option('yes'), // --yes → true; absent → prompt
);
```
