### PR TITLE
Added `keepSummary`, `subLabel`, truncated labels and stable messages

### DIFF
--- a/src/Support/Logger.php
+++ b/src/Support/Logger.php
@@ -78,6 +78,14 @@ class Logger
     }
 
     /**
+     * Update the sub-label of the process log. Pass an empty string to clear.
+     */
+    public function subLabel(string $message): void
+    {
+        $this->write($message, 'sublabel');
+    }
+
+    /**
      * Write a message to the socket.
      */
     protected function write(string $message, ?string $type = null): void

--- a/src/Task.php
+++ b/src/Task.php
@@ -104,12 +104,8 @@ class Task extends Prompt
      */
     public function run(Closure $callback): mixed
     {
-        $maxHeight = $this->terminal()->lines() - 10;
-
-        $this->limit = min($this->limit, $maxHeight);
-        // Max height - limit - divider - task label (- subLabel when set)
-        $reserved = 2 + ($this->subLabel !== null && $this->subLabel !== '' ? 1 : 0);
-        $this->maxStableMessages = max(0, $maxHeight - $this->limit - $reserved);
+        $this->limit = min($this->limit, $this->terminal()->lines() - 10);
+        $this->recalculateMaxStableMessages();
 
         $this->capturePreviousNewLines();
 
@@ -221,6 +217,7 @@ class Task extends Prompt
                     $this->label = $content;
                 } elseif ($type === 'sublabel') {
                     $this->subLabel = $content;
+                    $this->recalculateMaxStableMessages();
                 } else {
                     $this->stableMessages[] = ['type' => $type, 'message' => $content];
                     $this->logs = [];
@@ -291,6 +288,15 @@ class Task extends Prompt
             array_shift($this->logs);
             $this->partialStartIndex = max(0, $this->partialStartIndex - 1);
         }
