### PR TITLE
refactor: normalize internal newline handling to LF

### DIFF
--- a/src/Concerns/TypedValue.php
+++ b/src/Concerns/TypedValue.php
@@ -63,7 +63,7 @@ trait TypedValue
                     }
 
                     if ($allowNewLine) {
-                        $this->typedValue = mb_substr($this->typedValue, 0, $this->cursorPosition).PHP_EOL.mb_substr($this->typedValue, $this->cursorPosition);
+                        $this->typedValue = mb_substr($this->typedValue, 0, $this->cursorPosition)."\n".mb_substr($this->typedValue, $this->cursorPosition);
                         $this->cursorPosition++;
                     }
                 } elseif ($key === Key::BACKSPACE || $key === Key::CTRL_H) {
@@ -98,7 +98,7 @@ trait TypedValue
         $current = mb_substr($value, $cursorPosition, 1);
         $after = mb_substr($value, $cursorPosition + 1);
 
-        $cursor = mb_strlen($current) && $current !== PHP_EOL ? $current : ' ';
+        $cursor = mb_strlen($current) && $current !== "\n" ? $current : ' ';
 
         $spaceBefore = $maxWidth < 0 || $maxWidth === null ? mb_strwidth($before) : $maxWidth - mb_strwidth($cursor) - (mb_strwidth($after) > 0 ? 1 : 0);
         [$truncatedBefore, $wasTruncatedBefore] = mb_strwidth($before) > $spaceBefore
@@ -113,7 +113,7 @@ trait TypedValue
         return ($wasTruncatedBefore ? $this->dim('…') : '')
             .$truncatedBefore
             .$this->inverse($cursor)
-            .($current === PHP_EOL ? PHP_EOL : '')
+            .($current === "\n" ? "\n" : '')
             .$truncatedAfter
             .($wasTruncatedAfter ? $this->dim('…') : '');
     }

--- a/src/Output/BufferedConsoleOutput.php
+++ b/src/Output/BufferedConsoleOutput.php
@@ -36,7 +36,7 @@ class BufferedConsoleOutput extends ConsoleOutput
         $this->buffer .= $message;
 
         if ($newline) {
-            $this->buffer .= \PHP_EOL;
+            $this->buffer .= "\n";
         }
     }
 

--- a/src/Output/ConsoleOutput.php
+++ b/src/Output/ConsoleOutput.php
@@ -27,7 +27,7 @@ class ConsoleOutput extends SymfonyConsoleOutput
         parent::doWrite($message, $newline);
 
         if ($newline) {
-            $message .= \PHP_EOL;
+            $message .= "\n";
         }
 
         preg_match('/(?:\r?\n)*$/', $message, $matches);

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -297,13 +297,13 @@ abstract class Prompt
         }
 
         $terminalHeight = $this->terminal()->lines();
-        $previousFrameHeight = count(explode(PHP_EOL, $this->prevFrame));
-        $renderableLines = array_slice(explode(PHP_EOL, $frame), abs(min(0, $terminalHeight - $previousFrameHeight)));
+        $previousFrameHeight = count(explode("\n", $this->prevFrame));
+        $renderableLines = array_slice(explode("\n", $frame), abs(min(0, $terminalHeight - $previousFrameHeight)));
 
         $this->moveCursorToColumn(1);
         $this->moveCursorUp(min($terminalHeight, $previousFrameHeight) - 1);
         $this->eraseDown();
-        $this->output()->write(implode(PHP_EOL, $renderableLines));
+        $this->output()->write(implode("\n", $renderableLines));
 
         $this->prevFrame = $frame;
     }

--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -142,7 +142,7 @@ class Spinner extends Prompt
      */
     protected function eraseRenderedLines(): void
     {
-        $lines = explode(PHP_EOL, $this->prevFrame);
+        $lines = explode("\n", $this->prevFrame);
         $this->moveCursor(-999, -count($lines) + 1);
         $this->eraseDown();
     }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -65,7 +65,7 @@ class Stream extends Prompt
             $toFadeIn[] = $this->fadingOutColors[$index]($message);
         }
 
