### PR TITLE
Truncate grid items that are wider than the grid

### DIFF
--- a/src/Themes/Default/GridRenderer.php
+++ b/src/Themes/Default/GridRenderer.php
@@ -23,12 +23,19 @@ class GridRenderer extends Renderer
             return $this;
         }
 
-        $maxWidth = $grid->maxWidth - 2;
-        $cellWidth = max(array_map(fn ($item) => mb_strwidth($this->stripEscapeSequences($item)), $grid->items)) + 4;
-        $maxColumns = max(1, (int) floor(($maxWidth - 1) / ($cellWidth + 1)));
-        $columnCount = max(1, $this->balancedColumnCount(count($grid->items), $maxColumns));
+        // An item wider than a single column would push the border past the grid's
+        // width, so items are truncated to what one column can hold...
+        $items = array_map(
+            fn ($item) => $this->truncate($item, max(1, $grid->maxWidth - 5)),
+            $grid->items
+        );
 
-        $rows = $this->buildRowsWithSeparators($grid->items, $columnCount);
+        $maxWidth = $grid->maxWidth - 2;
+        $cellWidth = max(array_map(fn ($item) => mb_strwidth($this->stripEscapeSequences($item)), $items)) + 4;
+        $maxColumns = max(1, (int) floor(($maxWidth - 1) / ($cellWidth + 1)));
+        $columnCount = max(1, $this->balancedColumnCount(count($items), $maxColumns));
+
+        $rows = $this->buildRowsWithSeparators($items, $columnCount);
 
         $tableStyle = (new TableStyle)
             ->setHorizontalBorderChars('─')

--- a/src/Themes/Default/GridRenderer.php
+++ b/src/Themes/Default/GridRenderer.php
@@ -23,8 +23,6 @@ class GridRenderer extends Renderer
             return $this;
         }
 
-        // An item wider than a single column would push the border past the grid's
-        // width, so items are truncated to what one column can hold...
         $items = array_map(
             fn ($item) => $this->truncate($item, max(1, $grid->maxWidth - 5)),
             $grid->items

--- a/tests/Feature/GridTest.php
+++ b/tests/Feature/GridTest.php
@@ -212,3 +212,25 @@ it('renders a complete grid with multiple rows and balanced columns', function (
     Prompt::assertStrippedOutputContains('│ using-fluxui                 │ using-folio-routing  │ using-tailwindcss │');
     Prompt::assertStrippedOutputContains('└──────────────────────────────┴──────────────────────┴───────────────────┘');
 });
+
+it('truncates items that are wider than the grid', function (): void {
+    Prompt::fake();
+
+    (new Grid([str_repeat('a', 200)], maxWidth: 80))->display();
+
+    $widest = collect(explode(PHP_EOL, Prompt::strippedContent()))
+        ->map(fn (string $line) => mb_strwidth(rtrim($line)))
+        ->max();
+
+    expect($widest)->toBeLessThanOrEqual(80);
+    Prompt::assertStrippedOutputContains('…');
+});
+
+it('leaves items that already fit untouched', function (): void {
+    Prompt::fake();
+
+    (new Grid(['item1', 'item2'], maxWidth: 80))->display();
+
+    Prompt::assertStrippedOutputContains('│ item1 │ item2 │');
+    Prompt::assertStrippedOutputDoesntContain('…');
+});


### PR DESCRIPTION
`Grid` sizes its columns from its widest item, but never limits how wide an item may be. An item wider than the grid pushes the border past `maxWidth`:

```php
(new Grid([str_repeat('a', 200)], maxWidth: 80))->display();
```

renders 205 columns wide, so the border wraps and the layout breaks in a terminal that narrow.

Every other renderer already truncates what it draws — `DataTableRenderer` truncates its row content, and `AutoCompletePromptRenderer` truncates labels, values and errors — all through the `Truncation` concern that `Renderer` already brings in. `GridRenderer` extends the same base class and simply never calls it.

This truncates items to what a single column can hold, so the grid stays within `maxWidth` at any size:

```
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │ qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq… │
 └─────────────────────────────────────────────────────────────────────────────┘
```

Items that already fit are untouched, so existing grids render exactly as before.

Verified at `maxWidth` 80, 40 and 20, with one long item and with a long item mixed among short ones: the widest rendered line now matches `maxWidth` in every case. Two tests added; the suite passes (344 tests) and `phpstan` is clean.
