### PR TITLE
Add Link element with OSC 8 hyperlink support

### DIFF
--- a/playground/callout.php
+++ b/playground/callout.php
@@ -152,3 +152,13 @@ callout(
     ],
     'warning',
 );
+
+callout(
+    'Server Health Check',
+    [
+        'Multiple services are reporting degraded performance.',
+        Element::heading('Affected Services'),
+        'Look here: '.Element::link('https://example.com/health', 'Health Dashboard'),
+        Element::link('https://example.com/health'),
+    ],
+);

--- a/src/Elements/Element.php
+++ b/src/Elements/Element.php
@@ -32,4 +32,9 @@ class Element
     {
         return new KeyValueList($items);
     }
+
+    public static function link(string $url, ?string $label = null, bool $underline = true): Link
+    {
+        return new Link($url, $label, $underline);
+    }
 }

--- a/src/Elements/Link.php
+++ b/src/Elements/Link.php
@@ -13,7 +13,7 @@ class Link implements ElementContract
     }
 
     /**
-     * @return array<string, string>
+     * @return array<int, string>
      */
     public function content(): array
     {

--- a/src/Elements/Link.php
+++ b/src/Elements/Link.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Laravel\Prompts\Elements;
+
+class Link implements ElementContract
+{
+    public function __construct(
+        protected string $url,
+        protected ?string $label = null,
+        public readonly bool $underline = true,
+    ) {
+        //
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function content(): array
+    {
+        return [$this->url, $this->label ?? $this->url];
+    }
+
+    public function __toString(): string
+    {
+        $text = $this->label ?? $this->url;
+
+        if ($this->underline) {
+            $text = "\e[4m{$text}\e[24m";
+        }
+
+        return "\e]8;;{$this->url}\e\\{$text}\e]8;;\e\\";
+    }
+}

--- a/src/Themes/Default/CalloutRenderer.php
+++ b/src/Themes/Default/CalloutRenderer.php
@@ -7,6 +7,7 @@ use Laravel\Prompts\Elements\BulletedList;
 use Laravel\Prompts\Elements\ElementContract;
 use Laravel\Prompts\Elements\Heading;
 use Laravel\Prompts\Elements\KeyValueList;
+use Laravel\Prompts\Elements\Link;
 use Laravel\Prompts\Elements\NumberedList;
 
 class CalloutRenderer extends Renderer
@@ -158,6 +159,10 @@ class CalloutRenderer extends Renderer
             }
 
             return $finalLines;
+        }
+
+        if ($part instanceof Link) {
+            return (string) $part;
         }
 
         return $this->autoFormat(implode(PHP_EOL, $part->content()));

--- a/src/Themes/Default/Concerns/InteractsWithStrings.php
+++ b/src/Themes/Default/Concerns/InteractsWithStrings.php
@@ -147,7 +147,7 @@ trait InteractsWithStrings
             $segmentChars = mb_str_split($segment['text']);
 
             foreach ($segmentChars as $char) {
-                $chars[] = ['char' => $char, 'codes' => $segment['codes'], 'link' => $segment['link'] ?? ''];
+                $chars[] = ['char' => $char, 'codes' => $segment['codes'], 'link' => $segment['link']];
             }
         }
 

--- a/src/Themes/Default/Concerns/InteractsWithStrings.php
+++ b/src/Themes/Default/Concerns/InteractsWithStrings.php
@@ -32,6 +32,9 @@ trait InteractsWithStrings
      */
     protected function stripEscapeSequences(string $text): string
     {
+        // Strip OSC 8 hyperlink sequences.
+        $text = preg_replace("/\e\]8;[^\e]*\e\\\\/", '', $text);
+
         // Strip ANSI escape sequences.
         $text = preg_replace("/\e[^m]*m/", '', $text);
 
@@ -144,7 +147,7 @@ trait InteractsWithStrings
             $segmentChars = mb_str_split($segment['text']);
 
             foreach ($segmentChars as $char) {
-                $chars[] = ['char' => $char, 'codes' => $segment['codes']];
+                $chars[] = ['char' => $char, 'codes' => $segment['codes'], 'link' => $segment['link'] ?? ''];
             }
         }
 
