### PR TITLE
Add Tree element for rendering nested hierarchies

### DIFF
--- a/playground/tree.php
+++ b/playground/tree.php
@@ -1,0 +1,61 @@
+<?php
+
+use Laravel\Prompts\Elements\Element;
+
+use function Laravel\Prompts\callout;
+use function Laravel\Prompts\tree;
+
+require __DIR__.'/../vendor/autoload.php';
+
+tree([
+    'app' => [
+        'Models' => ['User.php', 'Order.php'],
+        'Providers' => ['AppServiceProvider.php'],
+    ],
+    'config' => ['app.php', 'database.php'],
+    'composer.json',
+    'README.md',
+]);
+
+tree([
+    'laravel/prompts' => [
+        'symfony/console' => [
+            'symfony/polyfill-mbstring',
+            'symfony/service-contracts',
+        ],
+        'composer-runtime-api',
+    ],
+]);
+
+tree([
+    'Deployment steps' => [
+        'Run `composer install --no-dev`',
+        'Run `php artisan migrate --force`',
+        'Restart the queue workers with `php artisan queue:restart`',
+    ],
+]);
+
+callout(
+    'Application Scaffolded',
+    [
+        'The following files were created for you:',
+        Element::heading('Structure'),
+        Element::tree([
+            'app' => [
+                'Http' => [
+                    'Controllers' => ['PodcastsController.php'],
+                    'Requests' => ['StorePodcastRequest.php'],
+                ],
+                'Models' => ['Podcast.php'],
+            ],
+            'database' => [
+                'migrations' => ['2024_03_15_000000_create_podcasts_table.php'],
+            ],
+        ]),
+        Element::heading('Next Steps'),
+        Element::numberedList([
+            'Run `php artisan migrate`',
+            'Register the routes in `routes/web.php`',
+        ]),
+    ],
+);

--- a/src/Concerns/Themes.php
+++ b/src/Concerns/Themes.php
@@ -49,7 +49,9 @@ use Laravel\Prompts\Themes\Default\TaskRenderer;
 use Laravel\Prompts\Themes\Default\TextareaPromptRenderer;
 use Laravel\Prompts\Themes\Default\TextPromptRenderer;
 use Laravel\Prompts\Themes\Default\TitleRenderer;
+use Laravel\Prompts\Themes\Default\TreeRenderer;
 use Laravel\Prompts\Title;
+use Laravel\Prompts\Tree;
 
 trait Themes
 {
@@ -88,6 +90,7 @@ trait Themes
             Task::class => TaskRenderer::class,
             DataTablePrompt::class => DataTableRenderer::class,
             Callout::class => CalloutRenderer::class,
+            Tree::class => TreeRenderer::class,
         ],
     ];
 

--- a/src/Elements/Element.php
+++ b/src/Elements/Element.php
@@ -37,4 +37,12 @@ class Element
     {
         return new Link($url, $label, $underline);
     }
+
+    /**
+     * @param  array<int|string, string|array<int|string, mixed>>  $items
+     */
+    public static function tree(array $items): Tree
+    {
+        return new Tree($items);
+    }
 }

--- a/src/Elements/Tree.php
+++ b/src/Elements/Tree.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Prompts\Elements;
+
+class Tree implements ElementContract
+{
+    /**
+     * @param  array<int|string, string|array<int|string, mixed>>  $items
+     */
+    public function __construct(public readonly array $items)
+    {
+        //
+    }
+}

--- a/src/Themes/Default/CalloutRenderer.php
+++ b/src/Themes/Default/CalloutRenderer.php
@@ -190,24 +190,4 @@ class CalloutRenderer extends Renderer
 
         return "\e]8;;{$part->url}\e\\{$text}\e]8;;\e\\";
     }
-
-    /**
-     * Auto-format the text by applying styles to specific patterns, such as inline code blocks.
-     */
-    protected function autoFormat(string $text): string
-    {
-        $text = preg_replace('/`([^`]+)`/', $this->cyan('`$1`'), $text);
-
-        $text = preg_replace_callback('/\e\]8;;(.+?)\e\\\\(.*?)\e\]8;;\e\\\\/', function ($matches) {
-            $visibleText = $this->stripEscapeSequences($matches[2]);
-            $hadUnderline = str_contains($matches[2], "\e[4m");
-            $styled = $hadUnderline
-                ? "\e[4;36m{$visibleText}\e[0m"
-                : $this->cyan($visibleText);
-
-            return "\e]8;;{$matches[1]}\e\\{$styled}\e]8;;\e\\";
-        }, $text);
-
-        return $text;
-    }
 }