-        $lines = explode(PHP_EOL, $this->message.implode('', $toFadeIn));
+        $lines = explode("\n", $this->message.implode('', $toFadeIn));
         $finalLines = [];
 
         foreach ($lines as $line) {

--- a/src/Support/Logger.php
+++ b/src/Support/Logger.php
@@ -95,9 +95,9 @@ class Logger
         }
 
         if ($type !== null) {
-            fwrite($this->socket, $this->prefix($type, $message).PHP_EOL);
+            fwrite($this->socket, $this->prefix($type, $message)."\n");
         } else {
-            fwrite($this->socket, $message.PHP_EOL);
+            fwrite($this->socket, $message."\n");
         }
     }
 
@@ -106,6 +106,6 @@ class Logger
      */
     protected function prefix(string $type, string $message): string
     {
-        return $this->identifier.'_'.$type.':'.rtrim($message, PHP_EOL);
+        return $this->identifier.'_'.$type.':'.rtrim($message, "\n");
     }
 }

--- a/src/Task.php
+++ b/src/Task.php
@@ -157,7 +157,7 @@ class Task extends Prompt
 
                 if ($this->socket !== null) {
                     // Send a reset message to the parent process to reset the terminal.
-                    fwrite($this->socket, $this->identifier.'_'.'reset:'.($originalAsync ? 1 : 0).PHP_EOL);
+                    fwrite($this->socket, $this->identifier.'_'.'reset:'.($originalAsync ? 1 : 0)."\n");
                     usleep($this->interval * 2000);
                 }
 
