### PR TITLE
Add `date` and `datetime` prompts

### DIFF
--- a/playground/date.php
+++ b/playground/date.php
@@ -1,0 +1,20 @@
+<?php
+
+use function Laravel\Prompts\date;
+
+require __DIR__.'/../vendor/autoload.php';
+
+$date = date(
+    label: 'When should the deploy run?',
+    default: '+3 days',
+    min: 'today',
+    max: '+1 year',
+    validate: fn (DateTimeImmutable $date) => $date->format('N') >= 6
+        ? 'The deploy cannot run on a weekend.'
+        : null,
+    hint: 'The deploy will run at midnight UTC.',
+);
+
+var_dump($date);
+
+echo str_repeat(PHP_EOL, 5);

--- a/playground/datetime.php
+++ b/playground/datetime.php
@@ -1,0 +1,16 @@
+<?php
+
+use function Laravel\Prompts\datetime;
+
+require __DIR__.'/../vendor/autoload.php';
+
+$datetime = datetime(
+    label: 'When should the maintenance window start?',
+    default: 'tomorrow 22:00',
+    min: 'today',
+    weekStartsOn: 0,
+);
+
+var_dump($datetime);
+
+echo str_repeat(PHP_EOL, 5);

--- a/src/Concerns/Themes.php
+++ b/src/Concerns/Themes.php
@@ -8,6 +8,7 @@ use Laravel\Prompts\Callout;
 use Laravel\Prompts\Clear;
 use Laravel\Prompts\ConfirmPrompt;
 use Laravel\Prompts\DataTablePrompt;
+use Laravel\Prompts\DatePrompt;
 use Laravel\Prompts\Grid;
 use Laravel\Prompts\MultiSearchPrompt;
 use Laravel\Prompts\MultiSelectPrompt;
@@ -31,6 +32,7 @@ use Laravel\Prompts\Themes\Default\CalloutRenderer;
 use Laravel\Prompts\Themes\Default\ClearRenderer;
 use Laravel\Prompts\Themes\Default\ConfirmPromptRenderer;
 use Laravel\Prompts\Themes\Default\DataTableRenderer;
+use Laravel\Prompts\Themes\Default\DatePromptRenderer;
 use Laravel\Prompts\Themes\Default\GridRenderer;
 use Laravel\Prompts\Themes\Default\MultiSearchPromptRenderer;
 use Laravel\Prompts\Themes\Default\MultiSelectPromptRenderer;
@@ -88,6 +90,7 @@ trait Themes
             Task::class => TaskRenderer::class,
             DataTablePrompt::class => DataTableRenderer::class,
             Callout::class => CalloutRenderer::class,
+            DatePrompt::class => DatePromptRenderer::class,
         ],
     ];
 

--- a/src/Concerns/Themes.php
+++ b/src/Concerns/Themes.php
@@ -9,6 +9,7 @@ use Laravel\Prompts\Clear;
 use Laravel\Prompts\ConfirmPrompt;
 use Laravel\Prompts\DataTablePrompt;
 use Laravel\Prompts\DatePrompt;
+use Laravel\Prompts\DateTimePrompt;
 use Laravel\Prompts\Grid;
 use Laravel\Prompts\MultiSearchPrompt;
 use Laravel\Prompts\MultiSelectPrompt;
@@ -33,6 +34,7 @@ use Laravel\Prompts\Themes\Default\ClearRenderer;
 use Laravel\Prompts\Themes\Default\ConfirmPromptRenderer;
 use Laravel\Prompts\Themes\Default\DataTableRenderer;
 use Laravel\Prompts\Themes\Default\DatePromptRenderer;
+use Laravel\Prompts\Themes\Default\DateTimePromptRenderer;
 use Laravel\Prompts\Themes\Default\GridRenderer;
 use Laravel\Prompts\Themes\Default\MultiSearchPromptRenderer;
 use Laravel\Prompts\Themes\Default\MultiSelectPromptRenderer;
@@ -91,6 +93,7 @@ trait Themes
             DataTablePrompt::class => DataTableRenderer::class,
             Callout::class => CalloutRenderer::class,
             DatePrompt::class => DatePromptRenderer::class,
+            DateTimePrompt::class => DateTimePromptRenderer::class,
         ],
     ];
 

--- a/src/DatePrompt.php
+++ b/src/DatePrompt.php
@@ -198,10 +198,26 @@ class DatePrompt extends Prompt
 
             return match (true) {
                 is_callable($validate) => $validate($value),
-                isset(static::$validateUsing) => (static::$validateUsing)($this),
+                isset(static::$validateUsing) => $this->delegateValidation($validate),
                 default => throw new RuntimeException('The validation logic is missing.'),
             };
         };
