### PR TITLE
Prevent uncaught exception when restoring tty fails

### DIFF
--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -5,6 +5,7 @@ namespace Laravel\Prompts;
 use ReflectionClass;
 use RuntimeException;
 use Symfony\Component\Console\Terminal as SymfonyTerminal;
+use Throwable;
 
 class Terminal
 {
@@ -71,7 +72,11 @@ class Terminal
     public function restoreTty(): void
     {
         if (isset($this->initialTtyMode)) {
-            $this->exec("stty {$this->initialTtyMode}");
+            try {
+                $this->exec("stty {$this->initialTtyMode}");
+            } catch (Throwable $e) {
+                fwrite(STDERR, "{$e->getMessage()}\n");
+            }
 
             $this->initialTtyMode = null;
         }

--- a/tests/Feature/TerminalTest.php
+++ b/tests/Feature/TerminalTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Laravel\Prompts\Terminal;
+
+it('does not throw when restoring the tty fails', function () {
+    $terminal = new class extends Terminal
+    {
+        public function setInitialTtyMode(string $mode): void
+        {
+            $this->initialTtyMode = $mode;
+        }
+
+        protected function exec(string $command): string
+        {
+            throw new RuntimeException("stty: invalid argument '{$command}'");
+        }
+    };
+
+    $terminal->setInitialTtyMode('6902:3:4b00:5cb:4:ff:ff:7f:17:15:12:ff:3:1c:1a:19:11:13:16:f:1:0:14:ff');
+
+    $terminal->restoreTty();
+})->throwsNoExceptions();


### PR DESCRIPTION
Fixes #206

## Problem

`Terminal::setTty()` is called from `Prompt::prompt()` wrapped in a `try`/`catch` (added to handle environments where `stty` behaves unexpectedly, e.g. #63), and falls back gracefully when the `stty` call fails.

`Terminal::restoreTty()`, however, is called unconditionally from `Prompt::__destruct()` with no such guard. On Ubuntu 25.10 (and other distros shipping the rust-coreutils `stty`), the `-g` state captured by `setTty()` uses a format the same binary's restore path rejects, so `exec("stty {$this->initialTtyMode}")` throws a `RuntimeException`. Because this happens inside a destructor, the exception is fatal and crashes the whole process — including `laravel new` via `laravel/installer`, which shares this root cause (see the issue's own cross-references to laravel/installer#448 and #2080).

## Fix

Wrap the `exec()` call inside `restoreTty()` in a `try`/`catch`, mirroring the existing pattern used for `setTty()` in `Prompt::prompt()`. Restoring the tty is best-effort: if it fails, we write the error to `STDERR` once and continue, rather than letting the process crash on exit.

## Testing

Added `tests/Feature/TerminalTest.php`, which stubs `Terminal::exec()` to throw (simulating the rust-coreutils `stty` restore failure) and asserts `restoreTty()` does not throw.

**Note:** I was unable to run the test suite locally in this environment (no PHP runtime available). The test follows the existing Pest conventions used elsewhere in `tests/Feature/*Test.php`. Please run `vendor/bin/pest --filter=TerminalTest` in CI/review to confirm.