--- a/src/Themes/Default/CalloutRenderer.php
+++ b/src/Themes/Default/CalloutRenderer.php
@@ -10,10 +10,12 @@ use Laravel\Prompts\Elements\Heading;
 use Laravel\Prompts\Elements\KeyValueList;
 use Laravel\Prompts\Elements\Link;
 use Laravel\Prompts\Elements\NumberedList;
+use Laravel\Prompts\Elements\Tree;
 
 class CalloutRenderer extends Renderer
 {
     use Concerns\DrawsBoxes;
+    use Concerns\DrawsTrees;
 
     /**
      * Render the text prompt.
@@ -28,7 +30,9 @@ class CalloutRenderer extends Renderer
             $result = $this->resolvePart($part);
 
             if (is_array($result)) {
-                $sections[] = implode(PHP_EOL, $result);
+                if ($result !== []) {
+                    $sections[] = implode(PHP_EOL, $result);
+                }
             } else {
                 $sections[] = implode(PHP_EOL, $this->ansiWordwrap($result, $this->minWidth));
             }
@@ -77,6 +81,7 @@ class CalloutRenderer extends Renderer
             $part instanceof NumberedList => $this->renderNumberedList($part),
             $part instanceof KeyValueList => $this->renderKeyValueList($part),
             $part instanceof Link => $this->renderLink($part),
+            $part instanceof Tree => $this->treeLines($part->items, $this->minWidth),
             default => throw new InvalidArgumentException('Unsupported callout content part: '.get_debug_type($part)),
         };
     }

--- a/src/Themes/Default/Concerns/DrawsTrees.php
+++ b/src/Themes/Default/Concerns/DrawsTrees.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Laravel\Prompts\Themes\Default\Concerns;
+
+trait DrawsTrees
+{
+    /**
+     * Render a tree of nested items as connector-prefixed lines.
+     *
+     * @param  array<int|string, mixed>  $items
+     * @return array<int, string>
+     */
+    protected function treeLines(array $items, int $width, string $prefix = ''): array
+    {
+        $lines = [];
+        $nodes = $this->treeNodes($items);
+        $lastIndex = count($nodes) - 1;
+
+        foreach ($nodes as $index => $node) {
+            $isLast = $index === $lastIndex;
+            $connector = $isLast ? '└─ ' : '├─ ';
+            $childPrefix = $prefix.($isLast ? '   ' : $this->dim('│').'  ');
+
+            $labelWidth = max(1, $width - mb_strwidth($this->stripEscapeSequences($prefix)) - mb_strwidth($connector));
+
+            foreach ($this->ansiWordwrap($this->autoFormat($node['label']), $labelWidth) as $i => $line) {
+                $lines[] = ($i === 0 ? $prefix.$this->dim($connector) : $childPrefix).$line;
+            }
+
+            $lines = array_merge($lines, $this->treeLines($node['children'], $width, $childPrefix));
+        }
+
+        return $lines;
+    }
+
+    /**
+     * Normalize one level of items into labeled nodes with raw children.
+     *
+     * @param  array<int|string, mixed>  $items
+     * @return array<int, array{label: string, children: array<int|string, mixed>}>
+     */
+    protected function treeNodes(array $items): array
+    {
+        $nodes = [];
+
+        foreach ($items as $key => $value) {
+            if (is_string($key)) {
+                $nodes[] = ['label' => $key, 'children' => is_array($value) ? $value : [$value]];
+
+                continue;
+            }
+
+            if (is_array($value)) {
+                $nodes = array_merge($nodes, $this->treeNodes($value));
+
+                continue;
+            }
+
+            $nodes[] = ['label' => (string) $value, 'children' => []];
+        }
+
+        return $nodes;
+    }
+}

