### PR TITLE
Fix incorrect rendering of nested fg-color tags in select() title (#189)

### DIFF
--- a/src/Themes/Default/Concerns/InteractsWithStrings.php
+++ b/src/Themes/Default/Concerns/InteractsWithStrings.php
@@ -41,7 +41,7 @@ trait InteractsWithStrings
         // Strip Symfony named style tags.
         $text = preg_replace("/<(info|comment|question|error)>(.*?)<\/\\1>/", '$2', $text);
 
-        // Strip Symfony inline style tags (applied repeatedly to unwrap nested tags).
+        // Strip Symfony inline style tags.
         do {
             $text = preg_replace("/<(?:(?:[fb]g|options)=[a-z,;]+)+>(.*?)<\/>/i", '$1', $text, -1, $count);
         } while ($count > 0);

--- a/src/Themes/Default/Concerns/InteractsWithStrings.php
+++ b/src/Themes/Default/Concerns/InteractsWithStrings.php
@@ -41,8 +41,12 @@ trait InteractsWithStrings
         // Strip Symfony named style tags.
         $text = preg_replace("/<(info|comment|question|error)>(.*?)<\/\\1>/", '$2', $text);
 
-        // Strip Symfony inline style tags.
-        return preg_replace("/<(?:(?:[fb]g|options)=[a-z,;]+)+>(.*?)<\/>/i", '$1', $text);
+        // Strip Symfony inline style tags (applied repeatedly to unwrap nested tags).
+        do {
+            $text = preg_replace("/<(?:(?:[fb]g|options)=[a-z,;]+)+>(.*?)<\/>/i", '$1', $text, -1, $count);
+        } while ($count > 0);
+
+        return $text;
     }
 
     /**

--- a/tests/Feature/StripEscapeSequencesTest.php
+++ b/tests/Feature/StripEscapeSequencesTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Laravel\Prompts\Themes\Default\Concerns\InteractsWithStrings;
+
+$instance = new class
+{
+    use InteractsWithStrings;
+
+    protected int $minWidth = 0;
+
+    public function strip(string $text): string
+    {
+        return $this->stripEscapeSequences($text);
+    }
+};
+
+it('strips a single Symfony inline style tag', function () use ($instance) {
+    $result = $instance->strip('<fg=green>Your action?</>');
+
+    expect($result)->toBe('Your action?');
+});
+
+it('strips nested Symfony inline style tags', function () use ($instance) {
+    $result = $instance->strip('<fg=green>Your action, <fg=yellow>UserName</>?</>');
+
+    expect($result)->toBe('Your action, UserName?');
+});
+
+it('strips deeply nested Symfony inline style tags', function () use ($instance) {
+    $result = $instance->strip('<fg=green>A<fg=yellow>B<fg=red>C</>D</>E</>');
+
+    expect($result)->toBe('ABCDE');
+});
+
+it('strips multiple sibling nested tags', function () use ($instance) {
+    $result = $instance->strip('<fg=green>Hello <fg=yellow>World</></> and <fg=red>Foo <fg=blue>Bar</></>');
+
+    expect($result)->toBe('Hello World and Foo Bar');
+});


### PR DESCRIPTION
## Summary

Fixes #189 — nested `<fg=...>` tags in a `select()` (or any prompt) title render incorrectly, e.g.:

```php
select("<fg=green>Your action, <fg=yellow>{$name}</>?</>", $options);
```

### Root cause

`InteractsWithStrings::stripEscapeSequences()` used a single, non-greedy `preg_replace` pass to strip Symfony inline style tags (`<fg=...>...</>`). With nested tags, the non-greedy `(.*?)` only matches up to the *first* `</>` it encounters — the closing tag of the innermost element — leaving the outer tag's literal markup (`<fg=green>` / trailing `</>`) behind in the string. That residual markup corrupts the title's computed display width, which throws off padding/centering in the rendered prompt.

### Fix

Apply the same regex repeatedly (using `preg_replace`'s match-count out-parameter as the loop condition) until no more inline style tags remain, so nested tags are unwrapped one level at a time regardless of nesting depth.

This mirrors the approach from a prior, abandoned attempt at this issue (#230), which was closed as "moving to fork" rather than rejected on technical grounds — re-implemented here with an added test.

## Test plan

- [x] Added `tests/Feature/StripEscapeSequencesTest.php` covering: a single inline style tag, one level of nesting (the exact case from #189), three levels of nesting, and multiple sibling nested tags in the same string.
- [ ] **Not run locally** — this environment has no `php` binary available, so the new/updated tests are unverified locally and rely on CI to validate. The regex behavior was traced by hand against `preg_replace`'s actual all-matches-per-call semantics to build the expected test assertions.

Fixes #189