+    }
+
+    /**
+     * Delegate to the custom validation callback, exposing the original validation logic.
+     */
+    protected function delegateValidation(mixed $validate): mixed
+    {
+        $wrapped = $this->validate;
+
+        $this->validate = $validate;
+
+        try {
+            return (static::$validateUsing)($this);
+        } finally {
+            $this->validate = $wrapped;
+        }
     }
 
     /**

--- a/src/DatePrompt.php
+++ b/src/DatePrompt.php
@@ -142,6 +142,10 @@ class DatePrompt extends Prompt
      */
     protected function type(string $key): void
     {
+        if ($key !== '' && $key[0] === "\e") {
+            return;
+        }
+
         foreach (str_split($key) as $char) {
             if (ctype_digit($char) && strlen($this->buffer) < 8) {
                 $this->buffer .= $char;

--- a/src/DatePrompt.php
+++ b/src/DatePrompt.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace Laravel\Prompts;
+
+use Closure;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Exception;
+use InvalidArgumentException;
+use RuntimeException;
+
+class DatePrompt extends Prompt
+{
+    /**
+     * The date currently highlighted on the calendar.
+     */
+    public DateTimeImmutable $date;
+
+    /**
+     * The default date.
+     */
+    public ?DateTimeImmutable $default;
+
+    /**
+     * The earliest selectable date.
+     */
+    public ?DateTimeImmutable $min;
+
+    /**
+     * The latest selectable date.
+     */
+    public ?DateTimeImmutable $max;
+
+    /**
+     * The digits typed into the date mask.
+     */
+    public string $buffer = '';
+
+    /**
+     * Create a new DatePrompt instance.
+     */
+    public function __construct(
+        public string $label,
+        DateTimeInterface|string|null $default = null,
+        DateTimeInterface|string|null $min = null,
+        DateTimeInterface|string|null $max = null,
+        public bool|string $required = false,
+        public mixed $validate = null,
+        public string $hint = 'Use the arrow keys to navigate or type a date.',
+        public ?Closure $transform = null,
+        public int $weekStartsOn = 1,
+    ) {
+        if ($this->weekStartsOn < 0 || $this->weekStartsOn > 6) {
+            throw new InvalidArgumentException('Argument [weekStartsOn] must be between 0 (Sunday) and 6 (Saturday).');
+        }
+
+        $this->default = $this->normalizeDate($default);
+        $this->min = $this->normalizeDate($min);
+        $this->max = $this->normalizeDate($max);
+
+        if ($this->min !== null && $this->max !== null && $this->min > $this->max) {
+            throw new InvalidArgumentException('Argument [min] must be on or before [max].');
+        }
+
+        $this->date = $this->clamp($this->default ?? new DateTimeImmutable('today'));
+
+        $this->validate = $this->wrapValidation($this->validate);
+
+        $this->on('key', fn ($key) => $this->handleKey($key));
+    }
+
+    /**
+     * Handle a key press.
+     */
+    protected function handleKey(string $key): mixed
+    {
+        return match ($key) {
+            Key::LEFT, Key::LEFT_ARROW, Key::CTRL_B => $this->goTo($this->date->modify('-1 day')),
+            Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_F => $this->goTo($this->date->modify('+1 day')),
+            Key::UP, Key::UP_ARROW, Key::CTRL_P => $this->goTo($this->date->modify('-7 days')),
+            Key::DOWN, Key::DOWN_ARROW, Key::CTRL_N => $this->goTo($this->date->modify('+7 days')),
+            Key::PAGE_UP => $this->goTo($this->addMonths(-1)),
+            Key::PAGE_DOWN => $this->goTo($this->addMonths(1)),
+            Key::SHIFT_UP => $this->goTo($this->addMonths(-12)),
+            Key::SHIFT_DOWN => $this->goTo($this->addMonths(12)),
+            Key::oneOf([Key::HOME, Key::CTRL_A], $key) => $this->goTo($this->date->modify('first day of this month')),
+            Key::oneOf([Key::END, Key::CTRL_E], $key) => $this->goTo($this->date->modify('last day of this month')),
+            Key::BACKSPACE, Key::CTRL_H => $this->buffer = substr($this->buffer, 0, -1),
+            Key::ENTER => $this->submit(),
+            default => $this->type($key),
+        };
+    }
+
+    /**
+     * Get the selected date.
+     */
+    public function value(): ?DateTimeImmutable
+    {
+        if (static::$interactive === false) {
+            return $this->default;
+        }
+
+        return $this->date;
+    }
+
+    /**
+     * Get the selected date, or the typed digits over the mask, formatted for display.
+     */
+    public function formattedValue(): string
+    {
+        if ($this->buffer !== '') {
+            $digits = str_pad($this->buffer, 8, '_');
+
+            return sprintf('%s-%s-%s', substr($digits, 0, 4), substr($digits, 4, 2), substr($digits, 6, 2));
+        }
+
+        return $this->date->format('Y-m-d');
+    }
+
+    /**
+     * Determine whether any moment of the given day of the highlighted month is selectable.
+     */
+    public function selectableDay(int $day): bool
+    {
+        $date = $this->date->setDate((int) $this->date->format('Y'), (int) $this->date->format('n'), $day);
+
+        return ($this->min === null || $date->setTime(23, 59, 59) >= $this->min)
+            && ($this->max === null || $date->setTime(0, 0) <= $this->max);
+    }
+
+    /**
+     * Highlight the given date, keeping it within the min/max range.
+     */
+    protected function goTo(DateTimeImmutable $date): void
+    {
+        $this->buffer = '';
+        $this->date = $this->clamp($date);
+    }
+
+    /**
+     * Append the typed digits to the buffer and commit it once complete and valid.
+     */
+    protected function type(string $key): void
+    {
+        foreach (str_split($key) as $char) {
+            if (ctype_digit($char) && strlen($this->buffer) < 8) {
+                $this->buffer .= $char;
+            }
+        }
+
+        $date = $this->bufferedDate();
+
+        if ($date !== null && $date == $this->clamp($date)) {
+            $this->date = $date;
+            $this->buffer = '';
+        }
+    }
+
+    /**
+     * Get the date represented by a completely typed buffer.
+     */
+    protected function bufferedDate(): ?DateTimeImmutable
+    {
+        if (strlen($this->buffer) !== 8) {
+            return null;
+        }
+
+        [$year, $month, $day] = [substr($this->buffer, 0, 4), substr($this->buffer, 4, 2), substr($this->buffer, 6, 2)];
+
+        if (! checkdate((int) $month, (int) $day, (int) $year)) {
+            return null;
+        }
+
+        return (new DateTimeImmutable("{$year}-{$month}-{$day}"))->setTime(0, 0);
+    }
+
+    /**
+     * Wrap the validation logic to first verify the typed buffer.
+     */
+    protected function wrapValidation(mixed $validate): callable
+    {
+        return function ($value) use ($validate) {
+            if (strlen($this->buffer) > 0 && strlen($this->buffer) < 8) {
+                return 'Incomplete date.';
+            }
+
+            if (strlen($this->buffer) === 8) {
+                return $this->bufferedDate() === null ? 'Invalid date.' : $this->rangeError($this->bufferedDate());
+            }
+
+            if (! $validate && ! isset(static::$validateUsing)) {
+                return null;
+            }
+
+            return match (true) {
+                is_callable($validate) => $validate($value),
+                isset(static::$validateUsing) => (static::$validateUsing)($this),
+                default => throw new RuntimeException('The validation logic is missing.'),
+            };
+        };
+    }
+
+    /**
+     * Get the validation error for a date outside of the min/max range.
+     */
+    protected function rangeError(DateTimeImmutable $date): ?string
+    {
+        return match (true) {
+            $this->min !== null && $date < $this->min => 'Must be on or after '.$this->min->format($this->dateFormat()).'.',
+            $this->max !== null && $date > $this->max => 'Must be on or before '.$this->max->format($this->dateFormat()).'.',
+            default => null,
+        };
+    }
+
+    /**
+     * The format used when displaying dates in messages.
+     */
+    protected function dateFormat(): string
+    {
+        return 'Y-m-d';
+    }
+
+    /**
+     * Add the given number of months, clamping the day to the target month.
+     */
+    protected function addMonths(int $months): DateTimeImmutable
+    {
+        $month = $this->date->modify('first day of this month')->modify(sprintf('%+d months', $months));
+
+        $day = min((int) $this->date->format('j'), (int) $month->format('t'));
+
+        return $month->setDate((int) $month->format('Y'), (int) $month->format('n'), $day);
+    }
+
+    /**
+     * Constrain the given date to the min/max range.
+     */
+    protected function clamp(DateTimeImmutable $date): DateTimeImmutable
+    {
+        return match (true) {
+            $this->min !== null && $date < $this->min => $this->min,
+            $this->max !== null && $date > $this->max => $this->max,
+            default => $date,
+        };
+    }
+
+    /**
+     * Normalize the given date to a DateTimeImmutable at the prompt's precision.
+     */
+    protected function normalizeDate(DateTimeInterface|string|null $date): ?DateTimeImmutable
+    {
+        if ($date === null) {
+            return null;
+        }
+
+        if ($date instanceof DateTimeInterface) {
+            return $this->truncateTime(DateTimeImmutable::createFromInterface($date));
+        }
+
+        try {
+            return $this->truncateTime(new DateTimeImmutable($date));
+        } catch (Exception) {
+            throw new InvalidArgumentException("Date [{$date}] is not valid.");
+        }
+    }
+
+    /**
+     * Truncate the time to the prompt's precision.
+     */
+    protected function truncateTime(DateTimeImmutable $date): DateTimeImmutable
+    {
+        return $date->setTime(0, 0);
+    }
+
+    /**
+     * Determine whether the given value is invalid when the prompt is required.
+     */
+    protected function isInvalidWhenRequired(mixed $value): bool
+    {
+        return $value === null;
+    }
+}

--- a/src/DatePrompt.php
+++ b/src/DatePrompt.php
@@ -179,7 +179,7 @@ class DatePrompt extends Prompt
     }
 
     /**
-     * Wrap the validation logic to first verify the typed buffer.
+     * Wrap the validation logic to first verify the typed buffer and the range.
      */
     protected function wrapValidation(mixed $validate): callable
     {
@@ -190,6 +190,10 @@ class DatePrompt extends Prompt
 
             if (strlen($this->buffer) === 8) {
                 return $this->bufferedDate() === null ? 'Invalid date.' : $this->rangeError($this->bufferedDate());
+            }
+
+            if (($selected = $this->value()) !== null && ($error = $this->rangeError($selected)) !== null) {
+                return $error;
             }
 
             if (! $validate && ! isset(static::$validateUsing)) {

--- a/src/DateTimePrompt.php
+++ b/src/DateTimePrompt.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Laravel\Prompts;
+
+use Closure;
+use DateTimeImmutable;
+use DateTimeInterface;
+
+class DateTimePrompt extends DatePrompt
+{
+    /**
+     * The hour of the selected time.
+     */
+    public int $hour;
+
+    /**
+     * The minute of the selected time.
+     */
+    public int $minute;
+
+    /**
+     * The second of the selected time.
+     */
+    public int $second;
+
+    /**
+     * The segment that currently has focus: "calendar", "hour", "minute", or "second".
+     */
+    public string $focused = 'calendar';
+
+    /**
+     * Create a new DateTimePrompt instance.
+     */
+    public function __construct(
+        string $label,
+        DateTimeInterface|string|null $default = null,
+        DateTimeInterface|string|null $min = null,
+        DateTimeInterface|string|null $max = null,
+        bool|string $required = false,
+        mixed $validate = null,
+        string $hint = 'Use the arrow keys to navigate or type a date. Tab edits the time.',
+        ?Closure $transform = null,
+        int $weekStartsOn = 1,
+        public bool $withSeconds = false,
+    ) {
+        parent::__construct($label, $default, $min, $max, $required, $validate, $hint, $transform, $weekStartsOn);
+
+        $time = $this->clamp($this->default ?? $this->truncateTime(new DateTimeImmutable('now')));
+
+        $this->hour = (int) $time->format('G');
+        $this->minute = (int) $time->format('i');
+        $this->second = (int) $time->format('s');
+    }
+
+    /**
+     * Get the selected date and time.
+     */
+    public function value(): ?DateTimeImmutable
+    {
+        return parent::value()?->setTime($this->hour, $this->minute, $this->second);
+    }
+
+    /**
+     * Get the selected date and time formatted for display.
+     */
+    public function formattedValue(): string
+    {
+        return parent::formattedValue().' '.$this->formattedTime();
+    }
+
+    /**
+     * Get the selected time formatted for display.
+     */
+    public function formattedTime(): string
+    {
+        return $this->withSeconds
+            ? sprintf('%02d:%02d:%02d', $this->hour, $this->minute, $this->second)
+            : sprintf('%02d:%02d', $this->hour, $this->minute);
+    }
+
+    /**
+     * Handle a key press, routing it to the focused segment.
+     */
+    protected function handleKey(string $key): mixed
+    {
+        return match (true) {
+            $key === Key::TAB => $this->moveFocus(1),
+            $key === Key::SHIFT_TAB => $this->moveFocus(-1),
+            $this->focused === 'calendar' => parent::handleKey($key),
+            default => $this->handleTimeKey($key),
+        };
+    }
+
+    /**
+     * Handle a key press while a time segment has focus.
+     */
+    protected function handleTimeKey(string $key): mixed
+    {
+        return match ($key) {
+            Key::UP, Key::UP_ARROW, Key::CTRL_P => $this->stepSegment(1),
+            Key::DOWN, Key::DOWN_ARROW, Key::CTRL_N => $this->stepSegment(-1),
+            Key::LEFT, Key::LEFT_ARROW, Key::CTRL_B => $this->moveFocus(-1),
+            Key::RIGHT, Key::RIGHT_ARROW, Key::CTRL_F => $this->focused === $this->lastSegment() ? null : $this->moveFocus(1),
+            Key::ENTER => $this->submit(),
+            default => $this->typeIntoSegment($key),
+        };
+    }
+
+    /**
+     * Move the focus by the given number of segments, wrapping around.
+     */
+    protected function moveFocus(int $direction): void
+    {
+        $segments = $this->segments();
+
+        $index = array_search($this->focused, $segments) + $direction;
+
+        $this->focused = $segments[($index + count($segments)) % count($segments)];
+    }
+
+    /**
+     * Step the focused time segment, wrapping around.
+     */
+    protected function stepSegment(int $step): void
+    {
+        match ($this->focused) {
+            'hour' => $this->hour = ($this->hour + $step + 24) % 24,
+            'minute' => $this->minute = ($this->minute + $step + 60) % 60,
+            'second' => $this->second = ($this->second + $step + 60) % 60,
+            default => null,
+        };
+    }
+
+    /**
+     * Type digits into the focused time segment, rolling the last two digits.
+     */
+    protected function typeIntoSegment(string $key): void
+    {
+        foreach (str_split($key) as $char) {
+            if (! ctype_digit($char)) {
+                continue;
+            }
+
+            match ($this->focused) {
+                'hour' => $this->hour = min(($this->hour % 10) * 10 + (int) $char, 23),
+                'minute' => $this->minute = min(($this->minute % 10) * 10 + (int) $char, 59),
+                'second' => $this->second = min(($this->second % 10) * 10 + (int) $char, 59),
+                default => null,
+            };
+        }
+    }
+
+    /**
+     * The focusable segments.
+     *
+     * @return list<string>
+     */
+    protected function segments(): array
+    {
+        return $this->withSeconds
+            ? ['calendar', 'hour', 'minute', 'second']
+            : ['calendar', 'hour', 'minute'];
+    }
+
+    /**
+     * The last focusable segment.
+     */
+    protected function lastSegment(): string
+    {
+        $segments = $this->segments();
+
+        return $segments[count($segments) - 1];
+    }
+
+    /**
+     * Get the date represented by a completely typed buffer, at the selected time.
+     */
+    protected function bufferedDate(): ?DateTimeImmutable
+    {
+        return parent::bufferedDate()?->setTime($this->hour, $this->minute, $this->second);
+    }
+
+    /**
+     * Wrap the validation logic to also verify the selected time against the range.
+     */
+    protected function wrapValidation(mixed $validate): callable
+    {
+        $validateDate = parent::wrapValidation($validate);
+
+        return function ($value) use ($validateDate) {
+            $selected = $this->value();
+
+            if ($this->buffer === '' && $selected !== null && ($error = $this->rangeError($selected)) !== null) {
+                return $error;
+            }
+
+            return $validateDate($value);
+        };
+    }
+
+    /**
+     * Truncate the time to the prompt's precision.
+     */
+    protected function truncateTime(DateTimeImmutable $date): DateTimeImmutable
+    {
+        return $this->withSeconds
+            ? $date
+            : $date->setTime((int) $date->format('G'), (int) $date->format('i'));
+    }
+
+    /**
+     * The format used when displaying dates in messages.
+     */
+    protected function dateFormat(): string
+    {
+        return $this->withSeconds ? 'Y-m-d H:i:s' : 'Y-m-d H:i';
+    }
+}

--- a/src/DateTimePrompt.php
+++ b/src/DateTimePrompt.php
@@ -200,7 +200,7 @@ class DateTimePrompt extends DatePrompt
     protected function truncateTime(DateTimeImmutable $date): DateTimeImmutable
     {
         return $this->withSeconds
-            ? $date
+            ? $date->setTime((int) $date->format('G'), (int) $date->format('i'), (int) $date->format('s'))
             : $date->setTime((int) $date->format('G'), (int) $date->format('i'));
     }
 

--- a/src/DateTimePrompt.php
+++ b/src/DateTimePrompt.php
@@ -146,12 +146,22 @@ class DateTimePrompt extends DatePrompt
             }
 
             match ($this->focused) {
-                'hour' => $this->hour = min(($this->hour % 10) * 10 + (int) $char, 23),
-                'minute' => $this->minute = min(($this->minute % 10) * 10 + (int) $char, 59),
-                'second' => $this->second = min(($this->second % 10) * 10 + (int) $char, 59),
+                'hour' => $this->hour = $this->rollSegment($this->hour, (int) $char, 23),
+                'minute' => $this->minute = $this->rollSegment($this->minute, (int) $char, 59),
+                'second' => $this->second = $this->rollSegment($this->second, (int) $char, 59),
                 default => null,
             };
         }
+    }
+
+    /**
+     * Roll the typed digit into the segment, restarting from the digit on overflow.
+     */
+    protected function rollSegment(int $current, int $digit, int $max): int
+    {
+        $rolled = ($current % 10) * 10 + $digit;
+
+        return $rolled <= $max ? $rolled : $digit;
     }
 
     /**

--- a/src/DateTimePrompt.php
+++ b/src/DateTimePrompt.php
@@ -136,6 +136,10 @@ class DateTimePrompt extends DatePrompt
      */
     protected function typeIntoSegment(string $key): void
     {
+        if ($key !== '' && $key[0] === "\e") {
+            return;
+        }
+
         foreach (str_split($key) as $char) {
             if (! ctype_digit($char)) {
                 continue;

--- a/src/DateTimePrompt.php
+++ b/src/DateTimePrompt.php
@@ -195,24 +195,6 @@ class DateTimePrompt extends DatePrompt
     }
 
     /**
-     * Wrap the validation logic to also verify the selected time against the range.
-     */
-    protected function wrapValidation(mixed $validate): callable
-    {
-        $validateDate = parent::wrapValidation($validate);
-
-        return function ($value) use ($validateDate) {
-            $selected = $this->value();
-
-            if ($this->buffer === '' && $selected !== null && ($error = $this->rangeError($selected)) !== null) {
-                return $error;
-            }
-
-            return $validateDate($value);
-        };
-    }
-
-    /**
      * Truncate the time to the prompt's precision.
      */
     protected function truncateTime(DateTimeImmutable $date): DateTimeImmutable

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -3,6 +3,7 @@
 namespace Laravel\Prompts;
 
 use Closure;
+use DateTimeInterface;
 use Illuminate\Support\Collection;
 use Laravel\Prompts\Exceptions\FormRevertedException;
 
@@ -176,6 +177,22 @@ class FormBuilder
     public function multisearch(string $label, Closure $options, string $placeholder = '', int $scroll = 5, bool|string $required = false, mixed $validate = null, string $hint = 'Use the space bar to select options.', ?string $name = null, ?Closure $transform = null): self
     {
         return $this->runPrompt(multisearch(...), get_defined_vars());
+    }
+
+    /**
+     * Prompt the user for a date using a navigable calendar.
+     */
+    public function date(string $label, DateTimeInterface|string|null $default = null, DateTimeInterface|string|null $min = null, DateTimeInterface|string|null $max = null, bool|string $required = false, mixed $validate = null, string $hint = 'Use the arrow keys to navigate or type a date.', ?Closure $transform = null, int $weekStartsOn = 1, ?string $name = null): self
+    {
+        return $this->runPrompt(date(...), get_defined_vars());
+    }
+
+    /**
+     * Prompt the user for a date and time using a navigable calendar.
+     */
+    public function datetime(string $label, DateTimeInterface|string|null $default = null, DateTimeInterface|string|null $min = null, DateTimeInterface|string|null $max = null, bool|string $required = false, mixed $validate = null, string $hint = 'Use the arrow keys to navigate or type a date. Tab edits the time.', ?Closure $transform = null, int $weekStartsOn = 1, bool $withSeconds = false, ?string $name = null): self
+    {
+        return $this->runPrompt(datetime(...), get_defined_vars());
     }
 
     /**

--- a/src/Themes/Default/DatePromptRenderer.php
+++ b/src/Themes/Default/DatePromptRenderer.php
@@ -10,6 +10,16 @@ class DatePromptRenderer extends Renderer
     use Concerns\DrawsBoxes;
 
     /**
+     * The width of a calendar cell: a three-letter day name or a padded day number.
+     */
+    protected int $cellWidth = 3;
+
+    /**
+     * The width of the calendar grid: seven cells with separators.
+     */
+    protected int $gridWidth = 27;
+
+    /**
      * Render the date prompt.
      */
     public function __invoke(DatePrompt $prompt): string
@@ -51,16 +61,6 @@ class DatePromptRenderer extends Renderer
                 ),
         };
     }
