### PR TITLE
Add default values support to multisearch prompt

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -172,8 +172,9 @@ class FormBuilder
      * Allow the user to search for multiple option.
      *
      * @param  Closure(string): array<int|string, string>  $options
+     * @param  array<int|string>|Collection<int, int|string>  $default
      */
-    public function multisearch(string $label, Closure $options, string $placeholder = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null, ?Closure $transform = null): self
+    public function multisearch(string $label, Closure $options, string $placeholder = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null, ?Closure $transform = null, array|Collection $default = []): self
     {
         return $this->runPrompt(multisearch(...), get_defined_vars());
     }

--- a/src/MultiSearchPrompt.php
+++ b/src/MultiSearchPrompt.php
@@ -3,6 +3,7 @@
 namespace Laravel\Prompts;
 
 use Closure;
+use Illuminate\Support\Collection;
 use Laravel\Prompts\Support\Utils;
 
 class MultiSearchPrompt extends Prompt
@@ -35,6 +36,7 @@ class MultiSearchPrompt extends Prompt
      * Create a new MultiSearchPrompt instance.
      *
      * @param  Closure(string): array<int|string, string>  $options
+     * @param  array<int|string>|Collection<int, int|string>  $default
      */
     public function __construct(
         public string $label,
@@ -46,7 +48,10 @@ class MultiSearchPrompt extends Prompt
         public string $hint = '',
         public ?Closure $transform = null,
         public string|Closure $info = '',
+        array|Collection $default = [],
     ) {
+        $this->setDefaultValues($default);
+
         $this->trackTypedValue(submit: false, ignore: fn ($key) => Key::oneOf([Key::SPACE, Key::HOME, Key::END, Key::CTRL_A, Key::CTRL_E], $key) && $this->highlighted !== null);
 
         $this->initializeScrolling(null);
@@ -63,6 +68,30 @@ class MultiSearchPrompt extends Prompt
             Key::LEFT, Key::LEFT_ARROW, Key::RIGHT, Key::RIGHT_ARROW => $this->highlighted = null,
             default => $this->search(),
         });
+    }
+
+    /**
+     * Set the initially selected values.
+     *
+     * @param  array<int|string>|Collection<int, int|string>  $default
+     */
+    protected function setDefaultValues(array|Collection $default): void
+    {
+        $default = $default instanceof Collection ? $default->all() : $default;
+
+        if ($default === []) {
+            return;
+        }
+
+        $matches = ($this->options)('');
+
+        if (count($matches) > 0) {
+            $this->isList = array_is_list($matches);
+        }
+
+        $this->values = array_is_list($matches)
+            ? array_combine($default, $default)
+            : array_intersect_key($matches, array_flip($default));
     }
 
     /**

--- a/src/MultiSearchPrompt.php
+++ b/src/MultiSearchPrompt.php
@@ -90,7 +90,7 @@ class MultiSearchPrompt extends Prompt
         }
 
         $this->values = array_is_list($matches)
-            ? array_combine($default, $default)
+            ? array_combine($default, array_map(fn (int|string $value) => (string) $value, $default))
             : array_intersect_key($matches, array_flip($default));
     }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -218,6 +218,7 @@ if (! function_exists('\Laravel\Prompts\multisearch')) {
      * Allow the user to search for multiple option.
      *
      * @param  Closure(string): array<int|string, string>  $options
+     * @param  array<int|string>|Collection<int, int|string>  $default
      * @return array<int|string>
      */
     function multisearch(
@@ -230,6 +231,7 @@ if (! function_exists('\Laravel\Prompts\multisearch')) {
         string $hint = 'Use the space bar to select options.',
         ?Closure $transform = null,
         string|Closure $info = '',
+        array|Collection $default = [],
     ): array {
         return (new MultiSearchPrompt(...get_defined_vars()))->prompt();
     }


### PR DESCRIPTION
## Summary

This adds support for default selected values to the `multisearch` prompt.

The new `default` argument is appended to the existing function and form builder signatures so existing positional calls remain backward compatible. When provided, default values are initialized as selected before the prompt is rendered.

## Notes

- Supports both array and collection defaults.
- Keeps existing `multisearch()` positional argument order unchanged.
- Matches the existing `multiselect()` default value behavior more closely.