--- a/src/Themes/Default/Concerns/DrawsTrees.php
+++ b/src/Themes/Default/Concerns/DrawsTrees.php
@@ -34,7 +34,9 @@ trait DrawsTrees
     }
 
     /**
-     * Normalize one level of items into labeled nodes with raw children.
+     * Normalize one level of items: string keys are branches (a string value
+     * becomes their single leaf child), plain strings are leaves, and unkeyed
+     * arrays flatten into the current level.
      *
      * @param  array<int|string, mixed>  $items
      * @return array<int, array{label: string, children: array<int|string, mixed>}>

--- a/src/Themes/Default/Concerns/InteractsWithStrings.php
+++ b/src/Themes/Default/Concerns/InteractsWithStrings.php
@@ -28,6 +28,26 @@ trait InteractsWithStrings
     }
 
     /**
+     * Auto-format the text by applying styles to specific patterns, such as inline code blocks.
+     */
+    protected function autoFormat(string $text): string
+    {
+        $text = preg_replace('/`([^`]+)`/', $this->cyan('`$1`'), $text);
+
+        $text = preg_replace_callback('/\e\]8;;(.+?)\e\\\\(.*?)\e\]8;;\e\\\\/', function ($matches) {
+            $visibleText = $this->stripEscapeSequences($matches[2]);
+            $hadUnderline = str_contains($matches[2], "\e[4m");
+            $styled = $hadUnderline
+                ? "\e[4;36m{$visibleText}\e[0m"
+                : $this->cyan($visibleText);
+
+            return "\e]8;;{$matches[1]}\e\\{$styled}\e]8;;\e\\";
+        }, $text);
+
+        return $text;
+    }
+
+    /**
      * Strip ANSI escape sequences from the given text.
      */
     protected function stripEscapeSequences(string $text): string

--- a/src/Themes/Default/TreeRenderer.php
+++ b/src/Themes/Default/TreeRenderer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Laravel\Prompts\Themes\Default;
+
+use Laravel\Prompts\Tree;
+
+class TreeRenderer extends Renderer
+{
+    use Concerns\DrawsTrees;
+    use Concerns\InteractsWithStrings;
+
+    protected int $minWidth = 60;
+
+    /**
+     * Render the tree.
+     */
+    public function __invoke(Tree $tree): string
+    {
+        foreach ($this->treeLines($tree->items, $tree->terminal()->cols() - 2) as $line) {
+            $this->line(" {$line}");
+        }
+
+        return $this;
+    }
+}