@@ -184,13 +184,13 @@ class Task extends Prompt
 
         while (($data = fgets($socket)) !== false) {
             // Buffer incomplete lines from non-blocking reads.
-            if (! str_ends_with($data, PHP_EOL)) {
+            if (! str_ends_with($data, "\n")) {
                 $this->buffer .= $data;
 
                 continue;
             }
 
-            $line = rtrim($this->buffer.$data, PHP_EOL);
+            $line = rtrim($this->buffer.$data, "\n");
             $this->buffer = '';
 
             if ($line === '') {
@@ -398,7 +398,7 @@ class Task extends Prompt
      */
     protected function eraseRenderedLines(): void
     {
-        $lines = explode(PHP_EOL, $this->prevFrame);
+        $lines = explode("\n", $this->prevFrame);
         $this->moveCursor(-999, -count($lines) + 1);
         $this->eraseDown();
     }

--- a/src/TextareaPrompt.php
+++ b/src/TextareaPrompt.php
@@ -81,7 +81,7 @@ class TextareaPrompt extends Prompt
      */
     public function wrappedValue(): string
     {
-        return $this->mbWordwrap($this->value(), $this->width, PHP_EOL, true);
+        return $this->mbWordwrap($this->value(), $this->width, "\n", true);
     }
 
     /**
@@ -91,7 +91,7 @@ class TextareaPrompt extends Prompt
      */
     public function lines(): array
     {
-        return explode(PHP_EOL, $this->wrappedValue());
+        return explode("\n", $this->wrappedValue());
     }
 
     /**
@@ -105,7 +105,7 @@ class TextareaPrompt extends Prompt
 
         $withCursor = $this->valueWithCursor();
 
-        return array_slice(explode(PHP_EOL, $withCursor), $this->firstVisible, $this->scroll, preserve_keys: true);
+        return array_slice(explode("\n", $withCursor), $this->firstVisible, $this->scroll, preserve_keys: true);
     }
 
     /**
@@ -158,7 +158,7 @@ class TextareaPrompt extends Prompt
 
         if ($currentLineIndex === count($lines) - 1) {
             // They're already at the last line, jump them to the last position
-            $this->cursorPosition = mb_strlen(implode(PHP_EOL, $lines));
+            $this->cursorPosition = mb_strlen(implode("\n", $lines));
 
             return;
         }
@@ -241,10 +241,10 @@ class TextareaPrompt extends Prompt
      */
     protected function wrappedPlaceholderWithCursor(): string
     {
-        return implode(PHP_EOL, array_map(
+        return implode("\n", array_map(
             $this->dim(...),
-            explode(PHP_EOL, $this->addCursor(
-                $this->mbWordwrap($this->placeholder, $this->width, PHP_EOL, true),
+            explode("\n", $this->addCursor(
+                $this->mbWordwrap($this->placeholder, $this->width, "\n", true),
                 cursorPosition: 0,
             ))
         ));

--- a/src/Themes/Default/CalloutRenderer.php
+++ b/src/Themes/Default/CalloutRenderer.php
@@ -28,13 +28,13 @@ class CalloutRenderer extends Renderer
             $result = $this->resolvePart($part);
 
             if (is_array($result)) {
-                $sections[] = implode(PHP_EOL, $result);
+                $sections[] = implode("\n", $result);
             } else {
-                $sections[] = implode(PHP_EOL, $this->ansiWordwrap($result, $this->minWidth));
+                $sections[] = implode("\n", $this->ansiWordwrap($result, $this->minWidth));
             }
         }
 
-        $message = implode(PHP_EOL.PHP_EOL, $sections);
+        $message = implode("\n\n", $sections);
 
         return match ($prompt->type) {
             'error' => $this
@@ -107,7 +107,7 @@ class CalloutRenderer extends Renderer
                 }
             }
 
-            $finalLines[] = implode(PHP_EOL, $partLines);
+            $finalLines[] = implode("\n", $partLines);
         }
 
         return $finalLines;
@@ -143,7 +143,7 @@ class CalloutRenderer extends Renderer
                 }
             }
 
-            $finalLines[] = implode(PHP_EOL, $partLines);
+            $finalLines[] = implode("\n", $partLines);
         }
 
         return $finalLines;

--- a/src/Themes/Default/Concerns/DrawsBoxes.php
+++ b/src/Themes/Default/Concerns/DrawsBoxes.php
@@ -24,8 +24,8 @@ trait DrawsBoxes
     ): self {
         $this->minWidth = min($this->minWidth, Prompt::terminal()->cols() - 6);
 
-        $bodyLines = explode(PHP_EOL, $body);
-        $footerLines = array_filter(explode(PHP_EOL, $footer));
+        $bodyLines = explode("\n", $body);
+        $footerLines = array_filter(explode("\n", $footer));
 
         $width = $this->longest(array_merge($bodyLines, $footerLines, [$title]));
 

--- a/src/Themes/Default/DataTableRenderer.php
+++ b/src/Themes/Default/DataTableRenderer.php
@@ -261,7 +261,7 @@ class DataTableRenderer extends Renderer implements Scrolling
 
             foreach ($widths as $i => $w) {
                 $text = $row[$i] ?? '';
-                $subLines = explode(PHP_EOL, $text);
+                $subLines = explode("\n", $text);
                 $cellLines[$i] = $subLines;
                 $maxSubRows = max($maxSubRows, count($subLines));
             }
@@ -388,7 +388,7 @@ class DataTableRenderer extends Renderer implements Scrolling
         foreach ($allRows as $row) {
             foreach ($row as $i => $cell) {
                 $cellMax = 0;
-                foreach (explode(PHP_EOL, $cell) as $line) {
+                foreach (explode("\n", $cell) as $line) {
                     $cellMax = max($cellMax, mb_strwidth($line));
                 }
                 if ($cellMax > 0) {

--- a/src/Themes/Default/GridRenderer.php
+++ b/src/Themes/Default/GridRenderer.php
@@ -48,7 +48,7 @@ class GridRenderer extends Renderer
             ->setStyle($tableStyle)
             ->render();
 
-        foreach (explode(PHP_EOL, trim($buffered->content(), PHP_EOL)) as $line) {
+        foreach (explode("\n", trim($buffered->content(), "\n")) as $line) {
             $this->line(' '.$line);
         }
 

--- a/src/Themes/Default/MultiSearchPromptRenderer.php
+++ b/src/Themes/Default/MultiSearchPromptRenderer.php
@@ -109,7 +109,7 @@ class MultiSearchPromptRenderer extends Renderer implements Scrolling
             return $this->gray('  '.($prompt->state === 'searching' ? 'Searching...' : 'No results.'));
         }
 
-        return implode(PHP_EOL, $this->scrollbar(
+        return implode("\n", $this->scrollbar(
             array_map(function ($label, $key) use ($prompt) {
                 $label = $this->truncate($label, $prompt->terminal()->cols() - 12);
 

--- a/src/Themes/Default/MultiSelectPromptRenderer.php
+++ b/src/Themes/Default/MultiSelectPromptRenderer.php
@@ -58,7 +58,7 @@ class MultiSelectPromptRenderer extends Renderer implements Scrolling
      */
     protected function renderOptions(MultiSelectPrompt $prompt): string
     {
-        return implode(PHP_EOL, $this->scrollbar(
+        return implode("\n", $this->scrollbar(
             array_values(array_map(function ($label, $key) use ($prompt) {
                 $label = $this->truncate($label, $prompt->terminal()->cols() - 12);
 

--- a/src/Themes/Default/NoteRenderer.php
+++ b/src/Themes/Default/NoteRenderer.php
@@ -11,7 +11,7 @@ class NoteRenderer extends Renderer
      */
     public function __invoke(Note $note): string
     {
-        $lines = explode(PHP_EOL, $note->message);
+        $lines = explode("\n", $note->message);
 
         switch ($note->type) {
             case 'intro':

--- a/src/Themes/Default/PausePromptRenderer.php
+++ b/src/Themes/Default/PausePromptRenderer.php
@@ -13,7 +13,7 @@ class PausePromptRenderer extends Renderer
      */
     public function __invoke(PausePrompt $prompt): string
     {
-        $lines = explode(PHP_EOL, $prompt->message);
+        $lines = explode("\n", $prompt->message);
 
         $color = $prompt->state === 'submit' ? 'green' : 'gray';
 

--- a/src/Themes/Default/Renderer.php
+++ b/src/Themes/Default/Renderer.php
@@ -29,7 +29,7 @@ abstract class Renderer
      */
     protected function line(string $message): self
     {
-        $this->output .= $message.PHP_EOL;
+        $this->output .= $message."\n";
 
         return $this;
     }
@@ -39,7 +39,7 @@ abstract class Renderer
      */
     protected function newLine(int $count = 1): self
     {
-        $this->output .= str_repeat(PHP_EOL, $count);
+        $this->output .= str_repeat("\n", $count);
 
         return $this;
     }
@@ -95,8 +95,8 @@ abstract class Renderer
      */
     public function __toString()
     {
-        return str_repeat(PHP_EOL, max(2 - $this->prompt->newLinesWritten(), 0))
+        return str_repeat("\n", max(2 - $this->prompt->newLinesWritten(), 0))
             .$this->output
-            .(in_array($this->prompt->state, ['submit', 'cancel']) ? PHP_EOL : '');
+            .(in_array($this->prompt->state, ['submit', 'cancel']) ? "\n" : '');
     }
 }

--- a/src/Themes/Default/SearchPromptRenderer.php
+++ b/src/Themes/Default/SearchPromptRenderer.php
@@ -108,7 +108,7 @@ class SearchPromptRenderer extends Renderer implements Scrolling
             return $this->gray('  '.($prompt->state === 'searching' ? 'Searching...' : 'No results.'));
         }
 
-        return implode(PHP_EOL, $this->scrollbar(
+        return implode("\n", $this->scrollbar(
             array_values(array_map(function ($label, $key) use ($prompt) {
                 $label = $this->truncate($label, $prompt->terminal()->cols() - 10);
 

--- a/src/Themes/Default/SelectPromptRenderer.php
+++ b/src/Themes/Default/SelectPromptRenderer.php
@@ -59,7 +59,7 @@ class SelectPromptRenderer extends Renderer implements Scrolling
      */
     protected function renderOptions(SelectPrompt $prompt): string
     {
-        return implode(PHP_EOL, $this->scrollbar(
+        return implode("\n", $this->scrollbar(
             array_values(array_map(function ($label, $key) use ($prompt) {
                 $label = $this->truncate($label, $prompt->terminal()->cols() - 12);
 

--- a/src/Themes/Default/SuggestPromptRenderer.php
+++ b/src/Themes/Default/SuggestPromptRenderer.php
@@ -98,7 +98,7 @@ class SuggestPromptRenderer extends Renderer implements Scrolling
             return '';
         }
 
-        return implode(PHP_EOL, $this->scrollbar(
+        return implode("\n", $this->scrollbar(
             array_map(function ($label, $key) use ($prompt) {
                 $label = $this->truncate($label, $prompt->terminal()->cols() - 12);
 

--- a/src/Themes/Default/TableRenderer.php
+++ b/src/Themes/Default/TableRenderer.php
@@ -34,7 +34,7 @@ class TableRenderer extends Renderer
             ->setStyle($tableStyle)
             ->render();
 
-        foreach (explode(PHP_EOL, trim($buffered->content(), PHP_EOL)) as $line) {
+        foreach (explode("\n", trim($buffered->content(), "\n")) as $line) {
             $this->line(' '.$line);
         }
 

--- a/src/Themes/Default/TextareaPromptRenderer.php
+++ b/src/Themes/Default/TextareaPromptRenderer.php
@@ -21,13 +21,13 @@ class TextareaPromptRenderer extends Renderer implements Scrolling
             'submit' => $this
                 ->box(
                     $this->dim($this->truncate($prompt->label, $prompt->width)),
-                    implode(PHP_EOL, $prompt->lines()),
+                    implode("\n", $prompt->lines()),
                 ),
 
             'cancel' => $this
                 ->box(
                     $this->truncate($prompt->label, $prompt->width),
-                    implode(PHP_EOL, array_map(fn ($line) => $this->strikethrough($this->dim($line)), $prompt->lines())),
+                    implode("\n", array_map(fn ($line) => $this->strikethrough($this->dim($line)), $prompt->lines())),
                     color: 'red',
                 )
                 ->error($prompt->cancelMessage),
@@ -68,7 +68,7 @@ class TextareaPromptRenderer extends Renderer implements Scrolling
 
         $longest = $this->longest($prompt->lines()) + 2;
 
-        return implode(PHP_EOL, $this->scrollbar(
+        return implode("\n", $this->scrollbar(
             $visible,
             $prompt->firstVisible,
             $prompt->scroll,


### PR DESCRIPTION
**TL;DR:** This PR normalizes all internal newline handling in laravel/prompts to a literal `"\n"`, replacing every internal use of `PHP_EOL` in frame and string assembly. It is purely mechanical: on Unix/macOS, where `PHP_EOL === "\n"`, behavior is identical and the full test suite passes unchanged. It also fixes a class of real Windows bugs that currently affect users even on the degraded Symfony fallback path, and serves as the prerequisite cleanup for a native Windows driver that will be stacked on this branch.

## Why

Prompts builds frames, diffs previous frames and splits textarea values using literal `\n`, but parses those same strings with `explode(PHP_EOL, ...)`. On Unix and macOS the two coincide, so the mismatch is invisible. On Windows `PHP_EOL` is `"\r\n"`, so every such `explode()` finds no separators and every derived count collapses to 1. Concretely, Windows users on the fallback path currently hit:

- Broken frame height accounting: `prevFrame` explodes to a single line, so cursor-up counts drift and repaints erase the wrong amount.
- `Spinner`, `Stream` and `Task` `prevFrame` diffing never matches, causing constant full repaints and visible ghosting.
- Textareas cannot split a value containing `"\n"` into rows (wordwrap breakpoints, row splitting and cursor math disagree), so text escapes the box borders.
- Theme renderer joins for MultiSelect/MultiSearch produce text at the wrong position (the reported "Beta at column 0" symptom).

Normalizing the internal separator removes the mismatch at the source instead of patching each site per-platform, and gives the follow-up Windows work a stable base.

## What changes

One mechanical substitution, applied to internal frame/string assembly only:

- Frame height math in `Prompt` (`explode`/`implode` around `prevFrame` and the renderable lines).
- `Spinner`, `Task` and `Stream` `prevFrame` diffing.
- `TextareaPrompt` wordwrap, row splitting and cursor math.
- `TypedValue` newline insertion.
- Default theme renderer joins for `MultiSelectPromptRenderer` and `MultiSearchPromptRenderer`.

No public API changes, no output format changes, no key-handling changes. Internal strings now always use `"\n"` regardless of platform, so `explode()`/`implode()` round-trips stay consistent everywhere.

## Validation

- Full test suite passes unchanged; on Unix/macOS this is a no-op by construction, since `PHP_EOL === "\n"` there.
- On Windows 11 (Symfony fallback path): multi-line textarea values stay inside their borders, spinner/task/stream repaints stop ghosting and erase the correct number of lines, and multiselect/multisearch options render at the intended column instead of column 0.

## Reviewer note

Kept deliberately small and reviewable: it touches several files, but each hunk is a separator swap. This branch is also the base for a stacked native-Windows-input PR, so early sign-off here unblocks that work. **This opens as a draft pending discussion with maintainers - please share feedback (here or in the tracking issue) before it is marked ready.**
