### PR TITLE
Skip true color query on Windows to avoid stty error text (#262)

### DIFF
--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -141,6 +141,10 @@ class Terminal
      */
     public function supportsTrueColor(): bool
     {
+        if (PHP_OS_FAMILY === 'Windows') {
+            return false;
+        }
+
         return static::$trueColorSupport ??= in_array(getenv('COLORTERM'), ['truecolor', '24bit']);
     }
 

--- a/tests/Feature/TerminalTest.php
+++ b/tests/Feature/TerminalTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use Laravel\Prompts\Terminal;
+
+it('still detects true color support from COLORTERM on non-Windows platforms', function () {
+    $property = new ReflectionProperty(Terminal::class, 'trueColorSupport');
+    $property->setAccessible(true);
+    $property->setValue(null, null);
+
+    $previous = getenv('COLORTERM');
+    putenv('COLORTERM=truecolor');
+
+    try {
+        expect((new Terminal)->supportsTrueColor())->toBe(PHP_OS_FAMILY !== 'Windows');
+    } finally {
+        putenv($previous === false ? 'COLORTERM' : "COLORTERM={$previous}");
+        $property->setValue(null, null);
+    }
+});


### PR DESCRIPTION
Fixes #262

The Windows error text shows up because `Terminal::queryColors()` shells out to `stty -g < /dev/tty` unconditionally. Neither `stty` nor `/dev/tty` exist on Windows, so `shell_exec` writes the OS error ("The system cannot find the path specified.") straight to output before falling back to the default colors.

`queryColors()` is only reached through `supportsTrueColor()`, which some Windows terminals trigger by setting `COLORTERM=truecolor`/`24bit` even though they can't actually run the Unix TTY dance. This is the same class of platform check `Prompt::checkEnvironment()` already does at `src/Prompt.php:434`, so I mirrored it: `supportsTrueColor()` now returns `false` immediately on Windows, which skips `queryColors()` entirely and avoids the shell_exec call.

I couldn't exercise the actual Windows branch since this environment only runs Linux/PHP 8.4 (I used a disposable php:8.4-cli container to run the suite). I added a test that pins `supportsTrueColor()` to the existing COLORTERM behavior on non-Windows platforms, so at least the guard's non-Windows path is covered and regressions there would be caught. Ran `tests/Feature/TerminalTest.php` and `tests/Feature/StreamTest.php` (StreamTest exercises `supportsTrueColor`/color queries indirectly through `fadeOut`) plus phpstan against `src/Terminal.php` — all green. The Windows-specific behavior is verified by code inspection only, not by an automated test.