--- a/src/Tree.php
+++ b/src/Tree.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Laravel\Prompts;
+
+class Tree extends Prompt
+{
+    /**
+     * Create a new Tree instance.
+     *
+     * @param  array<int|string, string|array<int|string, mixed>>  $items
+     */
+    public function __construct(public array $items)
+    {
+        //
+    }
+
+    /**
+     * Display the tree.
+     */
+    public function display(): void
+    {
+        $this->prompt();
+    }
+
+    /**
+     * Display the tree.
+     */
+    public function prompt(): bool
+    {
+        $this->capturePreviousNewLines();
+
+        if (static::shouldFallback()) {
+            return $this->fallback();
+        }
+
+        $this->state = 'submit';
+
+        static::output()->write($this->renderTheme());
+
+        return true;
+    }
+
+    /**
+     * Get the value of the prompt.
+     */
+    public function value(): bool
+    {
+        return true;
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -374,6 +374,18 @@ if (! function_exists('\Laravel\Prompts\grid')) {
     }
 }
 
+if (! function_exists('\Laravel\Prompts\tree')) {
+    /**
+     * Display a tree of nested items.
+     *
+     * @param  array<int|string, string|array<int|string, mixed>>  $items
+     */
+    function tree(array $items): void
+    {
+        (new Tree($items))->display();
+    }
+}
+
 if (! function_exists('\Laravel\Prompts\progress')) {
     /**
      * Display a progress bar.

--- a/tests/Feature/CalloutTest.php
+++ b/tests/Feature/CalloutTest.php
@@ -195,6 +195,144 @@ it('renders a callout with an inline link', function () {
     Prompt::assertOutputContains("\e]8;;https://example.com\e\\");
 });
 
+it('renders a callout with a flat tree', function () {
+    Prompt::fake();
+
+    callout('Files', [
+        Element::tree([
+            'first.php',
+            'second.php',
+            'third.php',
+        ]),
+    ]);
+
+    Prompt::assertOutputContains('Files');
+    Prompt::assertStrippedOutputContains('├─ first.php');
+    Prompt::assertStrippedOutputContains('├─ second.php');
+    Prompt::assertStrippedOutputContains('└─ third.php');
+});
+
+it('renders a callout with a nested tree', function () {
+    Prompt::fake();
+
+    callout('Structure', [
+        'Files created:',
+        Element::tree([
+            'src' => [
+                'Elements' => ['Element.php', 'Tree.php'],
+                'helpers.php',
+            ],
+            'README.md',
+        ]),
+    ]);
+
+    Prompt::assertStrippedOutputContains('├─ src');
+    Prompt::assertStrippedOutputContains('│  ├─ Elements');
+    Prompt::assertStrippedOutputContains('│  │  ├─ Element.php');
+    Prompt::assertStrippedOutputContains('│  │  └─ Tree.php');
+    Prompt::assertStrippedOutputContains('│  └─ helpers.php');
+    Prompt::assertStrippedOutputContains('└─ README.md');
+});
+
+it('renders a callout with a tree between other elements', function () {
+    Prompt::fake();
+
+    callout('Scaffolding', [
+        'The following files were created:',
+        Element::heading('Structure'),
+        Element::tree([
+            'app' => [
+                'Models' => ['User.php'],
+            ],
+        ]),
+        Element::bulletedList(['Run the migrations next']),
+    ]);
+
+    Prompt::assertOutputContains('Scaffolding');
+    Prompt::assertOutputContains('Structure');
+    Prompt::assertStrippedOutputContains('└─ app');
+    Prompt::assertStrippedOutputContains('   └─ Models');
+    Prompt::assertStrippedOutputContains('      └─ User.php');
+    Prompt::assertStrippedOutputContains('· Run the migrations next');
+});
+
+it('auto-formats tree labels in a callout', function () {
+    Prompt::fake();
+
+    callout('Steps', [
+        Element::tree([
+            'Run `composer install`',
+        ]),
+    ]);
+
+    Prompt::assertStrippedOutputContains('└─ Run `composer install`');
+    Prompt::assertOutputContains("\e[36m`composer install`");
+});
+
+it('renders a callout tree branch with a single string child', function () {
+    Prompt::fake();
+
+    callout('Docs', [
+        Element::tree([
+            'docs' => 'README.md',
+        ]),
+    ]);
+
+    Prompt::assertStrippedOutputContains('└─ docs');
+    Prompt::assertStrippedOutputContains('   └─ README.md');
+});
+
+it('renders a callout tree branch with no children', function () {
+    Prompt::fake();
+
+    callout('Empty Directory', [
+        Element::tree([
+            'src' => [],
+            'README.md',
+        ]),
+    ]);
+
+    Prompt::assertStrippedOutputContains('├─ src');
+    Prompt::assertStrippedOutputContains('└─ README.md');
+});
+
+it('renders a callout with an empty tree', function () {
+    Prompt::fake();
+
+    callout('Empty', [
+        'Nothing to show.',
+        Element::tree([]),
+    ]);
+
+    Prompt::assertOutputContains('Empty');
+    Prompt::assertOutputContains('Nothing to show.');
+
+    // The empty tree adds no blank section: the bottom border follows the text.
+    expect(Prompt::strippedContent())->toMatch('/Nothing to show\..*\n └/u');
+});
+
+it('wraps long tree labels and keeps the guides aligned', function () {
+    Prompt::fake();
+
+    callout('Dependencies', [
+        Element::tree([
+            'vendor' => [
+                'This is a very long label that will definitely exceed the callout minimum width and wrap onto a second line',
+            ],
+            'composer.json',
+        ]),
+    ]);
+
+    $content = Prompt::strippedContent();
+
+    expect($content)->toContain('├─ vendor');
+    expect($content)->toContain('│  └─ This is a very long label');
+    expect($content)->toContain('└─ composer.json');
+
+    // The wrapped continuation keeps the vendor guide: "│" followed by five spaces.
+    expect($content)->toMatch('/│ {5}\S/u');
+});
+
 it('can fall back', function () {
     Prompt::fallbackWhen(true);
 

--- a/tests/Feature/TreeTest.php
+++ b/tests/Feature/TreeTest.php
@@ -35,6 +35,26 @@ it('auto-formats tree labels', function () {
     Prompt::assertOutputContains("\e[36m`composer install`");
 });
 
+it('wraps long labels at the terminal width and keeps the guides aligned', function () {
+    Prompt::fake();
+
+    tree([
+        'vendor' => [
+            'This is a very long dependency description that will definitely exceed the width of the fake terminal and wrap onto a second line',
+        ],
+        'composer.json',
+    ]);
+
+    $content = Prompt::strippedContent();
+
+    expect($content)->toContain('├─ vendor');
+    expect($content)->toContain('│  └─ This is a very long dependency description');
+    expect($content)->toContain('└─ composer.json');
+
+    // The wrapped continuation keeps the vendor guide: "│" followed by five spaces.
+    expect($content)->toMatch('/│ {5}\S/u');
+});
+
 it('renders nothing for an empty tree', function () {
     Prompt::fake();
 

--- a/tests/Feature/TreeTest.php
+++ b/tests/Feature/TreeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use Laravel\Prompts\Prompt;
+use Laravel\Prompts\Tree;
+
+use function Laravel\Prompts\tree;
+
+it('renders a tree', function () {
+    Prompt::fake();
+
+    tree([
+        'src' => [
+            'Elements' => ['Element.php', 'Tree.php'],
+            'helpers.php',
+        ],
+        'README.md',
+    ]);
+
+    Prompt::assertStrippedOutputContains('├─ src');
+    Prompt::assertStrippedOutputContains('│  ├─ Elements');
+    Prompt::assertStrippedOutputContains('│  │  ├─ Element.php');
+    Prompt::assertStrippedOutputContains('│  │  └─ Tree.php');
+    Prompt::assertStrippedOutputContains('│  └─ helpers.php');
+    Prompt::assertStrippedOutputContains('└─ README.md');
+});
+
+it('auto-formats tree labels', function () {
+    Prompt::fake();
+
+    tree([
+        'Run `composer install`',
+    ]);
+
+    Prompt::assertStrippedOutputContains('└─ Run `composer install`');
+    Prompt::assertOutputContains("\e[36m`composer install`");
+});
+
+it('renders nothing for an empty tree', function () {
+    Prompt::fake();
+
+    tree([]);
+
+    expect(trim(Prompt::strippedContent()))->toBe('');
+});
+
+it('can fall back', function () {
+    Prompt::fallbackWhen(true);
+
+    Tree::fallbackUsing(function (Tree $tree) {
+        expect($tree->items)->toBe(['README.md']);
+
+        return true;
+    });
+
+    $result = (new Tree(['README.md']))->display();
+
+    expect($result)->toBeNull();
+});


### PR DESCRIPTION
## Overview

The Elements system (headings, lists, key-value lists, links) has no primitive for hierarchy, so commands that want to show a directory structure or a dependency tree fall back to manually indented strings. This adds a `Tree` element that completes the set of static display building blocks.

## Solution

`Element::tree()` renders a nested hierarchy inside `callout()`, and a standalone `tree()` helper renders the same output outside of one. Both paths share a `DrawsTrees` concern, so the dimmed connectors, vertical guides, label wrapping, and backtick auto-formatting behave identically. String keys with array values become parent nodes, plain string values become leaves, and a string key with a string value renders a parent with a single child.

## Examples

```php
use function Laravel\Prompts\tree;

tree([
    'app' => [
        'Models' => ['User.php', 'Order.php'],
        'Providers' => ['AppServiceProvider.php'],
    ],
    'composer.json',
]);
```

```php
use Laravel\Prompts\Elements\Element;

callout('Application Scaffolded', [
    'The following files were created for you:',
    Element::tree([
        'app' => [
            'Models' => ['Podcast.php'],
        ],
    ]),
]);
```

## Screenshots

**Standalone `tree()` — directory structure and dependency tree**

<img width="687" height="647" alt="tree-1" src="https://github.com/user-attachments/assets/57ee5e14-90c7-4b0b-9aaa-a10d7535167a" />

**Trees inside callouts — default, warning, and error types**

<img width="1156" height="1453" alt="tree-2" src="https://github.com/user-attachments/assets/a3b76d16-a30f-4e4c-a288-bf2e216e3a38" />

**Edge cases — deep nesting, single-child shorthand, backtick formatting, label wrapping**

<img width="1162" height="1144" alt="tree-3" src="https://github.com/user-attachments/assets/4b1c1fed-9754-448d-a58b-ea22b48e2fd9" />