### PR TITLE
Remove `content()` from elements in favor of public readonly properties

### DIFF
--- a/src/Elements/BulletedList.php
+++ b/src/Elements/BulletedList.php
@@ -8,17 +8,9 @@ class BulletedList implements ElementContract
      * @param  array<int, string>  $items
      */
     public function __construct(
-        protected array $items,
+        public readonly array $items,
         public readonly bool $spaced = false,
     ) {
         //
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    public function content(): array
-    {
-        return $this->items;
     }
 }

--- a/src/Elements/ElementContract.php
+++ b/src/Elements/ElementContract.php
@@ -4,8 +4,5 @@ namespace Laravel\Prompts\Elements;
 
 interface ElementContract
 {
-    /**
-     * @return array<array-key, string>
-     */
-    public function content(): array;
+    //
 }

--- a/src/Elements/Heading.php
+++ b/src/Elements/Heading.php
@@ -4,16 +4,8 @@ namespace Laravel\Prompts\Elements;
 
 class Heading implements ElementContract
 {
-    public function __construct(protected string $text)
+    public function __construct(public readonly string $text)
     {
         //
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    public function content(): array
-    {
-        return [$this->text];
     }
 }

--- a/src/Elements/KeyValueList.php
+++ b/src/Elements/KeyValueList.php
@@ -7,16 +7,8 @@ class KeyValueList implements ElementContract
     /**
      * @param  array<string, string>  $items
      */
-    public function __construct(protected array $items)
+    public function __construct(public readonly array $items)
     {
         //
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    public function content(): array
-    {
-        return $this->items;
     }
 }

--- a/src/Elements/Link.php
+++ b/src/Elements/Link.php
@@ -5,28 +5,16 @@ namespace Laravel\Prompts\Elements;
 class Link implements ElementContract
 {
     public function __construct(
-        protected string $url,
-        protected ?string $label = null,
+        public readonly string $url,
+        public readonly ?string $label = null,
         public readonly bool $underline = true,
     ) {
-        //
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    public function content(): array
-    {
-        return [$this->url, $this->label ?? $this->url];
+        $this->label ??= $this->url;
     }
 
     public function __toString(): string
     {
-        $text = $this->label ?? $this->url;
-
-        if ($this->underline) {
-            $text = "\e[4m{$text}\e[24m";
-        }
+        $text = ($this->underline) ? "\e[4m{$this->label}\e[24m" : $this->label;
 
         return "\e]8;;{$this->url}\e\\{$text}\e]8;;\e\\";
     }

--- a/src/Elements/Link.php
+++ b/src/Elements/Link.php
@@ -4,12 +4,14 @@ namespace Laravel\Prompts\Elements;
 
 class Link implements ElementContract
 {
+    public readonly string $label;
+
     public function __construct(
         public readonly string $url,
-        public readonly ?string $label = null,
+        ?string $label = null,
         public readonly bool $underline = true,
     ) {
-        $this->label ??= $this->url;
+        $this->label = $label ?? $this->url;
     }
 
     public function __toString(): string

--- a/src/Elements/NumberedList.php
+++ b/src/Elements/NumberedList.php
@@ -8,17 +8,9 @@ class NumberedList implements ElementContract
      * @param  array<int, string>  $items
      */
     public function __construct(
-        protected array $items,
+        public readonly array $items,
         public readonly bool $spaced = false,
     ) {
         //
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    public function content(): array
-    {
-        return $this->items;
     }
 }

--- a/src/Themes/Default/CalloutRenderer.php
+++ b/src/Themes/Default/CalloutRenderer.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Prompts\Themes\Default;
 
+use InvalidArgumentException;
 use Laravel\Prompts\Callout;
 use Laravel\Prompts\Elements\BulletedList;
 use Laravel\Prompts\Elements\ElementContract;
@@ -74,17 +75,13 @@ class CalloutRenderer extends Renderer
         }
 
         if ($part instanceof Heading) {
-            return $this->bold(
-                $this->autoFormat(
-                    implode('', $part->content())
-                ),
-            );
+            return $this->bold($this->autoFormat($part->text));
         }
 
         if ($part instanceof BulletedList) {
             $finalLines = [];
 
-            foreach ($part->content() as $i => $p) {
+            foreach ($part->items as $i => $p) {
                 $p = $this->autoFormat($p);
                 $lines = $this->ansiWordwrap($p, $this->minWidth - 2);
                 $partLines = [];
@@ -110,9 +107,9 @@ class CalloutRenderer extends Renderer
         if ($part instanceof NumberedList) {
             $finalLines = [];
 
-            foreach ($part->content() as $i => $p) {
+            foreach ($part->items as $i => $p) {
                 // +1 for "."
-                $widestNumber = mb_strwidth((string) count($part->content())) + 1;
+                $widestNumber = mb_strwidth((string) count($part->items)) + 1;
                 $partLines = [];
                 // -1 for ' ' after number
                 $p = $this->autoFormat($p);
@@ -138,7 +135,7 @@ class CalloutRenderer extends Renderer
         }
 
         if ($part instanceof KeyValueList) {
-            $items = $part->content();
+            $items = $part->items;
             $keys = array_keys($items);
             $widestKey = max(array_map(fn ($key) => mb_strwidth($key), $keys));
 
@@ -165,7 +162,7 @@ class CalloutRenderer extends Renderer
             return (string) $part;
         }
 
-        return $this->autoFormat(implode(PHP_EOL, $part->content()));
+        throw new InvalidArgumentException('Unsupported callout content part: '.get_debug_type($part));
     }
 
     /**


### PR DESCRIPTION
Replace the `content()` method on each element class with `public readonly` promoted properties, and access them directly in the renderer. The method was just returning the property as-is, so this removes a layer of indirection.

Also throws on unsupported element types in `resolvePart` instead of silently attempting to render them.