+    }
+
+    /**
+     * Recompute the stable-message budget based on the current sub-label state.
+     */
+    protected function recalculateMaxStableMessages(): void
+    {
+        $reserved = 2 + ($this->subLabel !== null && $this->subLabel !== '' ? 1 : 0);
+        $this->maxStableMessages = max(0, $this->terminal()->lines() - 10 - $this->limit - $reserved);
     }
 
     /**

--- a/src/Task.php
+++ b/src/Task.php
@@ -89,6 +89,7 @@ class Task extends Prompt
         public string $label = '',
         public int $limit = 10,
         public bool $keepSummary = false,
+        public ?string $subLabel = null,
     ) {
         $this->identifier = uniqid();
     }
@@ -106,8 +107,9 @@ class Task extends Prompt
         $maxHeight = $this->terminal()->lines() - 10;
 
         $this->limit = min($this->limit, $maxHeight);
-        // Max height - limit - divider - task label
-        $this->maxStableMessages = max(0, $maxHeight - $this->limit - 2);
+        // Max height - limit - divider - task label (- subLabel when set)
+        $reserved = 2 + ($this->subLabel !== null && $this->subLabel !== '' ? 1 : 0);
+        $this->maxStableMessages = max(0, $maxHeight - $this->limit - $reserved);
 
         $this->capturePreviousNewLines();
 
@@ -193,7 +195,7 @@ class Task extends Prompt
             }
 
             // Check for typed messages: {id}_{type}:{content}
-            if (preg_match('/^'.$prefix.'_(success|warning|error|label|reset|partial|commitpartial):(.*)/', $line, $matches)) {
+            if (preg_match('/^'.$prefix.'_(success|warning|error|label|sublabel|reset|partial|commitpartial):(.*)/', $line, $matches)) {
                 $type = $matches[1];
                 $content = $matches[2];
 
@@ -217,6 +219,8 @@ class Task extends Prompt
 
                 if ($type === 'label') {
                     $this->label = $content;
+                } elseif ($type === 'sublabel') {
+                    $this->subLabel = $content;
                 } else {
                     $this->stableMessages[] = ['type' => $type, 'message' => $content];
                     $this->logs = [];

--- a/src/Task.php
+++ b/src/Task.php
@@ -88,6 +88,7 @@ class Task extends Prompt
     public function __construct(
         public string $label = '',
         public int $limit = 10,
+        public bool $keepSummary = false,
     ) {
         $this->identifier = uniqid();
     }
@@ -301,6 +302,12 @@ class Task extends Prompt
         if ($this->socket !== null) {
             fclose($this->socket);
             $this->socket = null;
+        }
+
+        if ($this->keepSummary && count($this->stableMessages) > 0) {
+            $this->render();
+
+            return;
         }
 
         $this->eraseRenderedLines();

--- a/src/Themes/Default/TaskRenderer.php
+++ b/src/Themes/Default/TaskRenderer.php
@@ -28,7 +28,7 @@ class TaskRenderer extends Renderer
         $stableMessages = array_slice($task->stableMessages, -$task->maxStableMessages);
 
         if ($task->finished && $task->keepSummary && count($stableMessages) > 0) {
-            $this->line(" {$this->cyan('•')} {$this->truncate($task->label,$stableLineMaxWidth)}");
+            $this->line(" {$this->cyan('•')} {$this->truncate($task->label,$labelMaxWidth)}");
 
             foreach ($stableMessages as $stableMessage) {
                 $this->line($leadPadding . $this->stableMessageSymbol($stableMessage['type']) . ' ' . $this->truncate($stableMessage['message'], $stableLineMaxWidth));

--- a/src/Themes/Default/TaskRenderer.php
+++ b/src/Themes/Default/TaskRenderer.php
@@ -20,21 +20,22 @@ class TaskRenderer extends Renderer
 
         $task->interval = $this->interval;
 
-        $this->line(" {$this->cyan($this->spinnerFrame($task->count))} {$task->label}");
-
         $leadPadding = str_repeat(' ', 3);
 
         $stableMessages = array_slice($task->stableMessages, -$task->maxStableMessages);
 
-        foreach ($stableMessages as $stableMessage) {
-            $symbol = match ($stableMessage['type']) {
-                'success' => $this->green('✔'),
-                'error' => $this->red('✘'),
-                'warning' => $this->yellow('⚠'),
-                default => '',
-            };
+        if ($task->finished && $task->keepSummary && count($stableMessages) > 0) {
+            foreach ($stableMessages as $stableMessage) {
+                $this->line(' '.$this->stableMessageSymbol($stableMessage['type']).' '.$stableMessage['message']);
+            }
 
-            $this->line($leadPadding.$symbol.' '.$stableMessage['message']);
+            return $this;
+        }
+
+        $this->line(" {$this->cyan($this->spinnerFrame($task->count))} {$task->label}");
+
+        foreach ($stableMessages as $stableMessage) {
+            $this->line($leadPadding.$this->stableMessageSymbol($stableMessage['type']).' '.$stableMessage['message']);
         }
 
         if (count($task->stableMessages) > 0 || count($task->logs) > 0) {
@@ -57,5 +58,15 @@ class TaskRenderer extends Renderer
         }
 
         return $this;
+    }
+
+    protected function stableMessageSymbol(string $type): string
+    {
+        return match ($type) {
+            'success' => $this->green('✔'),
+            'error' => $this->red('✘'),
+            'warning' => $this->yellow('⚠'),
+            default => '',
+        };
     }
 }

--- a/src/Themes/Default/TaskRenderer.php
+++ b/src/Themes/Default/TaskRenderer.php
@@ -20,7 +20,7 @@ class TaskRenderer extends Renderer
         $stableLineMaxWidth = $maxWidth - strlen($leadPadding) - 2; // symbol + space
 
         if ($task->static) {
-            return $this->line(" {$this->cyan($this->staticFrame)} {$this->truncate($task->label,$maxWidth)}");
+            return $this->line(" {$this->cyan($this->staticFrame)} {$this->truncate($task->label, $maxWidth)}");
         }
 
         $task->interval = $this->interval;
@@ -28,10 +28,10 @@ class TaskRenderer extends Renderer
         $stableMessages = array_slice($task->stableMessages, -$task->maxStableMessages);
 
         if ($task->finished && $task->keepSummary && count($stableMessages) > 0) {
-            $this->line(" {$this->cyan('•')} {$this->truncate($task->label,$labelMaxWidth)}");
+            $this->line(" {$this->cyan('•')} {$this->truncate($task->label, $labelMaxWidth)}");
 
             foreach ($stableMessages as $stableMessage) {
-                $this->line($leadPadding . $this->stableMessageSymbol($stableMessage['type']) . ' ' . $this->truncate($stableMessage['message'], $stableLineMaxWidth));
+                $this->line($leadPadding.$this->stableMessageSymbol($stableMessage['type']).' '.$this->truncate($stableMessage['message'], $stableLineMaxWidth));
             }
 
             $this->newLine();
@@ -39,18 +39,18 @@ class TaskRenderer extends Renderer
             return $this;
         }
 
-        $this->line(" {$this->cyan($this->spinnerFrame($task->count))} {$this->truncate($task->label,$labelMaxWidth)}");
+        $this->line(" {$this->cyan($this->spinnerFrame($task->count))} {$this->truncate($task->label, $labelMaxWidth)}");
 
         if ($task->subLabel !== null && $task->subLabel !== '') {
-            $this->line($leadPadding . $this->dim($this->truncate($task->subLabel, $stableLineMaxWidth)));
+            $this->line($leadPadding.$this->dim($this->truncate($task->subLabel, $stableLineMaxWidth)));
         }
 
         foreach ($stableMessages as $stableMessage) {
-            $this->line($leadPadding . $this->stableMessageSymbol($stableMessage['type']) . ' ' . $this->truncate($stableMessage['message'], $stableLineMaxWidth));
+            $this->line($leadPadding.$this->stableMessageSymbol($stableMessage['type']).' '.$this->truncate($stableMessage['message'], $stableLineMaxWidth));
         }
 
         if (count($task->stableMessages) > 0 || count($task->logs) > 0) {
-            $this->line($this->gray(' ' . str_repeat('─', $maxWidth)));
+            $this->line($this->gray(' '.str_repeat('─', $maxWidth)));
         } else {
             $this->newLine();
         }
@@ -58,7 +58,7 @@ class TaskRenderer extends Renderer
         $logs = array_slice($task->logs, -$task->limit);
 
         foreach ($logs as $log) {
-            $this->line(' ' . $this->dim($log));
+            $this->line(' '.$this->dim($log));
         }
 
         $remaining = $task->limit - count($task->logs);

--- a/src/Themes/Default/TaskRenderer.php
+++ b/src/Themes/Default/TaskRenderer.php
@@ -25,9 +25,13 @@ class TaskRenderer extends Renderer
         $stableMessages = array_slice($task->stableMessages, -$task->maxStableMessages);
 
         if ($task->finished && $task->keepSummary && count($stableMessages) > 0) {
+            $this->line(" {$this->cyan('•')} {$task->label}");
+
             foreach ($stableMessages as $stableMessage) {
-                $this->line(' '.$this->stableMessageSymbol($stableMessage['type']).' '.$stableMessage['message']);
+                $this->line($leadPadding.$this->stableMessageSymbol($stableMessage['type']).' '.$stableMessage['message']);
             }
+
+            $this->newLine();
 
             return $this;
         }

--- a/src/Themes/Default/TaskRenderer.php
+++ b/src/Themes/Default/TaskRenderer.php
@@ -17,7 +17,7 @@ class TaskRenderer extends Renderer
         $maxWidth = $task->terminal()->cols() - 6;
         $labelMaxWidth = $maxWidth - 3;
         $leadPadding = str_repeat(' ', 3);
-        $stableLineMaxWidth = $maxWidth - strlen($leadPadding) - 2;
+        $stableLineMaxWidth = $maxWidth - strlen($leadPadding) - 2; // symbol + space
 
         if ($task->static) {
             return $this->line(" {$this->cyan($this->staticFrame)} {$this->truncate($task->label,$maxWidth)}");

--- a/src/Themes/Default/TaskRenderer.php
+++ b/src/Themes/Default/TaskRenderer.php
@@ -14,8 +14,10 @@ class TaskRenderer extends Renderer
      */
     public function __invoke(Task $task): string
     {
+        $maxWidth = $task->terminal()->cols() - 6;
+
         if ($task->static) {
-            return $this->line(" {$this->cyan($this->staticFrame)} {$task->label}");
+            return $this->line(" {$this->cyan($this->staticFrame)} {$this->truncate($task->label, $maxWidth)}");
         }
 
         $task->interval = $this->interval;
@@ -25,10 +27,10 @@ class TaskRenderer extends Renderer
         $stableMessages = array_slice($task->stableMessages, -$task->maxStableMessages);
 
         if ($task->finished && $task->keepSummary && count($stableMessages) > 0) {
-            $this->line(" {$this->cyan('•')} {$task->label}");
+            $this->line(" {$this->cyan('•')} {$this->truncate($task->label, $maxWidth)}");
 
             foreach ($stableMessages as $stableMessage) {
-                $this->line($leadPadding.$this->stableMessageSymbol($stableMessage['type']).' '.$stableMessage['message']);
+                $this->line($leadPadding.$this->stableMessageSymbol($stableMessage['type']).' '.$this->truncate($stableMessage['message'], $maxWidth));
             }
 
             $this->newLine();
@@ -36,10 +38,10 @@ class TaskRenderer extends Renderer
             return $this;
         }
 
-        $this->line(" {$this->cyan($this->spinnerFrame($task->count))} {$task->label}");
+        $this->line(" {$this->cyan($this->spinnerFrame($task->count))} {$this->truncate($task->label, $maxWidth)}");
 
         foreach ($stableMessages as $stableMessage) {
-            $this->line($leadPadding.$this->stableMessageSymbol($stableMessage['type']).' '.$stableMessage['message']);
+            $this->line($leadPadding.$this->stableMessageSymbol($stableMessage['type']).' '.$this->truncate($stableMessage['message'], $maxWidth));
         }
 
         if (count($task->stableMessages) > 0 || count($task->logs) > 0) {

--- a/src/Themes/Default/TaskRenderer.php
+++ b/src/Themes/Default/TaskRenderer.php
@@ -41,6 +41,10 @@ class TaskRenderer extends Renderer
 
         $this->line(" {$this->cyan($this->spinnerFrame($task->count))} {$this->truncate($task->label,$labelMaxWidth)}");
 
+        if ($task->subLabel !== null && $task->subLabel !== '') {
+            $this->line($leadPadding . $this->dim($this->truncate($task->subLabel, $stableLineMaxWidth)));
+        }
+
         foreach ($stableMessages as $stableMessage) {
             $this->line($leadPadding . $this->stableMessageSymbol($stableMessage['type']) . ' ' . $this->truncate($stableMessage['message'], $stableLineMaxWidth));
         }

--- a/src/Themes/Default/TaskRenderer.php
+++ b/src/Themes/Default/TaskRenderer.php
@@ -15,22 +15,23 @@ class TaskRenderer extends Renderer
     public function __invoke(Task $task): string
     {
         $maxWidth = $task->terminal()->cols() - 6;
+        $labelMaxWidth = $maxWidth - 3;
+        $leadPadding = str_repeat(' ', 3);
+        $stableLineMaxWidth = $maxWidth - strlen($leadPadding) - 2;
 
         if ($task->static) {
-            return $this->line(" {$this->cyan($this->staticFrame)} {$this->truncate($task->label, $maxWidth)}");
+            return $this->line(" {$this->cyan($this->staticFrame)} {$this->truncate($task->label,$maxWidth)}");
         }
 
         $task->interval = $this->interval;
 
-        $leadPadding = str_repeat(' ', 3);
-
         $stableMessages = array_slice($task->stableMessages, -$task->maxStableMessages);
 
         if ($task->finished && $task->keepSummary && count($stableMessages) > 0) {
-            $this->line(" {$this->cyan('•')} {$this->truncate($task->label, $maxWidth)}");
+            $this->line(" {$this->cyan('•')} {$this->truncate($task->label,$stableLineMaxWidth)}");
 
             foreach ($stableMessages as $stableMessage) {
-                $this->line($leadPadding.$this->stableMessageSymbol($stableMessage['type']).' '.$this->truncate($stableMessage['message'], $maxWidth));
+                $this->line($leadPadding . $this->stableMessageSymbol($stableMessage['type']) . ' ' . $this->truncate($stableMessage['message'], $stableLineMaxWidth));
             }
 
             $this->newLine();
@@ -38,14 +39,14 @@ class TaskRenderer extends Renderer
             return $this;
         }
 
-        $this->line(" {$this->cyan($this->spinnerFrame($task->count))} {$this->truncate($task->label, $maxWidth)}");
+        $this->line(" {$this->cyan($this->spinnerFrame($task->count))} {$this->truncate($task->label,$labelMaxWidth)}");
 
         foreach ($stableMessages as $stableMessage) {
-            $this->line($leadPadding.$this->stableMessageSymbol($stableMessage['type']).' '.$this->truncate($stableMessage['message'], $maxWidth));
+            $this->line($leadPadding . $this->stableMessageSymbol($stableMessage['type']) . ' ' . $this->truncate($stableMessage['message'], $stableLineMaxWidth));
         }
 
         if (count($task->stableMessages) > 0 || count($task->logs) > 0) {
-            $this->line($this->gray(' '.str_repeat('─', $this->prompt->terminal()->cols() - 10)));
+            $this->line($this->gray(' ' . str_repeat('─', $maxWidth)));
         } else {
             $this->newLine();
         }
@@ -53,7 +54,7 @@ class TaskRenderer extends Renderer
         $logs = array_slice($task->logs, -$task->limit);
 
         foreach ($logs as $log) {
-            $this->line(' '.$this->dim($log));
+            $this->line(' ' . $this->dim($log));
         }
 
         $remaining = $task->limit - count($task->logs);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -424,9 +424,9 @@ if (! function_exists('\Laravel\Prompts\task')) {
      * @param  Closure(Support\Logger): TReturn  $callback
      * @return TReturn
      */
-    function task(string $label, Closure $callback, ?int $limit = null): mixed
+    function task(string $label, Closure $callback, ?int $limit = null, bool $keepSummary = false): mixed
     {
-        return (new Task($label, $limit ?? 10))->run($callback);
+        return (new Task($label, $limit ?? 10, $keepSummary))->run($callback);
     }
 }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -424,9 +424,9 @@ if (! function_exists('\Laravel\Prompts\task')) {
      * @param  Closure(Support\Logger): TReturn  $callback
      * @return TReturn
      */
-    function task(string $label, Closure $callback, ?int $limit = null, bool $keepSummary = false): mixed
+    function task(string $label, Closure $callback, ?int $limit = null, bool $keepSummary = false, ?string $subLabel = null): mixed
     {
-        return (new Task($label, $limit ?? 10, $keepSummary))->run($callback);
+        return (new Task($label, $limit ?? 10, $keepSummary, $subLabel))->run($callback);
     }
 }
 

--- a/tests/Feature/TaskTest.php
+++ b/tests/Feature/TaskTest.php
@@ -283,6 +283,46 @@ it('renders nothing special when finished with no stable messages', function () 
     expect($output)->toContain('Running');
 });
 
+it('shrinks the stable-message budget when a sub-label appears mid-task', function () {
+    Prompt::fake();
+
+    $task = new Task(label: 'Running', limit: 10);
+    $task->maxStableMessages = 3;
+
+    $task->stableMessages = [
+        ['type' => 'success', 'message' => 'one'],
+        ['type' => 'success', 'message' => 'two'],
+        ['type' => 'success', 'message' => 'three'],
+    ];
+
+    $receiveMessages = new ReflectionMethod($task, 'receiveMessages');
+    $sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+
+    $id = $task->identifier;
+    fwrite($sockets[1], "{$id}_sublabel:Now doing a thing\n");
+    fclose($sockets[1]);
+
+    stream_set_blocking($sockets[0], false);
+    $receiveMessages->invoke($task, $sockets[0]);
+    fclose($sockets[0]);
+
+    expect($task->subLabel)->toBe('Now doing a thing');
+    expect($task->maxStableMessages)->toBeLessThan(3);
+    expect(count($task->stableMessages))->toBeLessThanOrEqual($task->maxStableMessages);
+
+    $previousBudget = $task->maxStableMessages;
+
+    $sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+    fwrite($sockets[1], "{$id}_sublabel:\n");
+    fclose($sockets[1]);
+    stream_set_blocking($sockets[0], false);
+    $receiveMessages->invoke($task, $sockets[0]);
+    fclose($sockets[0]);
+
+    expect($task->subLabel)->toBe('');
+    expect($task->maxStableMessages)->toBe($previousBudget + 1);
+});
+
 it('does not take the retain branch when keepSummary is disabled', function () {
     Prompt::fake();
 

--- a/tests/Feature/TaskTest.php
+++ b/tests/Feature/TaskTest.php
@@ -253,7 +253,7 @@ it('does not keep the summary by default', function () {
     expect($task->keepSummary)->toBeFalse();
 });
 
-it('renders only stable messages when finished with retain enabled', function () {
+it('renders the label and stable messages when finished with retain enabled', function () {
     Prompt::fake();
 
     $task = new Task(label: 'Running', limit: 10, keepSummary: true);
@@ -264,9 +264,11 @@ it('renders only stable messages when finished with retain enabled', function ()
     $renderer = new Laravel\Prompts\Themes\Default\TaskRenderer($task);
     $output = (string) $renderer($task);
 
+    expect($output)->toContain('Running');
     expect($output)->toContain('Step one done');
     expect($output)->toContain('Step two failed');
-    expect($output)->not->toContain('Running');
+    expect($output)->not->toContain('─');
+    expect($output)->toEndWith(PHP_EOL.PHP_EOL);
 });
 
 it('renders nothing special when finished with no stable messages', function () {

--- a/tests/Feature/TaskTest.php
+++ b/tests/Feature/TaskTest.php
@@ -246,3 +246,51 @@ it('updates the label through the socket protocol', function () {
 
     expect($task->label)->toBe('Updated Label');
 });
+
+it('does not keep the summary by default', function () {
+    $task = new Task(label: 'Running', limit: 10);
+
+    expect($task->keepSummary)->toBeFalse();
+});
+
+it('renders only stable messages when finished with retain enabled', function () {
+    Prompt::fake();
+
+    $task = new Task(label: 'Running', limit: 10, keepSummary: true);
+    $task->finished = true;
+    $task->stableMessages[] = ['type' => 'success', 'message' => 'Step one done'];
+    $task->stableMessages[] = ['type' => 'error', 'message' => 'Step two failed'];
+
+    $renderer = new Laravel\Prompts\Themes\Default\TaskRenderer($task);
+    $output = (string) $renderer($task);
+
+    expect($output)->toContain('Step one done');
+    expect($output)->toContain('Step two failed');
+    expect($output)->not->toContain('Running');
+});
+
+it('renders nothing special when finished with no stable messages', function () {
+    Prompt::fake();
+
+    $task = new Task(label: 'Running', limit: 10, keepSummary: true);
+    $task->finished = true;
+
+    $renderer = new Laravel\Prompts\Themes\Default\TaskRenderer($task);
+    $output = (string) $renderer($task);
+
+    expect($output)->toContain('Running');
+});
+
+it('does not take the retain branch when keepSummary is disabled', function () {
+    Prompt::fake();
+
+    $task = new Task(label: 'Running', limit: 10, keepSummary: false);
+    $task->finished = true;
+    $task->stableMessages[] = ['type' => 'success', 'message' => 'Step one done'];
+
+    $renderer = new Laravel\Prompts\Themes\Default\TaskRenderer($task);
+    $output = (string) $renderer($task);
+
+    expect($output)->toContain('Running');
+    expect($output)->toContain('Step one done');
+});

--- a/tests/Feature/TaskTest.php
+++ b/tests/Feature/TaskTest.php
@@ -3,6 +3,7 @@
 use Laravel\Prompts\Prompt;
 use Laravel\Prompts\Support\Logger;
 use Laravel\Prompts\Task;
+use Laravel\Prompts\Themes\Default\TaskRenderer;
 
 use function Laravel\Prompts\task;
 
@@ -261,7 +262,7 @@ it('renders the label and stable messages when finished with retain enabled', fu
     $task->stableMessages[] = ['type' => 'success', 'message' => 'Step one done'];
     $task->stableMessages[] = ['type' => 'error', 'message' => 'Step two failed'];
 
-    $renderer = new Laravel\Prompts\Themes\Default\TaskRenderer($task);
+    $renderer = new TaskRenderer($task);
     $output = (string) $renderer($task);
 
     expect($output)->toContain('Running');
@@ -277,7 +278,7 @@ it('renders nothing special when finished with no stable messages', function () 
     $task = new Task(label: 'Running', limit: 10, keepSummary: true);
     $task->finished = true;
 
-    $renderer = new Laravel\Prompts\Themes\Default\TaskRenderer($task);
+    $renderer = new TaskRenderer($task);
     $output = (string) $renderer($task);
 
     expect($output)->toContain('Running');
@@ -330,7 +331,7 @@ it('does not take the retain branch when keepSummary is disabled', function () {
     $task->finished = true;
     $task->stableMessages[] = ['type' => 'success', 'message' => 'Step one done'];
 
-    $renderer = new Laravel\Prompts\Themes\Default\TaskRenderer($task);
+    $renderer = new TaskRenderer($task);
     $output = (string) $renderer($task);
 
     expect($output)->toContain('Running');


### PR DESCRIPTION
A few additions to the `task()` prompt:

- `keepSummary: true` keeps the task's stable success/warning/error messages on screen after the callback finishes, instead of erasing the whole block. Useful when you want a record of what happened.
- A new `subLabel` argument, update-able via `$log->subLabel('…')`, renders a dim line under the main label, and clears when set to an empty string. Good for ephemeral status like "Building assets…" or commands being run without polluting the stable summary.
- Labels and stable messages are now truncated to terminal width so long strings don't break the redraw.

```php
task(
    label: 'Deploying',
    callback: function ($log) {
        $log->subLabel('Building assets…');
        runBuild($log);
        $log->success('Assets built');

        $log->subLabel('Running migrations…');
        runMigrations($log);
        $log->success('Migrations complete');

        $log->subLabel('');
    },
    keepSummary: true,
);
```
