### PR TITLE
Add `spaced` option to bulleted and numbered lists

### DIFF
--- a/playground/callout.php
+++ b/playground/callout.php
@@ -4,7 +4,7 @@ use Laravel\Prompts\Elements\Element;
 
 use function Laravel\Prompts\callout;
 
-require __DIR__.'/../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 callout(
     'Environment Configured',
@@ -20,7 +20,27 @@ callout(
 callout(
     'Database Connection Failed',
     'Could not connect to MySQL on 127.0.0.1:3306. Check that the service is running and your DB_PASSWORD is correct in .env.',
-    'error'
+    'error',
+);
+
+callout(
+    'Server Health Check',
+    [
+        'Multiple services are reporting degraded performance.',
+        Element::heading('Affected Services'),
+        Element::bulletedList([
+            'Redis cache hit rate dropped to 42%',
+            'Queue worker memory usage exceeding 256MB',
+            'Scheduled task runner missed 3 jobs in the last hour',
+        ]),
+        Element::heading('Recommended Actions'),
+        Element::numberedList([
+            'Flush the Redis cache with `php artisan cache:clear`',
+            'Restart queue workers with `php artisan queue:restart`',
+            'Review the schedule output with `php artisan schedule:list`',
+        ]),
+    ],
+    'warning',
 );
 
 callout(
@@ -110,5 +130,25 @@ callout(
             'Add an `if not exists` check to the migration',
         ]),
     ],
-    'error'
+    'error',
+);
+
+callout(
+    'Server Health Check',
+    [
+        'Multiple services are reporting degraded performance.',
+        Element::heading('Affected Services'),
+        Element::bulletedList([
+            'Redis cache hit rate dropped to 42%',
+            'Queue worker memory usage exceeding 256MB',
+            'Scheduled task runner missed 3 jobs in the last hour',
+        ], spaced: true),
+        Element::heading('Recommended Actions'),
+        Element::numberedList([
+            'Flush the Redis cache with `php artisan cache:clear`',
+            'Restart queue workers with `php artisan queue:restart`',
+            'Review the schedule output with `php artisan schedule:list`',
+        ], spaced: true),
+    ],
+    'warning',
 );

--- a/playground/callout.php
+++ b/playground/callout.php
@@ -4,7 +4,7 @@ use Laravel\Prompts\Elements\Element;
 
 use function Laravel\Prompts\callout;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__.'/../vendor/autoload.php';
 
 callout(
     'Environment Configured',

--- a/src/Elements/BulletedList.php
+++ b/src/Elements/BulletedList.php
@@ -7,8 +7,10 @@ class BulletedList implements ElementContract
     /**
      * @param  array<int, string>  $items
      */
-    public function __construct(protected array $items)
-    {
+    public function __construct(
+        protected array $items,
+        public readonly bool $spaced = false,
+    ) {
         //
     }
 

--- a/src/Elements/Element.php
+++ b/src/Elements/Element.php
@@ -12,17 +12,17 @@ class Element
     /**
      * @param  array<int, string>  $items
      */
-    public static function bulletedList(array $items): BulletedList
+    public static function bulletedList(array $items, bool $spaced = false): BulletedList
     {
-        return new BulletedList($items);
+        return new BulletedList($items, $spaced);
     }
 
     /**
      * @param  array<int, string>  $items
      */
-    public static function numberedList(array $items): NumberedList
+    public static function numberedList(array $items, bool $spaced = false): NumberedList
     {
-        return new NumberedList($items);
+        return new NumberedList($items, $spaced);
     }
 
     /**

--- a/src/Elements/NumberedList.php
+++ b/src/Elements/NumberedList.php
@@ -7,8 +7,10 @@ class NumberedList implements ElementContract
     /**
      * @param  array<int, string>  $items
      */
-    public function __construct(protected array $items)
-    {
+    public function __construct(
+        protected array $items,
+        public readonly bool $spaced = false,
+    ) {
         //
     }
 

--- a/src/Themes/Default/CalloutRenderer.php
+++ b/src/Themes/Default/CalloutRenderer.php
@@ -81,21 +81,29 @@ class CalloutRenderer extends Renderer
         }
 
         if ($part instanceof BulletedList) {
-            return array_map(function ($p) {
+            $finalLines = [];
+
+            foreach ($part->content() as $i => $p) {
                 $p = $this->autoFormat($p);
                 $lines = $this->ansiWordwrap($p, $this->minWidth - 2);
-                $finalLines = [];
+                $partLines = [];
+
+                if ($part->spaced && $i !== 0) {
+                    $partLines[] = '';
+                }
 
                 foreach ($lines as $index => $line) {
                     if ($index === 0) {
-                        $finalLines[] = $this->dim('·').' '.$line;
+                        $partLines[] = $this->dim('·').' '.$line;
                     } else {
-                        $finalLines[] = '  '.$line;
+                        $partLines[] = '  '.$line;
                     }
                 }
 
-                return implode(PHP_EOL, $finalLines);
-            }, $part->content());
+                $finalLines[] = implode(PHP_EOL, $partLines);
+            }
+
+            return $finalLines;
         }
 
         if ($part instanceof NumberedList) {
@@ -108,6 +116,10 @@ class CalloutRenderer extends Renderer
                 // -1 for ' ' after number
                 $p = $this->autoFormat($p);
                 $lines = $this->ansiWordwrap($p, $this->minWidth - $widestNumber - 1);
+
+                if ($part->spaced && $i !== 0) {
+                    $partLines[] = '';
+                }
 
                 foreach ($lines as $index => $line) {
                     if ($index === 0) {

--- a/tests/Feature/CalloutTest.php
+++ b/tests/Feature/CalloutTest.php
@@ -128,6 +128,48 @@ it('renders a callout with mixed content', function () {
     Prompt::assertOutputContains('deploy-id: xyz');
 });
 
+it('renders a callout with a spaced bulleted list', function () {
+    Prompt::fake();
+
+    callout('Summary', [
+        Element::bulletedList([
+            'First item',
+            'Second item',
+            'Third item',
+        ], spaced: true),
+    ]);
+
+    $content = Prompt::strippedContent();
+
+    expect($content)->toContain('· First item');
+    expect($content)->toContain('· Second item');
+    expect($content)->toContain('· Third item');
+
+    preg_match('/· First item.*\n(.*)\n.*· Second item/s', $content, $matches);
+    expect($matches)->not->toBeEmpty('Expected a blank line between first and second items');
+});
+
+it('renders a callout with a spaced numbered list', function () {
+    Prompt::fake();
+
+    callout('Steps', [
+        Element::numberedList([
+            'Step one',
+            'Step two',
+            'Step three',
+        ], spaced: true),
+    ]);
+
+    $content = Prompt::strippedContent();
+
+    expect($content)->toContain('1. Step one');
+    expect($content)->toContain('2. Step two');
+    expect($content)->toContain('3. Step three');
+
+    preg_match('/1\. Step one.*\n(.*)\n.*2\. Step two/s', $content, $matches);
+    expect($matches)->not->toBeEmpty('Expected a blank line between first and second items');
+});
+
 it('can fall back', function () {
     Prompt::fallbackWhen(true);
 


### PR DESCRIPTION
Adds a `spaced` boolean flag to `Element::bulletedList()` and `Element::numberedList()` that inserts a blank line between list items when set to `true`. Defaults to `false` to preserve existing behavior.