### PR TITLE
Print completion line after task finishes

### DIFF
--- a/playground/task.php
+++ b/playground/task.php
@@ -121,6 +121,9 @@ $mode = select('Which demo?', [
     'standard' => 'Standard (line-by-line with stable messages)',
     'stream' => 'Stream (streaming text accumulation)',
     'mixed' => 'Mixed (lines, then stream, then lines)',
+    'no_stable_with_summary' => 'No Stable (keep summary)',
+    'no_stable_no_summary' => 'No Stable (no summary)',
+    'standard_with_summary' => 'Standard (keep summary)',
 ]);
 
 match ($mode) {
@@ -188,6 +191,55 @@ match ($mode) {
 
             $logger->success('All done!');
         },
+    ),
+
+    'no_stable_with_summary' => task(
+        label: $commands[0][1],
+        callback: function (Logger $logger) use ($commands) {
+            foreach ($commands as $data) {
+                [$output, $label, $message, $type] = $data;
+                $logger->label($label);
+
+                foreach ($output as $line) {
+                    $logger->line($line);
+                    usleep(100_000);
+                }
+            }
+        },
+        keepSummary: true,
+    ),
+
+    'no_stable_no_summary' => task(
+        label: $commands[0][1],
+        callback: function (Logger $logger) use ($commands) {
+            foreach ($commands as $data) {
+                [$output, $label, $message, $type] = $data;
+                $logger->label($label);
+
+                foreach ($output as $line) {
+                    $logger->line($line);
+                    usleep(100_000);
+                }
+            }
+        },
+    ),
+
+    'standard_with_summary' => task(
+        label: $commands[0][1],
+        callback: function (Logger $logger) use ($commands) {
+            foreach ($commands as $data) {
+                [$output, $label, $message, $type] = $data;
+                $logger->label($label);
+
+                foreach ($output as $line) {
+                    $logger->line($line);
+                    usleep(100_000);
+                }
+
+                $logger->{$type}($message);
+            }
+        },
+        keepSummary: true,
     ),
 };
 

--- a/src/Task.php
+++ b/src/Task.php
@@ -352,7 +352,10 @@ class Task extends Prompt
         }
 
         $this->eraseRenderedLines();
-        $this->printCompletionLine();
+
+        if ($this->keepSummary && count($this->stableMessages) === 0) {
+            $this->printCompletionLine();
+        }
 
         return $result;
     }

--- a/src/Task.php
+++ b/src/Task.php
@@ -322,7 +322,7 @@ class Task extends Prompt
 
         $this->eraseRenderedLines();
 
-        if ($success) {
+        if ($this->keepSummary && $success && count($this->stableMessages) === 0) {
             $this->printCompletionLine();
         }
     }

--- a/src/Task.php
+++ b/src/Task.php
@@ -160,7 +160,7 @@ class Task extends Prompt
                 return $result;
             }
         } catch (\Throwable $e) {
-            $this->resetTerminal($originalAsync);
+            $this->resetTerminal($originalAsync, success: false);
 
             throw $e;
         }
@@ -302,7 +302,7 @@ class Task extends Prompt
     /**
      * Reset the terminal.
      */
-    protected function resetTerminal(bool $originalAsync): void
+    protected function resetTerminal(bool $originalAsync, bool $success = true): void
     {
         $this->finished = true;
 
@@ -321,6 +321,10 @@ class Task extends Prompt
         }
 
         $this->eraseRenderedLines();
+
+        if ($success) {
+            $this->printCompletionLine();
+        }
     }
 
     /**
@@ -341,11 +345,24 @@ class Task extends Prompt
 
             $logger = new Logger($this->identifier);
             $result = $callback($logger);
-        } finally {
+        } catch (\Throwable $e) {
             $this->eraseRenderedLines();
+
+            throw $e;
         }
 
+        $this->eraseRenderedLines();
+        $this->printCompletionLine();
+
         return $result;
+    }
+
+    /**
+     * Print a single-line completion indicator after the task has finished.
+     */
+    protected function printCompletionLine(): void
+    {
+        static::output()->writeln(' '.$this->green('✔').' '.$this->label);
     }
 
     /**

--- a/tests/Feature/TaskTest.php
+++ b/tests/Feature/TaskTest.php
@@ -24,6 +24,33 @@ it('renders a task while executing a callback and then returns the value', funct
     Prompt::assertOutputContains('Running...');
 });
 
+it('prints a completion line after the task finishes in static mode', function () {
+    Prompt::fake();
+
+    $task = new Task(label: 'My Task');
+
+    $renderStatically = new ReflectionMethod($task, 'renderStatically');
+    $renderStatically->setAccessible(true);
+    $renderStatically->invoke($task, fn (Logger $logger) => null);
+
+    Prompt::assertStrippedOutputContains('✔ My Task');
+});
+
+it('does not print a completion line when the callback throws in static mode', function () {
+    Prompt::fake();
+
+    $task = new Task(label: 'My Task');
+
+    $renderStatically = new ReflectionMethod($task, 'renderStatically');
+    $renderStatically->setAccessible(true);
+
+    expect(fn () => $renderStatically->invoke($task, function (Logger $logger) {
+        throw new RuntimeException('boom');
+    }))->toThrow(RuntimeException::class, 'boom');
+
+    Prompt::assertStrippedOutputDoesntContain('✔ My Task');
+});
+
 it('returns null when the callback does not return a value', function () {
     Prompt::fake();
 

--- a/tests/Feature/TaskTest.php
+++ b/tests/Feature/TaskTest.php
@@ -24,10 +24,10 @@ it('renders a task while executing a callback and then returns the value', funct
     Prompt::assertOutputContains('Running...');
 });
 
-it('prints a completion line after the task finishes in static mode', function () {
+it('prints a completion line after the task finishes in static mode with keepSummary', function () {
     Prompt::fake();
 
-    $task = new Task(label: 'My Task');
+    $task = new Task(label: 'My Task', keepSummary: true);
 
     $renderStatically = new ReflectionMethod($task, 'renderStatically');
     $renderStatically->setAccessible(true);
@@ -36,10 +36,22 @@ it('prints a completion line after the task finishes in static mode', function (
     Prompt::assertStrippedOutputContains('✔ My Task');
 });
 
-it('does not print a completion line when the callback throws in static mode', function () {
+it('does not print a completion line without keepSummary in static mode', function () {
     Prompt::fake();
 
     $task = new Task(label: 'My Task');
+
+    $renderStatically = new ReflectionMethod($task, 'renderStatically');
+    $renderStatically->setAccessible(true);
+    $renderStatically->invoke($task, fn (Logger $logger) => null);
+
+    Prompt::assertStrippedOutputDoesntContain('✔ My Task');
+});
+
+it('does not print a completion line when the callback throws in static mode', function () {
+    Prompt::fake();
+
+    $task = new Task(label: 'My Task', keepSummary: true);
 
     $renderStatically = new ReflectionMethod($task, 'renderStatically');
     $renderStatically->setAccessible(true);


### PR DESCRIPTION
Fixes #246

After `task()` finishes, the label and spinner disappear entirely with nothing left on screen. Added a `printCompletionLine()` method that writes `✓ {label}` after the spinner block is erased, called from both the `resetTerminal()` and `renderStatically()` paths.