@@ -159,6 +162,7 @@ trait InteractsWithStrings
         foreach ($plainLines as $plainLine) {
             $line = '';
             $lastCodes = '';
+            $lastLink = '';
             $lineChars = mb_str_split($plainLine);
 
             foreach ($lineChars as $lineChar) {
@@ -173,7 +177,20 @@ trait InteractsWithStrings
                 }
 
                 if ($charIndex < count($chars)) {
+                    $link = $chars[$charIndex]['link'];
                     $codes = $chars[$charIndex]['codes'];
+
+                    if ($link !== $lastLink) {
+                        if ($lastLink !== '') {
+                            $line .= "\e]8;;\e\\";
+                        }
+
+                        if ($link !== '') {
+                            $line .= $link;
+                        }
+
+                        $lastLink = $link;
+                    }
 
                     if ($codes !== $lastCodes) {
                         if ($lastCodes !== '') {
@@ -199,6 +216,10 @@ trait InteractsWithStrings
                 $line .= "\e[0m";
             }
 
+            if ($lastLink !== '') {
+                $line .= "\e]8;;\e\\";
+            }
+
             $result[] = $line;
         }
 
@@ -208,42 +229,72 @@ trait InteractsWithStrings
     /**
      * Parse text into segments with their associated ANSI codes.
      *
-     * @return array<int, array{text: string, codes: string}>
+     * @return array<int, array{text: string, codes: string, link: string}>
      */
     protected function parseAnsiText(string $text): array
     {
         $segments = [];
         $currentCodes = '';
+        $currentLink = '';
         $currentText = '';
         $i = 0;
         $textLength = strlen($text);
 
         while ($i < $textLength) {
-            if ($text[$i] === "\e" && ($i + 1 < $textLength) && $text[$i + 1] === '[') {
-                // Save current segment if it has text
-                if ($currentText !== '') {
-                    $segments[] = ['text' => $currentText, 'codes' => $currentCodes];
-                    $currentText = '';
-                }
-
-                // Extract ANSI escape sequence
-                $escapeSequence = '';
-                while ($i < $textLength) {
-                    $escapeSequence .= $text[$i];
-                    $i++;
-
-                    if (preg_match('/^\\e\\[[0-9;]*m$/', $escapeSequence)) {
-                        // Update current codes
-                        if ($escapeSequence === "\e[0m") {
-                            $currentCodes = '';
-                        } else {
-                            $currentCodes = $escapeSequence;
-                        }
-                        break;
+            if ($text[$i] === "\e" && ($i + 1 < $textLength)) {
+                if ($text[$i + 1] === '[') {
+                    // Save current segment if it has text
+                    if ($currentText !== '') {
+                        $segments[] = ['text' => $currentText, 'codes' => $currentCodes, 'link' => $currentLink];
+                        $currentText = '';
                     }
-                }
 
-                continue;
+                    // Extract CSI escape sequence
+                    $escapeSequence = '';
+                    while ($i < $textLength) {
+                        $escapeSequence .= $text[$i];
+                        $i++;
+
+                        if (preg_match('/^\\e\\[[0-9;]*m$/', $escapeSequence)) {
+                            if ($escapeSequence === "\e[0m") {
+                                $currentCodes = '';
+                            } else {
+                                $currentCodes = $escapeSequence;
+                            }
+                            break;
+                        }
+                    }
+
+                    continue;
+                } elseif ($text[$i + 1] === ']') {
+                    // Save current segment if it has text
+                    if ($currentText !== '') {
+                        $segments[] = ['text' => $currentText, 'codes' => $currentCodes, 'link' => $currentLink];
+                        $currentText = '';
+                    }
+
+                    // Extract OSC sequence (read until ST: ESC \)
+                    $escapeSequence = "\e]";
+                    $i += 2;
+
+                    while ($i < $textLength) {
+                        if ($text[$i] === "\e" && ($i + 1 < $textLength) && $text[$i + 1] === '\\') {
+                            $escapeSequence .= "\e\\";
+                            $i += 2;
+                            break;
+                        }
+                        $escapeSequence .= $text[$i];
+                        $i++;
+                    }
+
+                    if ($escapeSequence === "\e]8;;\e\\") {
+                        $currentLink = '';
+                    } else {
+                        $currentLink = $escapeSequence;
+                    }
+
+                    continue;
+                }
             }
 
             $currentText .= $text[$i];
@@ -252,7 +303,7 @@ trait InteractsWithStrings
 
         // Add final segment
         if ($currentText !== '') {
-            $segments[] = ['text' => $currentText, 'codes' => $currentCodes];
+            $segments[] = ['text' => $currentText, 'codes' => $currentCodes, 'link' => $currentLink];
         }
 
         return $segments;

--- a/tests/Feature/AnsiWordwrapTest.php
+++ b/tests/Feature/AnsiWordwrapTest.php
@@ -88,3 +88,35 @@ it('preserves unstyled text that does not need wrapping', function () use ($inst
 
     expect($result)->toBe(['Short']);
 });
+
+it('preserves OSC 8 hyperlink sequences', function () use ($instance) {
+    $result = $instance->wrap("Click \e]8;;https://example.com\e\\here\e]8;;\e\\", 80);
+
+    expect($result)->toHaveCount(1);
+    expect($result[0])->toContain("\e]8;;https://example.com\e\\");
+    expect($result[0])->toContain('here');
+    expect($result[0])->toContain("\e]8;;\e\\");
+});
+
+it('closes and reopens OSC 8 hyperlink when wrapping across lines', function () use ($instance) {
+    $result = $instance->wrap("\e]8;;https://example.com\e\\Hello World\e]8;;\e\\", 5);
+
+    expect($result)->toHaveCount(2);
+    // First line: link opens, text, link closes
+    expect($result[0])->toContain("\e]8;;https://example.com\e\\");
+    expect($result[0])->toContain('Hello');
+    expect($result[0])->toEndWith("\e]8;;\e\\");
+    // Second line: link reopens, text, link closes
+    expect($result[1])->toContain("\e]8;;https://example.com\e\\");
+    expect($result[1])->toContain('World');
+    expect($result[1])->toEndWith("\e]8;;\e\\");
+});
+
+it('handles OSC 8 hyperlink with ANSI codes inside', function () use ($instance) {
+    $result = $instance->wrap("\e]8;;https://example.com\e\\\e[4mLink Text\e[0m\e]8;;\e\\", 80);
+
+    expect($result)->toHaveCount(1);
+    expect($result[0])->toContain("\e]8;;https://example.com\e\\");
+    expect($result[0])->toContain("\e[4m");
+    expect($result[0])->toContain('Link Text');
+});

--- a/tests/Feature/CalloutTest.php
+++ b/tests/Feature/CalloutTest.php
@@ -170,6 +170,31 @@ it('renders a callout with a spaced numbered list', function () {
     expect($matches)->not->toBeEmpty('Expected a blank line between first and second items');
 });
 
+it('renders a callout with a link element', function () {
+    Prompt::fake();
+
+    callout('Info', [
+        'Visit the dashboard:',
+        Element::link('https://example.com', 'Dashboard'),
+    ]);
+
+    Prompt::assertOutputContains('Info');
+    Prompt::assertOutputContains('Dashboard');
+    Prompt::assertOutputContains("\e]8;;https://example.com\e\\");
+});
+
+it('renders a callout with an inline link', function () {
+    Prompt::fake();
+
+    callout('Info', [
+        'Go here: '.Element::link('https://example.com', 'My Link'),
+    ]);
+
+    Prompt::assertOutputContains('Go here:');
+    Prompt::assertOutputContains('My Link');
+    Prompt::assertOutputContains("\e]8;;https://example.com\e\\");
+});
+
 it('can fall back', function () {
     Prompt::fallbackWhen(true);
 

--- a/tests/Feature/ParseAnsiTextTest.php
+++ b/tests/Feature/ParseAnsiTextTest.php
@@ -18,7 +18,7 @@ it('parses plain text into a single segment', function () use ($instance) {
     $segments = $instance->parse('Hello, World!');
 
     expect($segments)->toBe([
-        ['text' => 'Hello, World!', 'codes' => ''],
+        ['text' => 'Hello, World!', 'codes' => '', 'link' => ''],
     ]);
 });
 
@@ -26,7 +26,7 @@ it('parses text with a single ANSI code', function () use ($instance) {
     $segments = $instance->parse("\e[31mHello\e[0m");
 
     expect($segments)->toBe([
-        ['text' => 'Hello', 'codes' => "\e[31m"],
+        ['text' => 'Hello', 'codes' => "\e[31m", 'link' => ''],
     ]);
 });
 
@@ -34,9 +34,9 @@ it('parses text with mixed styled and unstyled segments', function () use ($inst
     $segments = $instance->parse("Hello \e[1mBold\e[0m World");
 
     expect($segments)->toBe([
-        ['text' => 'Hello ', 'codes' => ''],
-        ['text' => 'Bold', 'codes' => "\e[1m"],
-        ['text' => ' World', 'codes' => ''],
+        ['text' => 'Hello ', 'codes' => '', 'link' => ''],
+        ['text' => 'Bold', 'codes' => "\e[1m", 'link' => ''],
+        ['text' => ' World', 'codes' => '', 'link' => ''],
     ]);
 });
 
@@ -44,11 +44,11 @@ it('parses text with multiple consecutive ANSI codes', function () use ($instanc
     $segments = $instance->parse("\e[31mRed\e[0m \e[32mGreen\e[0m \e[34mBlue\e[0m");
 
     expect($segments)->toBe([
-        ['text' => 'Red', 'codes' => "\e[31m"],
-        ['text' => ' ', 'codes' => ''],
-        ['text' => 'Green', 'codes' => "\e[32m"],
-        ['text' => ' ', 'codes' => ''],
-        ['text' => 'Blue', 'codes' => "\e[34m"],
+        ['text' => 'Red', 'codes' => "\e[31m", 'link' => ''],
+        ['text' => ' ', 'codes' => '', 'link' => ''],
+        ['text' => 'Green', 'codes' => "\e[32m", 'link' => ''],
+        ['text' => ' ', 'codes' => '', 'link' => ''],
+        ['text' => 'Blue', 'codes' => "\e[34m", 'link' => ''],
     ]);
 });
 
@@ -62,6 +62,6 @@ it('parses text with 24-bit color codes', function () use ($instance) {
     $segments = $instance->parse("\e[38;2;255;100;50mColored\e[0m");
 
     expect($segments)->toBe([
-        ['text' => 'Colored', 'codes' => "\e[38;2;255;100;50m"],
+        ['text' => 'Colored', 'codes' => "\e[38;2;255;100;50m", 'link' => ''],
     ]);
 });


### PR DESCRIPTION
Adds `Element::link()` for rendering clickable terminal hyperlinks via OSC 8 escape sequences, with optional underline styling. Teaches the ANSI word wrapper and escape sequence stripper to handle OSC 8 so links survive text wrapping and width calculations.