### PR TITLE
Fix missing corners on header-less tables and grids

### DIFF
--- a/src/Themes/Default/GridRenderer.php
+++ b/src/Themes/Default/GridRenderer.php
@@ -34,9 +34,6 @@ class GridRenderer extends Renderer
             ->setHorizontalBorderChars('─')
             ->setVerticalBorderChars('│', '│')
             ->setCellRowFormat('<fg=default>%s</>')
-            // A grid is always header-less. symfony/console 8.1.2 and above draws its
-            // first separator with the "top" crossings, earlier versions use the
-            // "top bottom" ones, so the corners are given to both...
             ->setCrossingChars('┼', '┌', '┬', '┐', '┤', '┘', '┴', '└', '├', '┌', '┬', '┐');
 
         $buffered = new BufferedConsoleOutput;

--- a/src/Themes/Default/GridRenderer.php
+++ b/src/Themes/Default/GridRenderer.php
@@ -34,7 +34,10 @@ class GridRenderer extends Renderer
             ->setHorizontalBorderChars('─')
             ->setVerticalBorderChars('│', '│')
             ->setCellRowFormat('<fg=default>%s</>')
-            ->setCrossingChars('┼', '', '', '', '┤', '┘', '┴', '└', '├', '┌', '┬', '┐');
+            // A grid is always header-less. symfony/console 8.1.2 and above draws its
+            // first separator with the "top" crossings, earlier versions use the
+            // "top bottom" ones, so the corners are given to both...
+            ->setCrossingChars('┼', '┌', '┬', '┐', '┤', '┘', '┴', '└', '├', '┌', '┬', '┐');
 
         $buffered = new BufferedConsoleOutput;
 

--- a/src/Themes/Default/TableRenderer.php
+++ b/src/Themes/Default/TableRenderer.php
@@ -21,7 +21,10 @@ class TableRenderer extends Renderer
             ->setCellRowFormat('<fg=default>%s</>');
 
         if (empty($table->headers)) {
-            $tableStyle->setCrossingChars('┼', '', '', '', '┤', '┘</>', '┴', '└', '├', '<fg=gray>┌', '┬', '┐');
+            // A header-less table draws its first separator with the "top" crossings on
+            // symfony/console 8.1.2 and above, and with the "top bottom" ones before
+            // that, so the corners are given to both to render the same either way...
+            $tableStyle->setCrossingChars('┼', '<fg=gray>┌', '┬', '┐', '┤', '┘</>', '┴', '└', '├', '<fg=gray>┌', '┬', '┐');
         } else {
             $tableStyle->setCrossingChars('┼', '<fg=gray>┌', '┬', '┐', '┤', '┘</>', '┴', '└', '├');
         }

--- a/src/Themes/Default/TableRenderer.php
+++ b/src/Themes/Default/TableRenderer.php
@@ -21,9 +21,6 @@ class TableRenderer extends Renderer
             ->setCellRowFormat('<fg=default>%s</>');
 
         if (empty($table->headers)) {
-            // A header-less table draws its first separator with the "top" crossings on
-            // symfony/console 8.1.2 and above, and with the "top bottom" ones before
-            // that, so the corners are given to both to render the same either way...
             $tableStyle->setCrossingChars('┼', '<fg=gray>┌', '┬', '┐', '┤', '┘</>', '┴', '└', '├', '<fg=gray>┌', '┬', '┐');
         } else {
             $tableStyle->setCrossingChars('┼', '<fg=gray>┌', '┬', '┐', '┤', '┘</>', '┴', '└', '├');


### PR DESCRIPTION
`main` is currently failing. Four tests in `GridTest` and `TableTest` no longer find the box drawing corners they assert on, and a header-less table renders like this instead:

```
 ──────────────
 │ item1 │ item2 │
```

The cause is outside this repository. symfony/console v8.1.2 (released 27 July) picked up symfony/symfony#64843, "Fix table borders around colspan cells and header-less tables", which changed the first separator of a header-less table to be drawn with the *top* crossing characters rather than the *top bottom* ones:

```php
$horizontal || !array_filter($this->headers) ? self::SEPARATOR_TOP : self::SEPARATOR_TOP_BOTTOM,
```

The default theme passes empty strings for the top crossings and supplies the corners only in the top bottom slots, which is why they vanish on the new version:

```php
$tableStyle->setCrossingChars('┼', '', '', '', '┤', '┘</>', '┴', '└', '├', '<fg=gray>┌', '┬', '┐');
//                                 ↑   ↑   ↑  top left / mid / right
```

This gives the corners to both sets, so the same border is drawn whichever separator symfony/console picks. Nothing else about the styling changes, and the header-ed branch is untouched.

Verified against the whole supported range — the suite passes on symfony/console v8.1.2 (the version that breaks `main`), v8.1.1, and v7.4.15: 342 passed, 1692 assertions. `phpstan` is clean.
