### PR TITLE
Fix Logger to Return when constructed without a socket (Windows Laravel New Fix)

### DIFF
--- a/src/Support/Logger.php
+++ b/src/Support/Logger.php
@@ -90,6 +90,10 @@ class Logger
      */
     protected function write(string $message, ?string $type = null): void
     {
+        if ($this->socket === null) {
+            return;
+        }
+
         if ($type !== null) {
             fwrite($this->socket, $this->prefix($type, $message).PHP_EOL);
         } else {

--- a/tests/Feature/LoggerTest.php
+++ b/tests/Feature/LoggerTest.php
@@ -6,16 +6,16 @@ it('does not throw when constructed without a socket', function () {
     // Task::renderStatically() constructs the Logger without a socket on
     // platforms where pcntl_fork / posix_kill are unavailable (e.g. Windows).
     // Any logger call from the user-supplied callback must not crash.
-    $logger = new Logger('abc123');
+    expect(function () {
+        $logger = new Logger('abc123');
 
-    $logger->line('hello');
-    $logger->partial('streamed ');
-    $logger->commitPartial();
-    $logger->success('done');
-    $logger->warning('careful');
-    $logger->error('broken');
-    $logger->label('Updated');
-    $logger->subLabel('detail');
-
-    expect(fn() => $logger->line('hello'))->not->toThrow();
+        $logger->line('hello');
+        $logger->partial('streamed ');
+        $logger->commitPartial();
+        $logger->success('done');
+        $logger->warning('careful');
+        $logger->error('broken');
+        $logger->label('Updated');
+        $logger->subLabel('detail');
+    })->not->toThrow(\Exception::class);
 });

--- a/tests/Feature/LoggerTest.php
+++ b/tests/Feature/LoggerTest.php
@@ -17,5 +17,5 @@ it('does not throw when constructed without a socket', function () {
     $logger->label('Updated');
     $logger->subLabel('detail');
 
-    expect(true)->toBeTrue();
+    expect(fn() => $logger->line('hello'))->not->toThrow();
 });

--- a/tests/Feature/LoggerTest.php
+++ b/tests/Feature/LoggerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Laravel\Prompts\Support\Logger;
+
+it('does not throw when constructed without a socket', function () {
+    // Task::renderStatically() constructs the Logger without a socket on
+    // platforms where pcntl_fork / posix_kill are unavailable (e.g. Windows).
+    // Any logger call from the user-supplied callback must not crash.
+    $logger = new Logger('abc123');
+
+    $logger->line('hello');
+    $logger->partial('streamed ');
+    $logger->commitPartial();
+    $logger->success('done');
+    $logger->warning('careful');
+    $logger->error('broken');
+    $logger->label('Updated');
+    $logger->subLabel('detail');
+
+    expect(true)->toBeTrue();
+});


### PR DESCRIPTION
This solves an error when running `laravel new` on Windows (Not WSL), selecting the React starter kit, and letting the `php artisan install:features` execute, the task logger crashes.

This fix has an early-return when no socket is present (on Windows and any platform without `pcntl_fork' / `posix_kill`.

This just stops the crash and is similar to other places (`src/Task.php:154`) with existing defensive null-checks.