### PR TITLE
Support terminal extension backend

### DIFF
--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -108,7 +108,7 @@ abstract class Prompt
                 return $this->fallback();
             }
 
-            static::$interactive ??= stream_isatty(STDIN);
+            static::$interactive ??= static::terminal()->interactive();
 
             if (! static::$interactive) {
                 return $this->default();
@@ -431,7 +431,7 @@ abstract class Prompt
      */
     private function checkEnvironment(): void
     {
-        if (PHP_OS_FAMILY === 'Windows') {
+        if (PHP_OS_FAMILY === 'Windows' && ! static::terminal()->hasNativeTerminal()) {
             throw new RuntimeException('Prompts is not currently supported on Windows. Please use WSL or configure a fallback.');
         }
     }

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Prompts;
 
+use Closure;
 use ReflectionClass;
 use RuntimeException;
 use Symfony\Component\Console\Terminal as SymfonyTerminal;
@@ -12,6 +13,11 @@ class Terminal
      * The initial TTY mode.
      */
     protected ?string $initialTtyMode;
+
+    /**
+     * The initial native terminal mode.
+     */
+    protected ?string $initialNativeTtyMode;
 
     /**
      * Whether the terminal supports true color.
@@ -50,6 +56,12 @@ class Terminal
      */
     public function read(): string
     {
+        if ($this->hasNativeTerminal()) {
+            $key = $this->readNativeKey();
+
+            return is_string($key) ? $this->normalizeNativeKey($key) : '';
+        }
+
         $input = fread(STDIN, 1024);
 
         return $input !== false ? $input : '';
@@ -60,6 +72,20 @@ class Terminal
      */
     public function setTty(string $mode): void
     {
+        if ($this->hasNativeTerminal()) {
+            if (! isset($this->initialNativeTtyMode)) {
+                $nativeMode = $this->enableNativeRawMode();
+
+                if (! is_string($nativeMode)) {
+                    throw new RuntimeException('Failed to enable terminal raw mode.');
+                }
+
+                $this->initialNativeTtyMode = $nativeMode;
+            }
+
+            return;
+        }
+
         $this->initialTtyMode ??= $this->exec('stty -g');
 
         $this->exec("stty $mode");
@@ -70,6 +96,14 @@ class Terminal
      */
     public function restoreTty(): void
     {
+        if (isset($this->initialNativeTtyMode)) {
+            $this->restoreNativeMode($this->initialNativeTtyMode);
+
+            $this->initialNativeTtyMode = null;
+
+            return;
+        }
+
         if (isset($this->initialTtyMode)) {
             $this->exec("stty {$this->initialTtyMode}");
 
@@ -82,6 +116,10 @@ class Terminal
      */
     public function cols(): int
     {
+        if ($this->hasNativeTerminal() && ($size = $this->nativeSize()) !== false) {
+            return $size['columns'];
+        }
+
         return $this->terminal->getWidth();
     }
 
@@ -90,6 +128,10 @@ class Terminal
      */
     public function lines(): int
     {
+        if ($this->hasNativeTerminal() && ($size = $this->nativeSize()) !== false) {
+            return $size['rows'];
+        }
+
         return $this->terminal->getHeight();
     }
 
@@ -98,9 +140,39 @@ class Terminal
      */
     public function initDimensions(): void
     {
+        if ($this->hasNativeTerminal()) {
+            return;
+        }
+
         (new ReflectionClass($this->terminal))
             ->getMethod('initDimensions')
             ->invoke($this->terminal);
+    }
+
+    /**
+     * Determine if the terminal is interactive.
+     */
+    public function interactive(): bool
+    {
+        if ($this->hasNativeTerminal()) {
+            return $this->nativeStdinIsTty();
+        }
+
+        return stream_isatty(STDIN);
+    }
+
+    /**
+     * Determine if the native terminal extension is available.
+     */
+    public function hasNativeTerminal(): bool
+    {
+        return extension_loaded('terminal')
+            && function_exists('terminal_read_key')
+            && function_exists('terminal_enable_raw_mode')
+            && function_exists('terminal_restore_mode')
+            && function_exists('terminal_is_tty')
+            && function_exists('terminal_get_size')
+            && defined('TERMINAL_STDIN');
     }
 
     /**
@@ -134,6 +206,111 @@ class Terminal
         }
 
         return $stdout;
+    }
+
+    /**
+     * Read a key from the native terminal extension.
+     */
+    protected function readNativeKey(): string|false
+    {
+        $readKey = $this->nativeFunction('terminal_read_key');
+
+        if ($readKey === null) {
+            return false;
+        }
+
+        $key = $readKey();
+
+        return is_string($key) ? $key : false;
+    }
+
+    /**
+     * Enable raw mode through the native terminal extension.
+     */
+    protected function enableNativeRawMode(): string|false
+    {
+        $enableRawMode = $this->nativeFunction('terminal_enable_raw_mode');
+
+        if ($enableRawMode === null) {
+            return false;
+        }
+
+        $mode = $enableRawMode();
+
+        return is_string($mode) ? $mode : false;
+    }
+
+    /**
+     * Restore the native terminal mode.
+     */
+    protected function restoreNativeMode(string $mode): bool
+    {
+        $restoreMode = $this->nativeFunction('terminal_restore_mode');
+
+        return $restoreMode !== null && $restoreMode($mode) === true;
+    }
+
+    /**
+     * Determine if native standard input is a TTY.
+     */
+    protected function nativeStdinIsTty(): bool
+    {
+        $isTty = $this->nativeFunction('terminal_is_tty');
+
+        return $isTty !== null && $isTty((int) constant('TERMINAL_STDIN')) === true;
+    }
+
+    /**
+     * Get the native terminal size.
+     *
+     * @return array{columns:int, rows:int}|false
+     */
+    protected function nativeSize(): array|false
+    {
+        $getSize = $this->nativeFunction('terminal_get_size');
+
+        if ($getSize === null) {
+            return false;
+        }
+
+        $size = $getSize();
+
+        if (! is_array($size) || ! isset($size['columns'], $size['rows'])) {
+            return false;
+        }
+
+        return ['columns' => (int) $size['columns'], 'rows' => (int) $size['rows']];
+    }
+
+    /**
+     * Resolve a native terminal function.
+     */
+    protected function nativeFunction(string $function): ?Closure
+    {
+        return function_exists($function) ? Closure::fromCallable($function) : null;
+    }
+
+    /**
+     * Normalize native key names to the sequences Prompts already understands.
+     */
+    protected function normalizeNativeKey(string $key): string
+    {
+        return match ($key) {
+            'up' => Key::UP,
+            'down' => Key::DOWN,
+            'right' => Key::RIGHT,
+            'left' => Key::LEFT,
+            'enter' => Key::ENTER,
+            'backspace' => Key::BACKSPACE,
+            'escape' => Key::ESCAPE,
+            'delete' => Key::DELETE,
+            'tab' => Key::TAB,
+            'home' => Key::HOME[0],
+            'end' => Key::END[0],
+            'pageup' => Key::PAGE_UP,
+            'pagedown' => Key::PAGE_DOWN,
+            default => $key,
+        };
     }
 
     /**
@@ -177,6 +354,13 @@ class Terminal
      */
     protected function queryColors(): void
     {
+        if (PHP_OS_FAMILY === 'Windows') {
+            static::$foregroundColor = [204, 204, 204];
+            static::$backgroundColor = [0, 0, 0];
+
+            return;
+        }
+
         $savedStty = trim((string) shell_exec('stty -g < /dev/tty'));
 
         shell_exec('stty raw -echo min 0 time 1 < /dev/tty');

--- a/tests/Feature/TerminalTest.php
+++ b/tests/Feature/TerminalTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use Laravel\Prompts\Key;
+use Laravel\Prompts\Terminal;
+
+it('normalizes native terminal keys', function () {
+    $terminal = new class([
+        'up',
+        'down',
+        'right',
+        'left',
+        'enter',
+        'backspace',
+        'escape',
+        'delete',
+        'tab',
+        'home',
+        'end',
+        'pageup',
+        'pagedown',
+        'a',
+    ]) extends Terminal
+    {
+        public function __construct(public array $keys)
+        {
+            parent::__construct();
+        }
+
+        public function hasNativeTerminal(): bool
+        {
+            return true;
+        }
+
+        protected function readNativeKey(): string|false
+        {
+            return array_shift($this->keys) ?? false;
+        }
+    };
+
+    expect($terminal->read())->toBe(Key::UP)
+        ->and($terminal->read())->toBe(Key::DOWN)
+        ->and($terminal->read())->toBe(Key::RIGHT)
+        ->and($terminal->read())->toBe(Key::LEFT)
+        ->and($terminal->read())->toBe(Key::ENTER)
+        ->and($terminal->read())->toBe(Key::BACKSPACE)
+        ->and($terminal->read())->toBe(Key::ESCAPE)
+        ->and($terminal->read())->toBe(Key::DELETE)
+        ->and($terminal->read())->toBe(Key::TAB)
+        ->and($terminal->read())->toBe(Key::HOME[0])
+        ->and($terminal->read())->toBe(Key::END[0])
+        ->and($terminal->read())->toBe(Key::PAGE_UP)
+        ->and($terminal->read())->toBe(Key::PAGE_DOWN)
+        ->and($terminal->read())->toBe('a')
+        ->and($terminal->read())->toBe('');
+});
+
+it('uses native terminal dimensions and interactivity checks', function () {
+    $terminal = new class extends Terminal
+    {
+        public function hasNativeTerminal(): bool
+        {
+            return true;
+        }
+
+        protected function nativeStdinIsTty(): bool
+        {
+            return true;
+        }
+
+        protected function nativeSize(): array|false
+        {
+            return ['columns' => 123, 'rows' => 45];
+        }
+    };
+
+    expect($terminal->interactive())->toBeTrue()
+        ->and($terminal->cols())->toBe(123)
+        ->and($terminal->lines())->toBe(45);
+});
+
+it('restores native terminal mode once', function () {
+    $terminal = new class extends Terminal
+    {
+        public array $calls = [];
+
+        public function hasNativeTerminal(): bool
+        {
+            return true;
+        }
+
+        protected function enableNativeRawMode(): string|false
+        {
+            $this->calls[] = 'enable';
+
+            return 'mode-token';
+        }
+
+        protected function restoreNativeMode(string $mode): bool
+        {
+            $this->calls[] = 'restore:'.$mode;
+
+            return true;
+        }
+    };
+
+    $terminal->setTty('-icanon -isig -echo');
+    $terminal->setTty('-icanon -isig -echo');
+    $terminal->restoreTty();
+    $terminal->restoreTty();
+
+    expect($terminal->calls)->toBe(['enable', 'restore:mode-token']);
+});


### PR DESCRIPTION
This lets Prompts use the optional `terminal` PHP extension as its terminal backend when it is installed.

Context: I have been working on a small PHP extension for native terminal helpers here:

https://github.com/prateekbhujel/php-terminal

The reason for this PR is Windows support. Prompts currently rejects Windows before entering the interactive loop because the current backend depends on `stty` / Unix-style terminal input. The extension exposes the pieces Prompts needs through PHP functions instead: TTY checks, raw mode, safe restore, single-key reads, and terminal size.

This PR keeps the extension completely optional. If it is not installed, Prompts keeps the existing behavior. If it is installed, Prompts can use the extension backend and map its named keys back to the existing `Key::*` sequences, so the prompt code itself does not need to learn a second key format.

The extension has a `v0.1.0` alpha release with Windows builds here:

https://github.com/prateekbhujel/php-terminal/releases/tag/v0.1.0

Tests run:
- `vendor/bin/pest tests/Feature/TerminalTest.php`
- `vendor/bin/pest`
- `vendor/bin/phpstan analyse --memory-limit=1G`
- `php -d extension=/tmp/php-terminal-build-x86/modules/terminal.so vendor/bin/pest`