-
-    /**
-     * The width of a calendar cell: a three-letter day name or a padded day number.
-     */
-    protected int $cellWidth = 3;
-
-    /**
-     * The width of the calendar grid: seven cells with separators.
-     */
-    protected int $gridWidth = 27;
 
     /**
      * Render the selected date above the calendar grid.

--- a/src/Themes/Default/DatePromptRenderer.php
+++ b/src/Themes/Default/DatePromptRenderer.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Laravel\Prompts\Themes\Default;
+
+use DateTimeImmutable;
+use Laravel\Prompts\DatePrompt;
+
+class DatePromptRenderer extends Renderer
+{
+    use Concerns\DrawsBoxes;
+
+    /**
+     * Render the date prompt.
+     */
+    public function __invoke(DatePrompt $prompt): string
+    {
+        $maxWidth = $prompt->terminal()->cols() - 6;
+
+        return match ($prompt->state) {
+            'submit' => $this
+                ->box(
+                    $this->dim($this->truncate($prompt->label, $maxWidth)),
+                    $prompt->formattedValue(),
+                ),
+
+            'cancel' => $this
+                ->box(
+                    $this->truncate($prompt->label, $maxWidth),
+                    $this->strikethrough($this->dim($prompt->formattedValue())),
+                    color: 'red',
+                )
+                ->error($prompt->cancelMessage),
+
+            'error' => $this
+                ->box(
+                    $this->truncate($prompt->label, $maxWidth),
+                    $this->renderBody($prompt),
+                    color: 'yellow',
+                )
+                ->warning($this->truncate($prompt->error, $prompt->terminal()->cols() - 5)),
+
+            default => $this
+                ->box(
+                    $this->cyan($this->truncate($prompt->label, $maxWidth)),
+                    $this->renderBody($prompt),
+                )
+                ->when(
+                    $prompt->hint,
+                    fn () => $this->hint($prompt->hint),
+                    fn () => $this->newLine() // Space for errors
+                ),
+        };
+    }
+
+    /**
+     * The width of a calendar cell: a three-letter day name or a padded day number.
+     */
+    protected int $cellWidth = 3;
+
+    /**
+     * The width of the calendar grid: seven cells with separators.
+     */
+    protected int $gridWidth = 27;
+
+    /**
+     * Render the selected date above the calendar grid.
+     */
+    protected function renderBody(DatePrompt $prompt): string
+    {
+        return implode(PHP_EOL, [
+            $prompt->formattedValue(),
+            '',
+            $this->monthTitle($prompt),
+            $this->weekdayHeader($prompt),
+            ...$this->weeks($prompt),
+        ]);
+    }
+
+    /**
+     * Render the month title, centered over the grid.
+     */
+    protected function monthTitle(DatePrompt $prompt): string
+    {
+        $title = $prompt->date->format('F Y');
+
+        return str_repeat(' ', max(0, intdiv($this->gridWidth - mb_strwidth($title), 2))).$title;
+    }
+
+    /**
+     * Render the weekday header, starting the week on the prompt's first day.
+     */
+    protected function weekdayHeader(DatePrompt $prompt): string
+    {
+        $labels = array_map(
+            fn ($day) => (new DateTimeImmutable("Sunday +{$day} days"))->format('D'),
+            range($prompt->weekStartsOn, $prompt->weekStartsOn + 6),
+        );
+
+        return $this->dim(implode(' ', $labels));
+    }
+
+    /**
+     * Render the days of the month in rows of seven cells.
+     *
+     * @return list<string>
+     */
+    protected function weeks(DatePrompt $prompt): array
+    {
+        $month = $prompt->date->modify('first day of this month');
+
+        $offset = ((int) $month->format('w') - $prompt->weekStartsOn + 7) % 7;
+
+        $cells = array_fill(0, $offset, str_repeat(' ', $this->cellWidth));
+
+        foreach (range(1, (int) $month->format('t')) as $day) {
+            $cells[] = $this->dayCell($prompt, $day);
+        }
+
+        return array_map(
+            fn ($week) => implode(' ', $week),
+            array_chunk($cells, 7),
+        );
+    }
+
+    /**
+     * Render a single day cell.
+     */
+    protected function dayCell(DatePrompt $prompt, int $day): string
+    {
+        $cell = str_pad((string) $day, $this->cellWidth, ' ', STR_PAD_LEFT);
+
+        if ($day === (int) $prompt->date->format('j')) {
+            return $this->inverse($cell);
+        }
+
+        if (! $prompt->selectableDay($day)) {
+            return $this->dim($cell);
+        }
+
+        return $cell;
+    }
+}

