### PR TITLE
Preserve original signal handlers in Task and Spinner, fixes #263

### DIFF
--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -53,7 +53,6 @@ class Spinner extends Prompt
 
         $originalAsync = pcntl_async_signals(true);
         $originalSignalHandler = pcntl_signal_get_handler(SIGINT);
-        assert(is_int($originalSignalHandler) || is_callable($originalSignalHandler));
 
         pcntl_signal(SIGINT, fn () => exit());
 

--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -52,6 +52,8 @@ class Spinner extends Prompt
         }
 
         $originalAsync = pcntl_async_signals(true);
+        $originalSignalHandler = pcntl_signal_get_handler(SIGINT);
+        assert(is_int($originalSignalHandler) || is_callable($originalSignalHandler));
 
         pcntl_signal(SIGINT, fn () => exit());
 
@@ -72,12 +74,12 @@ class Spinner extends Prompt
             } else {
                 $result = $callback();
 
-                $this->resetTerminal($originalAsync);
+                $this->resetTerminal($originalAsync, $originalSignalHandler);
 
                 return $result;
             }
         } catch (\Throwable $e) {
-            $this->resetTerminal($originalAsync);
+            $this->resetTerminal($originalAsync, $originalSignalHandler);
 
             throw $e;
         }
@@ -86,10 +88,10 @@ class Spinner extends Prompt
     /**
      * Reset the terminal.
      */
-    protected function resetTerminal(bool $originalAsync): void
+    protected function resetTerminal(bool $originalAsync, callable|int $originalSignalHandler = SIG_DFL): void
     {
         pcntl_async_signals($originalAsync);
-        pcntl_signal(SIGINT, SIG_DFL);
+        pcntl_signal(SIGINT, $originalSignalHandler);
 
         $this->eraseRenderedLines();
     }

--- a/src/Task.php
+++ b/src/Task.php
@@ -115,7 +115,6 @@ class Task extends Prompt
 
         $originalAsync = pcntl_async_signals(true);
         $originalSignalHandler = pcntl_signal_get_handler(SIGINT);
-        assert(is_int($originalSignalHandler) || is_callable($originalSignalHandler));
 
         pcntl_signal(SIGINT, fn () => exit());
 

--- a/src/Task.php
+++ b/src/Task.php
@@ -114,6 +114,8 @@ class Task extends Prompt
         }
 
         $originalAsync = pcntl_async_signals(true);
+        $originalSignalHandler = pcntl_signal_get_handler(SIGINT);
+        assert(is_int($originalSignalHandler) || is_callable($originalSignalHandler));
 
         pcntl_signal(SIGINT, fn () => exit());
 
@@ -157,10 +159,13 @@ class Task extends Prompt
                     usleep($this->interval * 2000);
                 }
 
+                pcntl_async_signals($originalAsync);
+                pcntl_signal(SIGINT, $originalSignalHandler);
+
                 return $result;
             }
         } catch (\Throwable $e) {
-            $this->resetTerminal($originalAsync, success: false);
+            $this->resetTerminal($originalAsync, success: false, originalSignalHandler: $originalSignalHandler);
 
             throw $e;
         }
@@ -302,12 +307,12 @@ class Task extends Prompt
     /**
      * Reset the terminal.
      */
-    protected function resetTerminal(bool $originalAsync, bool $success = true): void
+    protected function resetTerminal(bool $originalAsync, bool $success = true, callable|int $originalSignalHandler = SIG_DFL): void
     {
         $this->finished = true;
 
         pcntl_async_signals($originalAsync);
-        pcntl_signal(SIGINT, SIG_DFL);
+        pcntl_signal(SIGINT, $originalSignalHandler);
 
         if ($this->socket !== null) {
             fclose($this->socket);

--- a/src/Task.php
+++ b/src/Task.php
@@ -125,6 +125,9 @@ class Task extends Prompt
             $sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
 
             if ($sockets === false) {
+                pcntl_async_signals($originalAsync);
+                pcntl_signal(SIGINT, $originalSignalHandler);
+
                 return $this->renderStatically($callback);
             }
 

--- a/tests/Feature/SpinnerTest.php
+++ b/tests/Feature/SpinnerTest.php
@@ -31,3 +31,19 @@ it('renders a spinner statically when output is not decorated', function () {
     expect($result)->toBe('done');
     expect($output->content())->toContain('Running...');
 });
+
+it('restores the previous signal handler', function () {
+    Prompt::fake();
+
+    $originalSignalHandler = pcntl_signal_get_handler(SIGINT);
+    $signalHandler = fn () => null;
+    pcntl_signal(SIGINT, $signalHandler);
+
+    try {
+        spin(fn () => 'done', 'Running...');
+
+        expect(pcntl_signal_get_handler(SIGINT))->toBe($signalHandler);
+    } finally {
+        pcntl_signal(SIGINT, $originalSignalHandler);
+    }
+});

--- a/tests/Feature/TaskTest.php
+++ b/tests/Feature/TaskTest.php
@@ -76,6 +76,25 @@ it('returns null when the callback does not return a value', function () {
     expect($result)->toBeNull();
 });
 
+it('restores the previous signal handler', function () {
+    Prompt::fake();
+
+    $originalSignalHandler = pcntl_signal_get_handler(SIGINT);
+    $signalHandler = fn () => null;
+    pcntl_signal(SIGINT, $signalHandler);
+
+    try {
+        task(
+            label: 'Running...',
+            callback: fn (Logger $logger) => null,
+        );
+
+        expect(pcntl_signal_get_handler(SIGINT))->toBe($signalHandler);
+    } finally {
+        pcntl_signal(SIGINT, $originalSignalHandler);
+    }
+});
+
 it('receives log lines into the ring buffer', function () {
     $task = new Task(label: 'Test', limit: 3);
 


### PR DESCRIPTION
Fixes #263 

- Store and restore the original signal handler for `SIGINT` in `Task` and `Spinner`.
- Updated the `resetTerminal` methods to accept and reset to the original signal handler.
- Added assertion to validate the original signal handler type.
- Enhanced tests to verify proper restoration of signal handlers.

