### PR TITLE
Remove escape sequences cut in the middle by truncation

### DIFF
--- a/src/Concerns/Truncation.php
+++ b/src/Concerns/Truncation.php
@@ -7,6 +7,12 @@ use InvalidArgumentException;
 trait Truncation
 {
     /**
+     * Regular expression matching a single complete ANSI escape sequence:
+     * CSI, OSC, or a two-character escape.
+     */
+    private const ESCAPE_SEQUENCE_PATTERN = '/\e\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]|\e\][^\x07\x1b]*(?:\x07|\x1b\x5c)|\e[\x40-\x5a\x5c-\x5f]/';
+
+    /**
      * Truncate a value with an ellipsis if it exceeds the given width.
      */
     protected function truncate(string $string, int $width): string
@@ -15,6 +21,29 @@ trait Truncation
             throw new InvalidArgumentException("Width [{$width}] must be greater than zero.");
         }
 
-        return mb_strwidth($string) <= $width ? $string : (mb_strimwidth($string, 0, $width - 1).'…');
+        if (mb_strwidth($string) <= $width) {
+            return $string;
+        }
+
+        return $this->withoutTrailingIncompleteEscapeSequence(mb_strimwidth($string, 0, $width - 1).'…');
+    }
+
+    /**
+     * Remove any trailing escape sequence that was cut in the middle by truncation,
+     * as its remainder would otherwise be interpreted as formatting for subsequent output.
+     */
+    private function withoutTrailingIncompleteEscapeSequence(string $string): string
+    {
+        if (preg_match_all(self::ESCAPE_SEQUENCE_PATTERN, $string, $matches, PREG_OFFSET_CAPTURE) > 0) {
+            $lastCompleteSequence = end($matches[0]);
+
+            $searchFrom = $lastCompleteSequence[1] + strlen($lastCompleteSequence[0]);
+        } else {
+            $searchFrom = 0;
+        }
+
+        $incompletePosition = strpos($string, "\e", $searchFrom);
+
+        return $incompletePosition === false ? $string : substr($string, 0, $incompletePosition);
     }
 }

--- a/tests/TruncationTest.php
+++ b/tests/TruncationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Prompts\Concerns\Truncation;
+
+$truncate = new class
+{
+    use Truncation;
+
+    public function t(string $string, int $width): string
+    {
+        return $this->truncate($string, $width);
+    }
+};
+
+it('removes an escape sequence that was cut in the middle by truncation', function () use ($truncate): void {
+    $result = $truncate->t("\e[38;2;255;0;0m".str_repeat('a', 40), 12);
+
+    expect($result)->not->toContain("\e");
+});
+
+it('keeps complete escape sequences when the cut lands between them', function () use ($truncate): void {
+    $result = $truncate->t("\e[31mred\e[0m ".str_repeat('a', 30), 8);
+
+    expect($result)->toBe("\e[31mre…");
+});
+
+it('does not modify strings without escape sequences', function () use ($truncate): void {
+    expect($truncate->t(str_repeat('a', 30), 8))->toBe('aaaaaaa…');
+});


### PR DESCRIPTION
`mb_strimwidth()` counts escape-sequence bytes toward display width, so truncating a styled string can cut an ANSI sequence in half. The dangling remainder (for example a partial `ESC[38;2;255...`) is then emitted into the terminal and interpreted as formatting for whatever is rendered next, corrupting the surrounding output.

After truncating, this scans for complete escape sequences and removes any trailing `ESC` that no longer begins one, keeping complete sequences intact. Strings without escapes are untouched.

Added unit tests covering a cut inside an SGR sequence, a cut landing between complete sequences, and plain strings.