### PR TITLE
Use static rendering for Spinner when output is not decorated

### DIFF
--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -47,7 +47,7 @@ class Spinner extends Prompt
     {
         $this->capturePreviousNewLines();
 
-        if (! (function_exists('pcntl_fork') && function_exists('posix_kill'))) {
+        if (! static::output()->isDecorated() || ! (function_exists('pcntl_fork') && function_exists('posix_kill'))) {
             return $this->renderStatically($callback);
         }
 

--- a/src/Task.php
+++ b/src/Task.php
@@ -109,7 +109,7 @@ class Task extends Prompt
 
         $this->capturePreviousNewLines();
 
-        if (! (function_exists('pcntl_fork') && function_exists('posix_kill'))) {
+        if (! static::output()->isDecorated() || ! (function_exists('pcntl_fork') && function_exists('posix_kill'))) {
             return $this->renderStatically($callback);
         }
 

--- a/tests/Feature/SpinnerTest.php
+++ b/tests/Feature/SpinnerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Laravel\Prompts\Output\BufferedConsoleOutput;
 use Laravel\Prompts\Prompt;
 
 use function Laravel\Prompts\spin;
@@ -16,4 +17,17 @@ it('renders a spinner while executing a callback and then returns the value', fu
     expect($result)->toBe('done');
 
     Prompt::assertOutputContains('Running...');
+});
+
+it('renders a spinner statically when output is not decorated', function () {
+    Prompt::fake();
+
+    $output = new BufferedConsoleOutput;
+    $output->setDecorated(false);
+    Prompt::setOutput($output);
+
+    $result = spin(fn () => 'done', 'Running...');
+
+    expect($result)->toBe('done');
+    expect($output->content())->toContain('Running...');
 });


### PR DESCRIPTION
When the `--no-ansi` flag is passed, the output is not decorated and cursor-movement escape sequences have no effect. Previously the spinner would still fork a child process that wrote animation frames in a loop, flooding the console with lines like `⠋ Running...`, `⠙ Running...`, and so on indefinitely. Now, when `isDecorated()` returns false, the spinner falls back to `renderStatically()` — the same path taken when `pcntl_fork` is unavailable — so only a single static frame is shown.

Fixes #201.