--- a/src/Themes/Default/DateTimePromptRenderer.php
+++ b/src/Themes/Default/DateTimePromptRenderer.php
@@ -12,8 +12,7 @@ class DateTimePromptRenderer extends DatePromptRenderer
      */
     protected function renderBody(DatePrompt $prompt): string
     {
-        assert($prompt instanceof DateTimePrompt);
-
+        /** @var DateTimePrompt $prompt */
         return implode(PHP_EOL, [
             parent::renderBody($prompt),
             '',

--- a/src/Themes/Default/DateTimePromptRenderer.php
+++ b/src/Themes/Default/DateTimePromptRenderer.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravel\Prompts\Themes\Default;
+
+use Laravel\Prompts\DatePrompt;
+use Laravel\Prompts\DateTimePrompt;
+
+class DateTimePromptRenderer extends DatePromptRenderer
+{
+    /**
+     * Render the selected date, the calendar grid, and the time row.
+     */
+    protected function renderBody(DatePrompt $prompt): string
+    {
+        assert($prompt instanceof DateTimePrompt);
+
+        return implode(PHP_EOL, [
+            parent::renderBody($prompt),
+            '',
+            $this->timeRow($prompt),
+        ]);
+    }
+
+    /**
+     * Render the time segments, highlighting the focused one.
+     */
+    protected function timeRow(DateTimePrompt $prompt): string
+    {
+        $segments = [
+            'hour' => sprintf('%02d', $prompt->hour),
+            'minute' => sprintf('%02d', $prompt->minute),
+        ];
+
+        if ($prompt->withSeconds) {
+            $segments['second'] = sprintf('%02d', $prompt->second);
+        }
+
+        if (isset($segments[$prompt->focused])) {
+            $segments[$prompt->focused] = $this->inverse($segments[$prompt->focused]);
+        }
+
+        return $this->dim('Time').'  '.implode(':', $segments);
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -3,6 +3,8 @@
 namespace Laravel\Prompts;
 
 use Closure;
+use DateTimeImmutable;
+use DateTimeInterface;
 use Illuminate\Support\Collection;
 use Laravel\Prompts\Elements\ElementContract;
 
@@ -440,6 +442,27 @@ if (! function_exists('\Laravel\Prompts\task')) {
     function task(string $label, Closure $callback, ?int $limit = null, bool $keepSummary = false, ?string $subLabel = null): mixed
     {
         return (new Task($label, $limit ?? 10, $keepSummary, $subLabel))->run($callback);
+    }
+}
+
+if (! function_exists('\Laravel\Prompts\date')) {
+    /**
+     * Prompt the user for a date using a navigable calendar.
+     *
+     * @return ($transform is null ? DateTimeImmutable|null : mixed)
+     */
+    function date(
+        string $label,
+        DateTimeInterface|string|null $default = null,
+        DateTimeInterface|string|null $min = null,
+        DateTimeInterface|string|null $max = null,
+        bool|string $required = false,
+        mixed $validate = null,
+        string $hint = 'Use the arrow keys to navigate or type a date.',
+        ?Closure $transform = null,
+        int $weekStartsOn = 1,
+    ): mixed {
+        return (new DatePrompt(...get_defined_vars()))->prompt();
     }
 }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -466,6 +466,28 @@ if (! function_exists('\Laravel\Prompts\date')) {
     }
 }
 
+if (! function_exists('\Laravel\Prompts\datetime')) {
+    /**
+     * Prompt the user for a date and time using a navigable calendar.
+     *
+     * @return ($transform is null ? DateTimeImmutable|null : mixed)
+     */
+    function datetime(
+        string $label,
+        DateTimeInterface|string|null $default = null,
+        DateTimeInterface|string|null $min = null,
+        DateTimeInterface|string|null $max = null,
+        bool|string $required = false,
+        mixed $validate = null,
+        string $hint = 'Use the arrow keys to navigate or type a date. Tab edits the time.',
+        ?Closure $transform = null,
+        int $weekStartsOn = 1,
+        bool $withSeconds = false,
+    ): mixed {
+        return (new DateTimePrompt(...get_defined_vars()))->prompt();
+    }
+}
+
 if (! function_exists('\Laravel\Prompts\datatable')) {
     /**
      * Display an interactive data table.

--- a/tests/Feature/DatePromptTest.php
+++ b/tests/Feature/DatePromptTest.php
@@ -178,6 +178,12 @@ it('fails when non-interactive and required without a default', function () {
     date(label: 'When should the deploy run?', required: true);
 })->throws(NonInteractiveValidationException::class, 'Required.');
 
+it('fails when non-interactive with a default outside of the range', function () {
+    Prompt::interactive(false);
+
+    date(label: 'When should the deploy run?', default: '2026-07-24', min: '2026-08-01');
+})->throws(NonInteractiveValidationException::class, 'Must be on or after 2026-08-01.');
+
 it('renders the calendar grid for the highlighted month', function () {
     Prompt::fake([Key::ENTER]);
 

--- a/tests/Feature/DatePromptTest.php
+++ b/tests/Feature/DatePromptTest.php
@@ -279,6 +279,19 @@ it('ignores non-digit input', function () {
     expect($result->format('Y-m-d'))->toBe('2026-07-24');
 });
 
+it('ignores escape sequences while typing', function () {
+    Prompt::fake([
+        '2', '0', Key::DELETE, "\e[1;5C", '2', '6', '1', '2', '2', '5',
+        Key::BACKSPACE, Key::BACKSPACE, Key::BACKSPACE, Key::BACKSPACE,
+        Key::BACKSPACE, Key::BACKSPACE, Key::BACKSPACE, Key::BACKSPACE,
+        Key::ENTER,
+    ]);
+
+    $result = date(label: 'When should the deploy run?', default: '2026-07-24');
+
+    expect($result->format('Y-m-d'))->toBe('2026-12-25');
+});
+
 it('clamps navigation to the min date', function () {
     Prompt::fake([Key::LEFT, Key::LEFT, Key::ENTER]);
 

--- a/tests/Feature/DatePromptTest.php
+++ b/tests/Feature/DatePromptTest.php
@@ -1,0 +1,380 @@
+<?php
+
+use Laravel\Prompts\DatePrompt;
+use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
+use Laravel\Prompts\Key;
+use Laravel\Prompts\Prompt;
+
+use function Laravel\Prompts\date;
+
+it('returns the default date as a DateTimeImmutable at midnight', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = date(
+        label: 'When should the deploy run?',
+        default: '2026-07-24',
+    );
+
+    expect($result)->toBeInstanceOf(DateTimeImmutable::class)
+        ->and($result->format('Y-m-d H:i:s'))->toBe('2026-07-24 00:00:00');
+});
+
+it('accepts a DateTimeInterface default', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = date(
+        label: 'When should the deploy run?',
+        default: new DateTime('2026-07-24 15:30:00'),
+    );
+
+    expect($result->format('Y-m-d H:i:s'))->toBe('2026-07-24 00:00:00');
+});
+
+it('defaults to today', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = date(label: 'When should the deploy run?');
+
+    expect($result->format('Y-m-d H:i:s'))
+        ->toBe((new DateTimeImmutable('today'))->format('Y-m-d H:i:s'));
+});
+
+it('navigates days with the left and right arrow keys', function () {
+    Prompt::fake([Key::RIGHT, Key::RIGHT, Key::LEFT, Key::ENTER]);
+
+    $result = date(
+        label: 'When should the deploy run?',
+        default: '2026-07-24',
+    );
+
+    expect($result->format('Y-m-d'))->toBe('2026-07-25');
+});
+
+it('navigates weeks with the up and down arrow keys across month boundaries', function () {
+    Prompt::fake([Key::UP, Key::DOWN, Key::DOWN, Key::ENTER]);
+
+    $result = date(
+        label: 'When should the deploy run?',
+        default: '2026-07-01',
+    );
+
+    expect($result->format('Y-m-d'))->toBe('2026-07-08');
+});
+
+it('navigates months with page up and page down, clamping the day', function () {
+    Prompt::fake([Key::PAGE_DOWN, Key::ENTER]);
+
+    $result = date(
+        label: 'When should the deploy run?',
+        default: '2026-01-31',
+    );
+
+    expect($result->format('Y-m-d'))->toBe('2026-02-28');
+});
+
+it('navigates back a month with page up', function () {
+    Prompt::fake([Key::PAGE_DOWN, Key::PAGE_UP, Key::ENTER]);
+
+    $result = date(
+        label: 'When should the deploy run?',
+        default: '2026-01-31',
+    );
+
+    expect($result->format('Y-m-d'))->toBe('2026-01-28');
+});
+
+it('navigates years with shift up and shift down, clamping leap days', function () {
+    Prompt::fake([Key::SHIFT_DOWN, Key::ENTER]);
+
+    $result = date(
+        label: 'When should the deploy run?',
+        default: '2024-02-29',
+    );
+
+    expect($result->format('Y-m-d'))->toBe('2025-02-28');
+});
+
+it('jumps to the first and last day of the month with home and end', function () {
+    Prompt::fake([Key::END[0], Key::ENTER]);
+
+    $result = date(
+        label: 'When should the deploy run?',
+        default: '2026-07-24',
+    );
+
+    expect($result->format('Y-m-d'))->toBe('2026-07-31');
+
+    Prompt::fake([Key::HOME[0], Key::ENTER]);
+
+    $result = date(
+        label: 'When should the deploy run?',
+        default: '2026-07-24',
+    );
+
+    expect($result->format('Y-m-d'))->toBe('2026-07-01');
+});
+
+it('transforms values', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = date(
+        label: 'When should the deploy run?',
+        default: '2026-07-24',
+        transform: fn (DateTimeImmutable $date) => $date->format('Y-m-d'),
+    );
+
+    expect($result)->toBe('2026-07-24');
+});
+
+it('validates', function () {
+    Prompt::fake([Key::ENTER, Key::LEFT, Key::ENTER]);
+
+    $result = date(
+        label: 'When should the deploy run?',
+        default: '2026-07-25',
+        validate: fn (DateTimeImmutable $date) => $date->format('N') >= 6
+            ? 'The deploy cannot run on a weekend.'
+            : null,
+    );
+
+    expect($result->format('Y-m-d'))->toBe('2026-07-24');
+
+    Prompt::assertOutputContains('The deploy cannot run on a weekend.');
+});
+
+it('rejects an invalid default string', function () {
+    date(label: 'When should the deploy run?', default: 'not-a-date');
+})->throws(InvalidArgumentException::class, 'not-a-date');
+
+it('rejects a week start outside of Sunday through Saturday', function () {
+    date(label: 'When should the deploy run?', weekStartsOn: 7);
+})->throws(InvalidArgumentException::class, 'weekStartsOn');
+
+it('can be cancelled', function () {
+    Prompt::fake([Key::CTRL_C]);
+
+    date(label: 'When should the deploy run?', default: '2026-07-24');
+
+    Prompt::assertOutputContains('Cancelled.');
+});
+
+it('returns the default when non-interactive', function () {
+    Prompt::interactive(false);
+
+    $result = date(label: 'When should the deploy run?', default: '2026-07-24');
+
+    expect($result->format('Y-m-d'))->toBe('2026-07-24');
+});
+
+it('returns null when non-interactive without a default', function () {
+    Prompt::interactive(false);
+
+    expect(date(label: 'When should the deploy run?'))->toBeNull();
+});
+
+it('fails when non-interactive and required without a default', function () {
+    Prompt::interactive(false);
+
+    date(label: 'When should the deploy run?', required: true);
+})->throws(NonInteractiveValidationException::class, 'Required.');
+
+it('renders the calendar grid for the highlighted month', function () {
+    Prompt::fake([Key::ENTER]);
+
+    date(label: 'When should the deploy run?', default: '2026-07-24');
+
+    Prompt::assertStrippedOutputContains('July 2026');
+    Prompt::assertStrippedOutputContains('Mon Tue Wed Thu Fri Sat Sun');
+    Prompt::assertStrippedOutputContains('1   2   3   4   5');
+    Prompt::assertStrippedOutputContains('6   7   8   9  10  11  12');
+    Prompt::assertStrippedOutputContains('13  14  15  16  17  18  19');
+    Prompt::assertStrippedOutputContains('27  28  29  30  31');
+});
+
+it('starts the week on Sunday when requested', function () {
+    Prompt::fake([Key::ENTER]);
+
+    date(label: 'When should the deploy run?', default: '2026-07-24', weekStartsOn: 0);
+
+    Prompt::assertStrippedOutputContains('Sun Mon Tue Wed Thu Fri Sat');
+    Prompt::assertStrippedOutputContains('5   6   7   8   9  10  11');
+});
+
+it('highlights the selected day', function () {
+    Prompt::fake([Key::ENTER]);
+
+    date(label: 'When should the deploy run?', default: '2026-07-24');
+
+    Prompt::assertOutputContains("\e[7m 24\e[27m");
+});
+
+it('renders the submitted date', function () {
+    Prompt::fake([Key::ENTER]);
+
+    date(label: 'When should the deploy run?', default: '2026-07-24');
+
+    Prompt::assertStrippedOutputContains('2026-07-24');
+});
+
+it('jumps to a typed date', function () {
+    Prompt::fake(['2', '0', '2', '6', '1', '2', '2', '5', Key::ENTER]);
+
+    $result = date(label: 'When should the deploy run?', default: '2026-07-24');
+
+    expect($result->format('Y-m-d'))->toBe('2026-12-25');
+});
+
+it('renders the typed digits over the mask', function () {
+    Prompt::fake(['2', '0', '2', '6', '1', '2', '2', '5', Key::ENTER]);
+
+    date(label: 'When should the deploy run?', default: '2026-07-24');
+
+    Prompt::assertStrippedOutputContains('2026-1_-__');
+});
+
+it('removes typed digits with backspace', function () {
+    Prompt::fake(['2', '0', '2', '6', '1', '3', Key::BACKSPACE, '2', '2', '5', Key::ENTER]);
+
+    $result = date(label: 'When should the deploy run?', default: '2026-07-24');
+
+    expect($result->format('Y-m-d'))->toBe('2026-12-25');
+});
+
+it('discards the typed buffer when navigating', function () {
+    Prompt::fake(['2', '0', '2', '7', Key::RIGHT, Key::ENTER]);
+
+    $result = date(label: 'When should the deploy run?', default: '2026-07-24');
+
+    expect($result->format('Y-m-d'))->toBe('2026-07-25');
+});
+
+it('requires a complete typed date', function () {
+    Prompt::fake(['2', '0', '2', '6', Key::ENTER, '1', '2', '2', '5', Key::ENTER]);
+
+    $result = date(label: 'When should the deploy run?', default: '2026-07-24');
+
+    expect($result->format('Y-m-d'))->toBe('2026-12-25');
+
+    Prompt::assertOutputContains('Incomplete date.');
+});
+
+it('rejects an impossible typed date', function () {
+    Prompt::fake([
+        '2', '0', '2', '6', '0', '2', '3', '0', Key::ENTER,
+        Key::BACKSPACE, Key::BACKSPACE, '2', '8', Key::ENTER,
+    ]);
+
+    $result = date(label: 'When should the deploy run?', default: '2026-07-24');
+
+    expect($result->format('Y-m-d'))->toBe('2026-02-28');
+
+    Prompt::assertOutputContains('Invalid date.');
+});
+
+it('ignores non-digit input', function () {
+    Prompt::fake(['a', '!', Key::ENTER]);
+
+    $result = date(label: 'When should the deploy run?', default: '2026-07-24');
+
+    expect($result->format('Y-m-d'))->toBe('2026-07-24');
+});
+
+it('clamps navigation to the min date', function () {
+    Prompt::fake([Key::LEFT, Key::LEFT, Key::ENTER]);
+
+    $result = date(
+        label: 'When should the deploy run?',
+        default: '2026-07-02',
+        min: '2026-07-01',
+    );
+
+    expect($result->format('Y-m-d'))->toBe('2026-07-01');
+});
+
+it('clamps month navigation to the max date', function () {
+    Prompt::fake([Key::PAGE_DOWN, Key::ENTER]);
+
+    $result = date(
+        label: 'When should the deploy run?',
+        default: '2026-07-24',
+        max: '2026-08-05',
+    );
+
+    expect($result->format('Y-m-d'))->toBe('2026-08-05');
+});
+
+it('clamps the default into the range', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = date(
+        label: 'When should the deploy run?',
+        default: '2026-07-24',
+        min: '2026-08-01',
+    );
+
+    expect($result->format('Y-m-d'))->toBe('2026-08-01');
+});
+
+it('dims days outside of the range', function () {
+    Prompt::fake([Key::ENTER]);
+
+    date(
+        label: 'When should the deploy run?',
+        default: '2026-07-24',
+        min: '2026-07-20',
+        max: '2026-07-28',
+    );
+
+    Prompt::assertOutputContains("\e[2m 19\e[22m");
+    Prompt::assertOutputContains("\e[2m 29\e[22m");
+});
+
+it('rejects typed dates before the min date', function () {
+    Prompt::fake([
+        '2', '0', '2', '6', '0', '1', '0', '1', Key::ENTER,
+        Key::BACKSPACE, Key::BACKSPACE, Key::BACKSPACE, Key::BACKSPACE, '0', '7', '0', '5', Key::ENTER,
+    ]);
+
+    $result = date(
+        label: 'When should the deploy run?',
+        default: '2026-07-24',
+        min: '2026-07-01',
+        max: '2026-07-31',
+    );
+
+    expect($result->format('Y-m-d'))->toBe('2026-07-05');
+
+    Prompt::assertOutputContains('Must be on or after 2026-07-01.');
+});
+
+it('rejects typed dates after the max date', function () {
+    Prompt::fake(['2', '0', '2', '7', '0', '1', '0', '1', Key::ENTER, Key::LEFT, Key::ENTER]);
+
+    $result = date(
+        label: 'When should the deploy run?',
+        default: '2026-07-24',
+        max: '2026-12-31',
+    );
+
+    expect($result->format('Y-m-d'))->toBe('2026-07-23');
+
+    Prompt::assertOutputContains('Must be on or before 2026-12-31.');
+});
+
+it('rejects a min date after the max date', function () {
+    date(label: 'When should the deploy run?', min: '2026-07-31', max: '2026-07-01');
+})->throws(InvalidArgumentException::class, 'min');
+
+it('can fall back', function () {
+    Prompt::fallbackWhen(true);
+
+    DatePrompt::fallbackUsing(function (DatePrompt $prompt) {
+        expect($prompt->label)->toBe('When should the deploy run?');
+
+        return new DateTimeImmutable('2026-01-01');
+    });
+
+    $result = date(label: 'When should the deploy run?');
+
+    expect($result->format('Y-m-d'))->toBe('2026-01-01');
+});

--- a/tests/Feature/DatePromptTest.php
+++ b/tests/Feature/DatePromptTest.php
@@ -378,6 +378,32 @@ it('rejects a min date after the max date', function () {
     date(label: 'When should the deploy run?', min: '2026-07-31', max: '2026-07-01');
 })->throws(InvalidArgumentException::class, 'min');
 
+it('supports custom validation', function () {
+    Prompt::validateUsing(function (Prompt $prompt) {
+        expect($prompt)
+            ->label->toBe('When should the deploy run?')
+            ->validate->toBe('weekday');
+
+        return $prompt->validate === 'weekday' && $prompt->value()->format('N') >= 6
+            ? 'The deploy cannot run on a weekend.'
+            : null;
+    });
+
+    Prompt::fake([Key::ENTER, Key::LEFT, Key::ENTER]);
+
+    $result = date(
+        label: 'When should the deploy run?',
+        default: '2026-07-25',
+        validate: 'weekday',
+    );
+
+    expect($result->format('Y-m-d'))->toBe('2026-07-24');
+
+    Prompt::assertOutputContains('The deploy cannot run on a weekend.');
+
+    Prompt::validateUsing(fn () => null);
+});
+
 it('can fall back', function () {
     Prompt::fallbackWhen(true);
 

--- a/tests/Feature/DatePromptTest.php
+++ b/tests/Feature/DatePromptTest.php
@@ -84,7 +84,7 @@ it('navigates back a month with page up', function () {
 });
 
 it('navigates years with shift up and shift down, clamping leap days', function () {
-    Prompt::fake([Key::SHIFT_DOWN, Key::ENTER]);
+    Prompt::fake([Key::SHIFT_DOWN, Key::SHIFT_DOWN, Key::SHIFT_UP, Key::ENTER]);
 
     $result = date(
         label: 'When should the deploy run?',

--- a/tests/Feature/DateTimePromptTest.php
+++ b/tests/Feature/DateTimePromptTest.php
@@ -59,6 +59,17 @@ it('types into the focused time segment', function () {
     expect($result->format('H:i'))->toBe('14:45');
 });
 
+it('ignores escape sequences while a time segment is focused', function () {
+    Prompt::fake([Key::TAB, Key::PAGE_UP, Key::SHIFT_UP, Key::ENTER]);
+
+    $result = datetime(
+        label: 'When should the deploy run?',
+        default: '2026-07-24 14:30',
+    );
+
+    expect($result->format('Y-m-d H:i'))->toBe('2026-07-24 14:30');
+});
+
 it('moves between time segments with the arrow keys', function () {
     Prompt::fake([Key::TAB, Key::RIGHT, '4', '5', Key::ENTER]);
 

--- a/tests/Feature/DateTimePromptTest.php
+++ b/tests/Feature/DateTimePromptTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use Laravel\Prompts\Key;
+use Laravel\Prompts\Prompt;
+
+use function Laravel\Prompts\datetime;
+
+it('returns the default datetime with the seconds zeroed', function () {
+    Prompt::fake([Key::ENTER]);
+
+    $result = datetime(
+        label: 'When should the deploy run?',
+        default: '2026-07-24 14:30:45',
+    );
+
+    expect($result)->toBeInstanceOf(DateTimeImmutable::class)
+        ->and($result->format('Y-m-d H:i:s'))->toBe('2026-07-24 14:30:00');
+});
+
+it('edits the hour with the arrow keys after tabbing', function () {
+    Prompt::fake([Key::TAB, Key::UP, Key::ENTER]);
+
+    $result = datetime(
+        label: 'When should the deploy run?',
+        default: '2026-07-24 14:30',
+    );
+
+    expect($result->format('Y-m-d H:i'))->toBe('2026-07-24 15:30');
+});
+
+it('wraps the hour around midnight', function () {
+    Prompt::fake([Key::TAB, Key::UP, Key::ENTER]);
+
+    $result = datetime(
+        label: 'When should the deploy run?',
+        default: '2026-07-24 23:30',
+    );
+
+    expect($result->format('H:i'))->toBe('00:30');
+
+    Prompt::fake([Key::TAB, Key::DOWN, Key::ENTER]);
+
+    $result = datetime(
+        label: 'When should the deploy run?',
+        default: '2026-07-24 00:15',
+    );
+
+    expect($result->format('H:i'))->toBe('23:15');
+});
+
+it('types into the focused time segment', function () {
+    Prompt::fake([Key::TAB, Key::TAB, '4', '5', Key::ENTER]);
+
+    $result = datetime(
+        label: 'When should the deploy run?',
+        default: '2026-07-24 14:30',
+    );
+
+    expect($result->format('H:i'))->toBe('14:45');
+});
+
+it('moves between time segments with the arrow keys', function () {
+    Prompt::fake([Key::TAB, Key::RIGHT, '4', '5', Key::ENTER]);
+
+    $result = datetime(
+        label: 'When should the deploy run?',
+        default: '2026-07-24 14:30',
+    );
+
+    expect($result->format('H:i'))->toBe('14:45');
+});
+
+it('cycles the focus back to the calendar with tab', function () {
+    Prompt::fake([Key::TAB, Key::TAB, Key::TAB, Key::RIGHT, Key::ENTER]);
+
+    $result = datetime(
+        label: 'When should the deploy run?',
+        default: '2026-07-24 14:30',
+    );
+
+    expect($result->format('Y-m-d H:i'))->toBe('2026-07-25 14:30');
+});
+
+it('cycles the focus backwards with shift tab', function () {
+    Prompt::fake([Key::SHIFT_TAB, '4', '5', Key::ENTER]);
+
+    $result = datetime(
+        label: 'When should the deploy run?',
+        default: '2026-07-24 14:30',
+    );
+
+    expect($result->format('H:i'))->toBe('14:45');
+});
+
+it('returns to the calendar with the left arrow from the hour', function () {
+    Prompt::fake([Key::TAB, Key::LEFT, Key::DOWN, Key::ENTER]);
+
+    $result = datetime(
+        label: 'When should the deploy run?',
+        default: '2026-07-24 14:30',
+    );
+
+    expect($result->format('Y-m-d H:i'))->toBe('2026-07-31 14:30');
+});
+
+it('supports a seconds segment', function () {
+    Prompt::fake([Key::TAB, Key::TAB, Key::TAB, Key::UP, Key::ENTER]);
+
+    $result = datetime(
+        label: 'When should the deploy run?',
+        default: '2026-07-24 14:30:10',
+        withSeconds: true,
+    );
+
+    expect($result->format('Y-m-d H:i:s'))->toBe('2026-07-24 14:30:11');
+});
+
+it('still accepts typed dates while the calendar is focused', function () {
+    Prompt::fake(['2', '0', '2', '6', '1', '2', '2', '5', Key::ENTER]);
+
+    $result = datetime(
+        label: 'When should the deploy run?',
+        default: '2026-07-24 14:30',
+    );
+
+    expect($result->format('Y-m-d H:i'))->toBe('2026-12-25 14:30');
+});
+
+it('renders the time row and highlights the focused segment', function () {
+    Prompt::fake([Key::TAB, Key::ENTER]);
+
+    datetime(label: 'When should the deploy run?', default: '2026-07-24 14:30');
+
+    Prompt::assertStrippedOutputContains('Time  14:30');
+    Prompt::assertStrippedOutputContains('2026-07-24 14:30');
+    Prompt::assertOutputContains("\e[7m14\e[27m");
+});
+
+it('rejects times outside of the range', function () {
+    Prompt::fake([Key::TAB, Key::DOWN, Key::ENTER, Key::UP, Key::ENTER]);
+
+    $result = datetime(
+        label: 'When should the deploy run?',
+        default: '2026-07-24 09:30',
+        min: '2026-07-24 09:00',
+    );
+
+    expect($result->format('Y-m-d H:i'))->toBe('2026-07-24 09:30');
+
+    Prompt::assertOutputContains('Must be on or after 2026-07-24 09:00.');
+});
+
+it('returns the default when non-interactive', function () {
+    Prompt::interactive(false);
+
+    $result = datetime(label: 'When should the deploy run?', default: '2026-07-24 14:30');
+
+    expect($result->format('Y-m-d H:i'))->toBe('2026-07-24 14:30');
+});
+
+it('returns null when non-interactive without a default', function () {
+    Prompt::interactive(false);
+
+    expect(datetime(label: 'When should the deploy run?'))->toBeNull();
+});

--- a/tests/Feature/DateTimePromptTest.php
+++ b/tests/Feature/DateTimePromptTest.php
@@ -181,6 +181,19 @@ it('rejects times outside of the range', function () {
     Prompt::assertOutputContains('Must be on or after 2026-07-24 09:00.');
 });
 
+it('ignores microseconds in the range boundaries', function () {
+    Prompt::interactive(false);
+
+    $result = datetime(
+        label: 'When should the maintenance window start?',
+        default: '2026-07-24 09:00:00.900000',
+        min: '2026-07-24 09:00:00.500000',
+        withSeconds: true,
+    );
+
+    expect($result->format('Y-m-d H:i:s.u'))->toBe('2026-07-24 09:00:00.000000');
+});
+
 it('returns the default when non-interactive', function () {
     Prompt::interactive(false);
 

--- a/tests/Feature/DateTimePromptTest.php
+++ b/tests/Feature/DateTimePromptTest.php
@@ -59,6 +59,26 @@ it('types into the focused time segment', function () {
     expect($result->format('H:i'))->toBe('14:45');
 });
 
+it('restarts a time segment from the typed digit when it would overflow', function () {
+    Prompt::fake([Key::TAB, '0', '9', Key::ENTER]);
+
+    $result = datetime(
+        label: 'When should the deploy run?',
+        default: '2026-07-24 14:30',
+    );
+
+    expect($result->format('H:i'))->toBe('09:30');
+
+    Prompt::fake([Key::TAB, Key::TAB, '3', '7', Key::ENTER]);
+
+    $result = datetime(
+        label: 'When should the deploy run?',
+        default: '2026-07-24 14:59',
+    );
+
+    expect($result->format('H:i'))->toBe('14:37');
+});
+
 it('ignores escape sequences while a time segment is focused', function () {
     Prompt::fake([Key::TAB, Key::PAGE_UP, Key::SHIFT_UP, Key::ENTER]);
 

--- a/tests/Feature/FormTest.php
+++ b/tests/Feature/FormTest.php
@@ -227,3 +227,35 @@ it('leaves skipped conditional field empty', function () {
         true,
     ]);
 });
+
+it('supports date and datetime steps', function () {
+    Prompt::fake([
+        Key::ENTER,
+        Key::TAB, Key::UP, Key::ENTER,
+    ]);
+
+    $responses = form()
+        ->date('When should the deploy run?', default: '2026-07-24', name: 'date')
+        ->datetime('When should the maintenance window start?', default: '2026-07-24 14:30', name: 'window')
+        ->submit();
+
+    expect($responses['date']->format('Y-m-d'))->toBe('2026-07-24')
+        ->and($responses['window']->format('Y-m-d H:i'))->toBe('2026-07-24 15:30');
+});
+
+it('reuses the previous date response as the default when reverting', function () {
+    Prompt::fake([
+        Key::ENTER,
+        Key::CTRL_U,
+        Key::RIGHT, Key::ENTER,
+        Key::ENTER,
+    ]);
+
+    $responses = form()
+        ->date('When should the deploy run?', default: '2026-07-24')
+        ->datetime('When should the maintenance window start?', default: '2026-07-24 14:30')
+        ->submit();
+
+    expect($responses[0]->format('Y-m-d'))->toBe('2026-07-25')
+        ->and($responses[1]->format('Y-m-d H:i'))->toBe('2026-07-24 14:30');
+});


### PR DESCRIPTION
## Overview

CLI apps ask for dates all the time — deploy schedules, maintenance windows, report ranges — but Prompts has no first-party way to collect one. The usual workaround is a `text()` prompt with format validation: no navigation, no range constraints, and easy to get wrong.

## Solution

This PR adds `date()` and `datetime()` prompts backed by an arrow-key navigable calendar with typed entry over a `YYYY-MM-DD` mask, both kept in sync. They return a `DateTimeImmutable`, accept `DateTimeInterface` instances or date strings for `default`, `min`, and `max` (out-of-range days are dimmed and navigation is clamped), and support `weekStartsOn`. `datetime()` adds Tab-focusable hour/minute segments, an opt-in seconds segment via `withSeconds`, and full-instant range validation. Both are also available as `form()` steps.

## Preview

**`date()`**

<img width="1134" height="466" alt="date" src="https://github.com/user-attachments/assets/19a308fb-3e8a-450d-b866-5a0aedf8d9d3" />

**`datetime()`**

<img width="1154" height="461" alt="datetime" src="https://github.com/user-attachments/assets/715d4fd0-3ae5-4127-a13e-c2991acba38c" />

## Keyboard shortcuts

| Keys | Action |
| --- | --- |
| ← / → | Previous / next day |
| ↑ / ↓ | Previous / next week |
| PgUp / PgDn | Previous / next month (day clamped) |
| Shift + ↑ / Shift + ↓ | Previous / next year (day clamped) |
| Home / End | First / last day of the month |
| 0–9 | Type into the date mask — Backspace edits, navigating discards, and the date commits once complete and in range |
| Tab / Shift + Tab | `datetime()`: cycle focus between the calendar and the time segments |
| ↑ / ↓ (time segment) | Step the segment, wrapping around |
| 0–9 (time segment) | Type the value, rolling the last two digits |
| Enter | Submit |

The usual Emacs-style aliases (`Ctrl+B/F`, `Ctrl+P/N`, `Ctrl+A/E`, `Ctrl+H`) are supported as well.

## Examples

```php
use function Laravel\Prompts\date;
use function Laravel\Prompts\datetime;

$deploy = date(
    label: 'When should the deploy run?',
    default: '+3 days',
    min: 'today',
    max: '+1 year',
);

$window = datetime(
    label: 'When should the maintenance window start?',
    min: 'now',
    weekStartsOn: 0,
    withSeconds: true,
);
```

Both also work as form steps: `form()->date(...)->datetime(...)->submit()`.

> [!NOTE]
> Importing the function with `use function Laravel\Prompts\date;` shadows PHP's native `date()` within that file — the native function stays available as `\date()`.