### PR TITLE
Prevent uncaught exception when restoring tty fails

### DIFF
--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -5,6 +5,7 @@ namespace Laravel\Prompts;
 use ReflectionClass;
 use RuntimeException;
 use Symfony\Component\Console\Terminal as SymfonyTerminal;
+use Throwable;
 
 class Terminal
 {
@@ -71,7 +72,11 @@ class Terminal
     public function restoreTty(): void
     {
         if (isset($this->initialTtyMode)) {
-            $this->exec("stty {$this->initialTtyMode}");
+            try {
+                $this->exec("stty {$this->initialTtyMode}");
+            } catch (Throwable $e) {
+                fwrite(STDERR, "{$e->getMessage()}\n");
+            }
 
             $this->initialTtyMode = null;
         }

--- a/tests/Feature/TerminalTest.php
+++ b/tests/Feature/TerminalTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Laravel\Prompts\Terminal;
+
+it('does not throw when restoring the tty fails', function () {
+    $terminal = new class extends Terminal
+    {
+        public function setInitialTtyMode(string $mode): void
+        {
+            $this->initialTtyMode = $mode;
+        }
+
+        protected function exec(string $command): string
+        {
+            throw new RuntimeException("stty: invalid argument '{$command}'");
+        }
+    };
+
+    $terminal->setInitialTtyMode('6902:3:4b00:5cb:4:ff:ff:7f:17:15:12:ff:3:1c:1a:19:11:13:16:f:1:0:14:ff');
+
+    $terminal->restoreTty();
+})->throwsNoExceptions();


### PR DESCRIPTION
On Ubuntu 25.10 (and a few other recent distros/terminal setups reported in #206), `stty` started rejecting the tty mode string we captured earlier, throwing "stty: invalid argument". The problem is that `restoreTty()` runs from `Prompt::__destruct()`, and PHP turns any exception thrown inside a destructor into an uncaught fatal error, which crashes the whole script right as it's trying to clean up after a prompt.

I wrapped the `stty` restore call in `restoreTty()` in a try/catch so a failure there just gets written to STDERR instead of blowing up the process. The tty mode is still cleared either way, so we don't retry a broken restore on a future call.

I added a feature test that makes `exec()` throw (simulating the invalid-argument case) and asserts `restoreTty()` doesn't propagate anything. I ran it against the unfixed code first to confirm it fails there, then confirmed it passes with the fix, plus a few of the existing feature tests around it, all in a php:8.3-cli container.

Fixes #206
