### PR TITLE
feat: native Windows terminal support

### DIFF
--- a/src/Concerns/TypedValue.php
+++ b/src/Concerns/TypedValue.php
@@ -63,7 +63,7 @@ trait TypedValue
                     }
 
                     if ($allowNewLine) {
-                        $this->typedValue = mb_substr($this->typedValue, 0, $this->cursorPosition).PHP_EOL.mb_substr($this->typedValue, $this->cursorPosition);
+                        $this->typedValue = mb_substr($this->typedValue, 0, $this->cursorPosition)."\n".mb_substr($this->typedValue, $this->cursorPosition);
                         $this->cursorPosition++;
                     }
                 } elseif ($key === Key::BACKSPACE || $key === Key::CTRL_H) {
@@ -98,7 +98,7 @@ trait TypedValue
         $current = mb_substr($value, $cursorPosition, 1);
         $after = mb_substr($value, $cursorPosition + 1);
 
-        $cursor = mb_strlen($current) && $current !== PHP_EOL ? $current : ' ';
+        $cursor = mb_strlen($current) && $current !== "\n" ? $current : ' ';
 
         $spaceBefore = $maxWidth < 0 || $maxWidth === null ? mb_strwidth($before) : $maxWidth - mb_strwidth($cursor) - (mb_strwidth($after) > 0 ? 1 : 0);
         [$truncatedBefore, $wasTruncatedBefore] = mb_strwidth($before) > $spaceBefore
@@ -113,7 +113,7 @@ trait TypedValue
         return ($wasTruncatedBefore ? $this->dim('…') : '')
             .$truncatedBefore
             .$this->inverse($cursor)
-            .($current === PHP_EOL ? PHP_EOL : '')
+            .($current === "\n" ? "\n" : '')
             .$truncatedAfter
             .($wasTruncatedAfter ? $this->dim('…') : '');
     }

--- a/src/Output/BufferedConsoleOutput.php
+++ b/src/Output/BufferedConsoleOutput.php
@@ -36,7 +36,7 @@ class BufferedConsoleOutput extends ConsoleOutput
         $this->buffer .= $message;
 
         if ($newline) {
-            $this->buffer .= \PHP_EOL;
+            $this->buffer .= "\n";
         }
     }
 

--- a/src/Output/ConsoleOutput.php
+++ b/src/Output/ConsoleOutput.php
@@ -27,7 +27,7 @@ class ConsoleOutput extends SymfonyConsoleOutput
         parent::doWrite($message, $newline);
 
         if ($newline) {
-            $message .= \PHP_EOL;
+            $message .= "\n";
         }
 
         preg_match('/(?:\r?\n)*$/', $message, $matches);

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -297,13 +297,13 @@ abstract class Prompt
         }
 
         $terminalHeight = $this->terminal()->lines();
-        $previousFrameHeight = count(explode(PHP_EOL, $this->prevFrame));
-        $renderableLines = array_slice(explode(PHP_EOL, $frame), abs(min(0, $terminalHeight - $previousFrameHeight)));
+        $previousFrameHeight = count(explode("\n", $this->prevFrame));
+        $renderableLines = array_slice(explode("\n", $frame), abs(min(0, $terminalHeight - $previousFrameHeight)));
 
         $this->moveCursorToColumn(1);
         $this->moveCursorUp(min($terminalHeight, $previousFrameHeight) - 1);
         $this->eraseDown();
-        $this->output()->write(implode(PHP_EOL, $renderableLines));
+        $this->output()->write(implode("\n", $renderableLines));
 
         $this->prevFrame = $frame;
     }

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -114,8 +114,6 @@ abstract class Prompt
                 return $this->default();
             }
 
-            $this->checkEnvironment();
-
             try {
                 static::terminal()->setTty('-icanon -isig -echo');
             } catch (Throwable $e) {
@@ -424,16 +422,6 @@ abstract class Prompt
     protected function isInvalidWhenRequired(mixed $value): bool
     {
         return $value === '' || $value === [] || $value === false || $value === null;
-    }
-
-    /**
-     * Check whether the environment can support the prompt.
-     */
-    private function checkEnvironment(): void
-    {
-        if (PHP_OS_FAMILY === 'Windows') {
-            throw new RuntimeException('Prompts is not currently supported on Windows. Please use WSL or configure a fallback.');
-        }
     }
 
     /**

--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -142,7 +142,7 @@ class Spinner extends Prompt
      */
     protected function eraseRenderedLines(): void
     {
-        $lines = explode(PHP_EOL, $this->prevFrame);
+        $lines = explode("\n", $this->prevFrame);
         $this->moveCursor(-999, -count($lines) + 1);
         $this->eraseDown();
     }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -65,7 +65,7 @@ class Stream extends Prompt
             $toFadeIn[] = $this->fadingOutColors[$index]($message);
         }
 
-        $lines = explode(PHP_EOL, $this->message.implode('', $toFadeIn));
+        $lines = explode("\n", $this->message.implode('', $toFadeIn));
         $finalLines = [];
 
         foreach ($lines as $line) {

--- a/src/Support/Logger.php
+++ b/src/Support/Logger.php
@@ -95,9 +95,9 @@ class Logger
         }
 
         if ($type !== null) {
-            fwrite($this->socket, $this->prefix($type, $message).PHP_EOL);
+            fwrite($this->socket, $this->prefix($type, $message)."\n");
         } else {
-            fwrite($this->socket, $message.PHP_EOL);
+            fwrite($this->socket, $message."\n");
         }
     }
 
@@ -106,6 +106,6 @@ class Logger
      */
     protected function prefix(string $type, string $message): string
     {
-        return $this->identifier.'_'.$type.':'.rtrim($message, PHP_EOL);
+        return $this->identifier.'_'.$type.':'.rtrim($message, "\n");
     }
 }

--- a/src/Task.php
+++ b/src/Task.php
@@ -157,7 +157,7 @@ class Task extends Prompt
 
                 if ($this->socket !== null) {
                     // Send a reset message to the parent process to reset the terminal.
-                    fwrite($this->socket, $this->identifier.'_'.'reset:'.($originalAsync ? 1 : 0).PHP_EOL);
+                    fwrite($this->socket, $this->identifier.'_'.'reset:'.($originalAsync ? 1 : 0)."\n");
                     usleep($this->interval * 2000);
                 }
 
@@ -184,13 +184,13 @@ class Task extends Prompt
 
         while (($data = fgets($socket)) !== false) {
             // Buffer incomplete lines from non-blocking reads.
-            if (! str_ends_with($data, PHP_EOL)) {
+            if (! str_ends_with($data, "\n")) {
                 $this->buffer .= $data;
 
                 continue;
             }
 
-            $line = rtrim($this->buffer.$data, PHP_EOL);
+            $line = rtrim($this->buffer.$data, "\n");
             $this->buffer = '';
 
             if ($line === '') {
@@ -398,7 +398,7 @@ class Task extends Prompt
      */
     protected function eraseRenderedLines(): void
     {
-        $lines = explode(PHP_EOL, $this->prevFrame);
+        $lines = explode("\n", $this->prevFrame);
         $this->moveCursor(-999, -count($lines) + 1);
         $this->eraseDown();
     }

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -38,6 +38,11 @@ class Terminal
     protected SymfonyTerminal $terminal;
 
     /**
+     * The shared Windows console driver.
+     */
+    protected static ?WindowsConsole $windowsConsole = null;
+
+    /**
      * Create a new Terminal instance.
      */
     public function __construct()
@@ -47,9 +52,18 @@ class Terminal
 
     /**
      * Read a line from the terminal.
+     *
+     * On Windows the read is delegated to the console driver: fread(STDIN)
+     * returns an empty string immediately instead of blocking on a raw-mode
+     * Windows console, so keystrokes are read via msvcrt and translated
+     * into the sequences a Unix terminal would send.
      */
     public function read(): string
     {
+        if (PHP_OS_FAMILY === 'Windows') {
+            return static::windowsConsole()->read();
+        }
+
         $input = fread(STDIN, 1024);
 
         return $input !== false ? $input : '';
@@ -57,9 +71,21 @@ class Terminal
 
     /**
      * Set the TTY mode.
+     *
+     * On Windows there is no stty; the console driver switches the console
+     * into raw mode through kernel32 instead. A failed setup throws so the
+     * caller falls back exactly as it does when stty is unavailable.
      */
     public function setTty(string $mode): void
     {
+        if (PHP_OS_FAMILY === 'Windows') {
+            if (! static::windowsConsole()->enable()) {
+                throw new RuntimeException('Failed to enable raw input mode on the Windows console.');
+            }
+
+            return;
+        }
+
         $this->initialTtyMode ??= $this->exec('stty -g');
 
         $this->exec("stty $mode");
@@ -70,11 +96,25 @@ class Terminal
      */
     public function restoreTty(): void
     {
+        if (PHP_OS_FAMILY === 'Windows') {
+            static::windowsConsole()->restore();
+
+            return;
+        }
+
         if (isset($this->initialTtyMode)) {
             $this->exec("stty {$this->initialTtyMode}");
 
             $this->initialTtyMode = null;
         }
+    }
+
+    /**
+     * Get the shared Windows console driver instance.
+     */
+    protected static function windowsConsole(): WindowsConsole
+    {
+        return static::$windowsConsole ??= new WindowsConsole;
     }
 
     /**

--- a/src/TextareaPrompt.php
+++ b/src/TextareaPrompt.php
@@ -81,7 +81,7 @@ class TextareaPrompt extends Prompt
      */
     public function wrappedValue(): string
     {
-        return $this->mbWordwrap($this->value(), $this->width, PHP_EOL, true);
+        return $this->mbWordwrap($this->value(), $this->width, "\n", true);
     }
 
     /**
@@ -91,7 +91,7 @@ class TextareaPrompt extends Prompt
      */
     public function lines(): array
     {
-        return explode(PHP_EOL, $this->wrappedValue());
+        return explode("\n", $this->wrappedValue());
     }
 
     /**
@@ -105,7 +105,7 @@ class TextareaPrompt extends Prompt
 
         $withCursor = $this->valueWithCursor();
 
-        return array_slice(explode(PHP_EOL, $withCursor), $this->firstVisible, $this->scroll, preserve_keys: true);
+        return array_slice(explode("\n", $withCursor), $this->firstVisible, $this->scroll, preserve_keys: true);
     }
 
     /**
@@ -158,7 +158,7 @@ class TextareaPrompt extends Prompt
 
         if ($currentLineIndex === count($lines) - 1) {
             // They're already at the last line, jump them to the last position
-            $this->cursorPosition = mb_strlen(implode(PHP_EOL, $lines));
+            $this->cursorPosition = mb_strlen(implode("\n", $lines));
 
             return;
         }
@@ -241,10 +241,10 @@ class TextareaPrompt extends Prompt
      */
     protected function wrappedPlaceholderWithCursor(): string
     {
-        return implode(PHP_EOL, array_map(
+        return implode("\n", array_map(
             $this->dim(...),
-            explode(PHP_EOL, $this->addCursor(
-                $this->mbWordwrap($this->placeholder, $this->width, PHP_EOL, true),
+            explode("\n", $this->addCursor(
+                $this->mbWordwrap($this->placeholder, $this->width, "\n", true),
                 cursorPosition: 0,
             ))
         ));

--- a/src/Themes/Default/CalloutRenderer.php
+++ b/src/Themes/Default/CalloutRenderer.php
@@ -28,13 +28,13 @@ class CalloutRenderer extends Renderer
             $result = $this->resolvePart($part);
 
             if (is_array($result)) {
-                $sections[] = implode(PHP_EOL, $result);
+                $sections[] = implode("\n", $result);
             } else {
-                $sections[] = implode(PHP_EOL, $this->ansiWordwrap($result, $this->minWidth));
+                $sections[] = implode("\n", $this->ansiWordwrap($result, $this->minWidth));
             }
         }
 
-        $message = implode(PHP_EOL.PHP_EOL, $sections);
+        $message = implode("\n\n", $sections);
 
         return match ($prompt->type) {
             'error' => $this
@@ -107,7 +107,7 @@ class CalloutRenderer extends Renderer
                 }
             }
 
-            $finalLines[] = implode(PHP_EOL, $partLines);
+            $finalLines[] = implode("\n", $partLines);
         }
 
         return $finalLines;
@@ -143,7 +143,7 @@ class CalloutRenderer extends Renderer
                 }
             }
 
-            $finalLines[] = implode(PHP_EOL, $partLines);
+            $finalLines[] = implode("\n", $partLines);
         }
 
         return $finalLines;

--- a/src/Themes/Default/Concerns/DrawsBoxes.php
+++ b/src/Themes/Default/Concerns/DrawsBoxes.php
@@ -24,8 +24,8 @@ trait DrawsBoxes
     ): self {
         $this->minWidth = min($this->minWidth, Prompt::terminal()->cols() - 6);
 
-        $bodyLines = explode(PHP_EOL, $body);
-        $footerLines = array_filter(explode(PHP_EOL, $footer));
+        $bodyLines = explode("\n", $body);
+        $footerLines = array_filter(explode("\n", $footer));
 
         $width = $this->longest(array_merge($bodyLines, $footerLines, [$title]));
 

--- a/src/Themes/Default/DataTableRenderer.php
+++ b/src/Themes/Default/DataTableRenderer.php
@@ -261,7 +261,7 @@ class DataTableRenderer extends Renderer implements Scrolling
 
             foreach ($widths as $i => $w) {
                 $text = $row[$i] ?? '';
-                $subLines = explode(PHP_EOL, $text);
+                $subLines = explode("\n", $text);
                 $cellLines[$i] = $subLines;
                 $maxSubRows = max($maxSubRows, count($subLines));
             }
@@ -388,7 +388,7 @@ class DataTableRenderer extends Renderer implements Scrolling
         foreach ($allRows as $row) {
             foreach ($row as $i => $cell) {
                 $cellMax = 0;
-                foreach (explode(PHP_EOL, $cell) as $line) {
+                foreach (explode("\n", $cell) as $line) {
                     $cellMax = max($cellMax, mb_strwidth($line));
                 }
                 if ($cellMax > 0) {

--- a/src/Themes/Default/GridRenderer.php
+++ b/src/Themes/Default/GridRenderer.php
@@ -48,7 +48,7 @@ class GridRenderer extends Renderer
             ->setStyle($tableStyle)
             ->render();
 
-        foreach (explode(PHP_EOL, trim($buffered->content(), PHP_EOL)) as $line) {
+        foreach (explode("\n", trim($buffered->content(), "\n")) as $line) {
             $this->line(' '.$line);
         }
 

--- a/src/Themes/Default/MultiSearchPromptRenderer.php
+++ b/src/Themes/Default/MultiSearchPromptRenderer.php
@@ -109,7 +109,7 @@ class MultiSearchPromptRenderer extends Renderer implements Scrolling
             return $this->gray('  '.($prompt->state === 'searching' ? 'Searching...' : 'No results.'));
         }
 
-        return implode(PHP_EOL, $this->scrollbar(
+        return implode("\n", $this->scrollbar(
             array_map(function ($label, $key) use ($prompt) {
                 $label = $this->truncate($label, $prompt->terminal()->cols() - 12);
 

--- a/src/Themes/Default/MultiSelectPromptRenderer.php
+++ b/src/Themes/Default/MultiSelectPromptRenderer.php
@@ -58,7 +58,7 @@ class MultiSelectPromptRenderer extends Renderer implements Scrolling
      */
     protected function renderOptions(MultiSelectPrompt $prompt): string
     {
-        return implode(PHP_EOL, $this->scrollbar(
+        return implode("\n", $this->scrollbar(
             array_values(array_map(function ($label, $key) use ($prompt) {
                 $label = $this->truncate($label, $prompt->terminal()->cols() - 12);
 

--- a/src/Themes/Default/NoteRenderer.php
+++ b/src/Themes/Default/NoteRenderer.php
@@ -11,7 +11,7 @@ class NoteRenderer extends Renderer
      */
     public function __invoke(Note $note): string
     {
-        $lines = explode(PHP_EOL, $note->message);
+        $lines = explode("\n", $note->message);
 
         switch ($note->type) {
             case 'intro':

--- a/src/Themes/Default/PausePromptRenderer.php
+++ b/src/Themes/Default/PausePromptRenderer.php
@@ -13,7 +13,7 @@ class PausePromptRenderer extends Renderer
      */
     public function __invoke(PausePrompt $prompt): string
     {
-        $lines = explode(PHP_EOL, $prompt->message);
+        $lines = explode("\n", $prompt->message);
 
         $color = $prompt->state === 'submit' ? 'green' : 'gray';
 

--- a/src/Themes/Default/Renderer.php
+++ b/src/Themes/Default/Renderer.php
@@ -29,7 +29,7 @@ abstract class Renderer
      */
     protected function line(string $message): self
     {
-        $this->output .= $message.PHP_EOL;
+        $this->output .= $message."\n";
 
         return $this;
     }
@@ -39,7 +39,7 @@ abstract class Renderer
      */
     protected function newLine(int $count = 1): self
     {
-        $this->output .= str_repeat(PHP_EOL, $count);
+        $this->output .= str_repeat("\n", $count);
 
         return $this;
     }
@@ -95,8 +95,8 @@ abstract class Renderer
      */
     public function __toString()
     {
-        return str_repeat(PHP_EOL, max(2 - $this->prompt->newLinesWritten(), 0))
+        return str_repeat("\n", max(2 - $this->prompt->newLinesWritten(), 0))
             .$this->output
-            .(in_array($this->prompt->state, ['submit', 'cancel']) ? PHP_EOL : '');
+            .(in_array($this->prompt->state, ['submit', 'cancel']) ? "\n" : '');
     }
 }

--- a/src/Themes/Default/SearchPromptRenderer.php
+++ b/src/Themes/Default/SearchPromptRenderer.php
@@ -108,7 +108,7 @@ class SearchPromptRenderer extends Renderer implements Scrolling
             return $this->gray('  '.($prompt->state === 'searching' ? 'Searching...' : 'No results.'));
         }
 
-        return implode(PHP_EOL, $this->scrollbar(
+        return implode("\n", $this->scrollbar(
             array_values(array_map(function ($label, $key) use ($prompt) {
                 $label = $this->truncate($label, $prompt->terminal()->cols() - 10);
 

--- a/src/Themes/Default/SelectPromptRenderer.php
+++ b/src/Themes/Default/SelectPromptRenderer.php
@@ -59,7 +59,7 @@ class SelectPromptRenderer extends Renderer implements Scrolling
      */
     protected function renderOptions(SelectPrompt $prompt): string
     {
-        return implode(PHP_EOL, $this->scrollbar(
+        return implode("\n", $this->scrollbar(
             array_values(array_map(function ($label, $key) use ($prompt) {
                 $label = $this->truncate($label, $prompt->terminal()->cols() - 12);
 

--- a/src/Themes/Default/SuggestPromptRenderer.php
+++ b/src/Themes/Default/SuggestPromptRenderer.php
@@ -98,7 +98,7 @@ class SuggestPromptRenderer extends Renderer implements Scrolling
             return '';
         }
 
-        return implode(PHP_EOL, $this->scrollbar(
+        return implode("\n", $this->scrollbar(
             array_map(function ($label, $key) use ($prompt) {
                 $label = $this->truncate($label, $prompt->terminal()->cols() - 12);
 

--- a/src/Themes/Default/TableRenderer.php
+++ b/src/Themes/Default/TableRenderer.php
@@ -34,7 +34,7 @@ class TableRenderer extends Renderer
             ->setStyle($tableStyle)
             ->render();
 
-        foreach (explode(PHP_EOL, trim($buffered->content(), PHP_EOL)) as $line) {
+        foreach (explode("\n", trim($buffered->content(), "\n")) as $line) {
             $this->line(' '.$line);
         }
 

--- a/src/Themes/Default/TextareaPromptRenderer.php
+++ b/src/Themes/Default/TextareaPromptRenderer.php
@@ -21,13 +21,13 @@ class TextareaPromptRenderer extends Renderer implements Scrolling
             'submit' => $this
                 ->box(
                     $this->dim($this->truncate($prompt->label, $prompt->width)),
-                    implode(PHP_EOL, $prompt->lines()),
+                    implode("\n", $prompt->lines()),
                 ),
 
             'cancel' => $this
                 ->box(
                     $this->truncate($prompt->label, $prompt->width),
-                    implode(PHP_EOL, array_map(fn ($line) => $this->strikethrough($this->dim($line)), $prompt->lines())),
+                    implode("\n", array_map(fn ($line) => $this->strikethrough($this->dim($line)), $prompt->lines())),
                     color: 'red',
                 )
                 ->error($prompt->cancelMessage),
@@ -68,7 +68,7 @@ class TextareaPromptRenderer extends Renderer implements Scrolling
 
         $longest = $this->longest($prompt->lines()) + 2;
 
-        return implode(PHP_EOL, $this->scrollbar(
+        return implode("\n", $this->scrollbar(
             $visible,
             $prompt->firstVisible,
             $prompt->scroll,

--- a/src/WindowsConsole.php
+++ b/src/WindowsConsole.php
@@ -51,6 +51,15 @@ class WindowsConsole
     private const ENABLE_ECHO_INPUT = 0x0004;
 
     /**
+     * Stripped as well: when the hosting terminal session already enabled
+     * virtual terminal input, _getwch delivers arrow keys as separate
+     * ESC/'['/'A' byte reads instead of scan-code pairs, which degenerates
+     * into literal '[A' text. Removing the flag makes the scan-code path
+     * deterministic regardless of session state.
+     */
+    private const ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200;
+
+    /**
      * Output mode flag requesting interpretation of ANSI escape sequences.
      */
     private const ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
@@ -128,7 +137,7 @@ class WindowsConsole
                 return false;
             }
 
-            $rawInputMode = $this->modeValue($inputMode) & ~(self::ENABLE_PROCESSED_INPUT | self::ENABLE_LINE_INPUT | self::ENABLE_ECHO_INPUT);
+            $rawInputMode = $this->modeValue($inputMode) & ~(self::ENABLE_PROCESSED_INPUT | self::ENABLE_LINE_INPUT | self::ENABLE_ECHO_INPUT | self::ENABLE_VIRTUAL_TERMINAL_INPUT);
 
             if ($this->setMode($kernel32, $this->stdHandle($kernel32, self::STD_INPUT_HANDLE), $rawInputMode) === 0) {
                 return false;

--- a/src/WindowsConsole.php
+++ b/src/WindowsConsole.php
@@ -1,0 +1,338 @@
+<?php
+
+namespace Laravel\Prompts;
+
+use FFI;
+use Throwable;
+
+/**
+ * Native Windows console driver.
+ *
+ * Windows consoles cannot drive Prompts the way Unix terminals do: there
+ * is no stty, and fread(STDIN) on a raw-mode Windows console returns an
+ * empty string immediately instead of blocking. This driver reaches the
+ * operating system directly through FFI instead:
+ *
+ * - kernel32 GetConsoleMode/SetConsoleMode switch stdout into virtual
+ *   terminal processing (so the ANSI sequences Prompts emits are
+ *   interpreted) and strip processed/line/echo input from stdin (so
+ *   keystrokes arrive one at a time, without echo or line buffering).
+ * - msvcrt _getwch performs the blocking single-keystroke read; it is the
+ *   only reliable blocking reader on Windows without implementing a full
+ *   INPUT_RECORD driver. Each keystroke is translated into the same
+ *   sequence a Unix terminal would send, so nothing downstream changes.
+ *
+ * The original console modes are captured by enable() and reapplied by
+ * restore(), which is also registered as a shutdown function so an exit()
+ * cannot leak raw mode into the user's shell.
+ *
+ * Bindings are built lazily on first use, and every FFI interaction is
+ * guarded, so environments without the FFI extension never fatal: enable()
+ * simply returns false and callers fall back. The same applies to pipes
+ * and pseudo terminals such as mintty, where Win32 console APIs do not
+ * apply at all (GetConsoleMode fails there by design).
+ */
+class WindowsConsole
+{
+    /**
+     * The std handle identifiers accepted by GetStdHandle.
+     */
+    private const STD_INPUT_HANDLE = -10;
+
+    private const STD_OUTPUT_HANDLE = -11;
+
+    /**
+     * Input mode flags stripped to obtain unbuffered, unechoed keystrokes.
+     */
+    private const ENABLE_PROCESSED_INPUT = 0x0001;
+
+    private const ENABLE_LINE_INPUT = 0x0002;
+
+    private const ENABLE_ECHO_INPUT = 0x0004;
+
+    /**
+     * Output mode flag requesting interpretation of ANSI escape sequences.
+     */
+    private const ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
+
+    private const KERNEL32_DECLARATIONS = <<<'C'
+        void* GetStdHandle(int handle);
+        int GetConsoleMode(void* h, unsigned int* mode);
+        int SetConsoleMode(void* h, unsigned int mode);
+        C;
+
+    private const MSVCRT_DECLARATIONS = 'int _getwch(void);';
+
+    /**
+     * The kernel32 bindings, built on first use.
+     */
+    protected ?FFI $kernel32 = null;
+
+    /**
+     * The msvcrt bindings, built on first use.
+     */
+    protected ?FFI $msvcrt = null;
+
+    /**
+     * The console input mode captured before raw mode was enabled.
+     */
+    protected ?int $originalInputMode = null;
+
+    /**
+     * The console output mode captured before VT processing was enabled.
+     */
+    protected ?int $originalOutputMode = null;
+
+    /**
+     * Whether this driver currently owns the console configuration.
+     */
+    protected bool $enabled = false;
+
+    /**
+     * Configure the console for Prompts: virtual terminal output and raw,
+     * silent, unbuffered input.
+     *
+     * Returns false when the environment cannot support this driver - no
+     * FFI extension, a non-CLI SAPI, or streams that are not attached to a
+     * real Windows console - signalling callers to fall back. Partial
+     * setups are rolled back to the captured modes.
+     */
+    public function enable(): bool
+    {
+        if ($this->enabled) {
+            return true;
+        }
+
+        if (PHP_OS_FAMILY !== 'Windows' || PHP_SAPI !== 'cli' || ! extension_loaded('ffi')) {
+            return false;
+        }
+
+        $kernel32 = $this->kernel32();
+
+        if ($kernel32 === null) {
+            return false;
+        }
+
+        try {
+            $outputMode = $kernel32->new('unsigned int');
+            $inputMode = $kernel32->new('unsigned int');
+
+            // GetConsoleMode failing is the definitive signal that these
+            // streams are not attached to a real console: redirected pipes
+            // and pseudo terminals such as mintty fail here by design,
+            // leaving the caller to fall back.
+            if (
+                $this->queryMode($kernel32, $this->stdHandle($kernel32, self::STD_OUTPUT_HANDLE), $outputMode) === 0 ||
+                $this->queryMode($kernel32, $this->stdHandle($kernel32, self::STD_INPUT_HANDLE), $inputMode) === 0
+            ) {
+                return false;
+            }
+
+            $rawInputMode = $this->modeValue($inputMode) & ~(self::ENABLE_PROCESSED_INPUT | self::ENABLE_LINE_INPUT | self::ENABLE_ECHO_INPUT);
+
+            if ($this->setMode($kernel32, $this->stdHandle($kernel32, self::STD_INPUT_HANDLE), $rawInputMode) === 0) {
+                return false;
+            }
+
+            if ($this->setMode($kernel32, $this->stdHandle($kernel32, self::STD_OUTPUT_HANDLE), $this->modeValue($outputMode) | self::ENABLE_VIRTUAL_TERMINAL_PROCESSING) === 0) {
+                $this->setMode($kernel32, $this->stdHandle($kernel32, self::STD_INPUT_HANDLE), $this->modeValue($inputMode));
+
+                return false;
+            }
+        } catch (Throwable) {
+            return false;
+        }
+
+        $this->originalOutputMode = $this->modeValue($outputMode);
+        $this->originalInputMode = $this->modeValue($inputMode);
+        $this->enabled = true;
+
+        register_shutdown_function(function (): void {
+            $this->restore();
+        });
+
+        return true;
+    }
+
+    /**
+     * Reapply the console modes captured by enable().
+     *
+     * Errors are swallowed deliberately: teardown must never break the
+     * application, and a console that disappeared mid-run cannot be fixed
+     * from here.
+     */
+    public function restore(): void
+    {
+        if (! $this->enabled) {
+            return;
+        }
+
+        $this->enabled = false;
+
+        $kernel32 = $this->kernel32();
+
+        if ($kernel32 === null) {
+            return;
+        }
+
+        try {
+            $this->setMode($kernel32, $this->stdHandle($kernel32, self::STD_OUTPUT_HANDLE), $this->originalOutputMode ?? 0);
+            $this->setMode($kernel32, $this->stdHandle($kernel32, self::STD_INPUT_HANDLE), $this->originalInputMode ?? 0);
+        } catch (Throwable) {
+            //
+        }
+    }
+
+    /**
+     * Blocking read of a single keystroke, translated into the sequence a
+     * Unix terminal would send.
+     *
+     * fread(STDIN) cannot be used: on a raw-mode Windows console it returns
+     * an empty string immediately instead of blocking. _getwch is the only
+     * reliable blocking reader without an INPUT_RECORD driver. Navigation
+     * keys arrive as prefix-plus-scan-code pairs and unknown pairs are
+     * consumed so the next real keystroke is what gets returned. Typed
+     * characters arrive as UTF-16 code units and are converted to UTF-8 so
+     * non-ASCII input survives.
+     */
+    public function read(): string
+    {
+        $msvcrt = $this->msvcrt();
+
+        if ($msvcrt === null) {
+            return '';
+        }
+
+        for ($attempt = 0; $attempt < 8; $attempt++) {
+            try {
+                $code = $this->nextCode($msvcrt);
+            } catch (Throwable) {
+                return '';
+            }
+
+            // Arrow, editing and function keys are delivered as a two-read
+            // pair: a prefix byte followed by the scan code. Translate the
+            // pair into the escape sequence Prompts already understands.
+            if ($code === 0x00 || $code === 0xE0) {
+                try {
+                    $scan = $this->nextCode($msvcrt);
+                } catch (Throwable) {
+                    return '';
+                }
+
+                $sequence = match ($scan) {
+                    72 => "\e[A",   // up arrow
+                    80 => "\e[B",   // down arrow
+                    77 => "\e[C",   // right arrow
+                    75 => "\e[D",   // left arrow
+                    71 => "\e[H",   // home
+                    79 => "\e[F",   // end
+                    73 => "\e[5~",  // page up
+                    81 => "\e[6~",  // page down
+                    83 => "\e[3~",  // delete
+                    default => '',
+                };
+
+                if ($sequence !== '') {
+                    return $sequence;
+                }
+
+                continue;
+            }
+
+            // Normalize the values Prompts matches by identity, and route
+            // wide characters through UTF-16 to UTF-8 conversion.
+            return match ($code) {
+                13 => "\n",     // enter
+                8 => "\177",    // backspace
+                3 => "\x03",    // ctrl+c
+                27 => "\e",     // escape
+                default => $code > 126
+                    ? mb_convert_encoding(pack('v', $code), 'UTF-8', 'UTF-16LE')
+                    : chr($code),
+            };
+        }
+
+        return '';
+    }
+
+    /**
+     * Build the kernel32 bindings on first use.
+     */
+    protected function kernel32(): ?FFI
+    {
+        return $this->kernel32 ??= $this->bind('kernel32.dll', self::KERNEL32_DECLARATIONS);
+    }
+
+    /**
+     * Build the msvcrt bindings on first use.
+     */
+    protected function msvcrt(): ?FFI
+    {
+        return $this->msvcrt ??= $this->bind('msvcrt.dll', self::MSVCRT_DECLARATIONS);
+    }
+
+    /**
+     * Compile FFI declarations against a library, or null when the FFI
+     * extension is unavailable or refuses the declarations.
+     */
+    protected function bind(string $library, string $declarations): ?FFI
+    {
+        if (! extension_loaded('ffi')) {
+            return null;
+        }
+
+        try {
+            return FFI::cdef($declarations, $library);
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Fetch one of the process std handles. Returns a null pointer, not
+     * null, when the handle does not exist; callers detect that condition
+     * through the failing mode calls instead.
+     */
+    protected function stdHandle(FFI $kernel32, int $handle): mixed
+    {
+        /** @phpstan-ignore-next-line */
+        return $kernel32->GetStdHandle($handle);
+    }
+
+    /**
+     * Read the current console mode into the given unsigned int.
+     */
+    protected function queryMode(FFI $kernel32, mixed $handle, FFI\CData $mode): int
+    {
+        /** @phpstan-ignore-next-line */
+        return $kernel32->GetConsoleMode($handle, FFI::addr($mode));
+    }
+
+    /**
+     * Apply a console mode to the given handle.
+     */
+    protected function setMode(FFI $kernel32, mixed $handle, int $mode): int
+    {
+        /** @phpstan-ignore-next-line */
+        return $kernel32->SetConsoleMode($handle, $mode);
+    }
+
+    /**
+     * Read the integer value held by an unsigned int binding.
+     */
+    protected function modeValue(FFI\CData $mode): int
+    {
+        /** @phpstan-ignore-next-line */
+        return $mode->cdata;
+    }
+
+    /**
+     * Blocking read of the next wide character code from the console.
+     */
+    protected function nextCode(FFI $msvcrt): int
+    {
+        /** @phpstan-ignore-next-line */
+        return $msvcrt->_getwch();
+    }
+}


### PR DESCRIPTION
﻿**TL;DR:** This PR adds native Windows terminal support to laravel/prompts. A small FFI-based console driver (`src/WindowsConsole.php`) provides raw input and VT output, so every prompt surface runs with the real arrow-key UI on Windows 10+ instead of `Prompt::checkEnvironment()` throwing and pushing all Windows users onto WSL or the degraded Symfony fallback. It was built and validated on real Windows 11 hardware across the full prompt matrix. It opens as a stacked PR on top of the `newline-consistency` branch and shows only its own delta; both PRs open as drafts pending maintainer discussion.

## Why

Today `checkEnvironment()` hard-throws whenever `PHP_OS_FAMILY === 'Windows'`. Meanwhile, Windows 10+ consoles (Windows Terminal, conhost) already handle the VT sequences Prompts emits. What is missing is exactly two things: console mode control, and a blocking keystroke reader that works where `stty` and `fread(STDIN)` do not exist. This PR supplies those two pieces and lets the rest of Prompts run unmodified.

## What changes

- **New `src/WindowsConsole.php`:** FFI-based console driver.
  - `kernel32.dll` `GetStdHandle`/`SetConsoleMode`: enables `ENABLE_VIRTUAL_TERMINAL_PROCESSING` on stdout, switches stdin to raw mode (processed/line/echo buffering off), and saves the original modes so they are restored on exit.
  - `msvcrt.dll` `_getwch` blocking reads are translated into the same escape sequences the Unix input paths produce: arrow keys, Home/End/PgUp/PgDn/Delete, Enter becomes `"\n"`, Backspace becomes `"\177"`, and Ctrl+D passes through as `"\x04"`. Wide-character input arrives as UTF-16 code units and is converted to UTF-8, so non-ASCII typing is preserved.
- **`Terminal.php`:** `read()`, `setTty()` and `restoreTty()` become platform-aware and route to `WindowsConsole` on Windows instead of `stty`/`fread`.
- **`Prompt.php` `checkEnvironment()`:** no longer hard-throws on Windows. If console setup fails (old terminals without VT support, restricted environments where `ext-ffi` is disabled), the existing fallback logic applies exactly as before, so degradation stays automatic and safe.

## Limitations and scope

Stated up front, since reviewers will ask:

- Requires the PHP FFI extension and Windows 10+ (for VT processing). Where either is unavailable, setup fails cleanly into the existing Symfony fallback.
- Git Bash/mintty sessions are detected and intentionally left on the Symfony fallback: Win32 console APIs do not apply to mintty pseudo-terminal sessions.
- Shift+modifier chords are not representable via `_getwch` (modifier key state is invisible to it). Chord support would need an `INPUT_RECORD`-based driver later.
- `number()` decimals remain int-only on all platforms. That is upstream `NumberPrompt` design and unrelated to this change.

## Validation

Performed on real Windows 11 hardware over an extended debugging session:

- Full interactive matrix across every prompt surface passed on both Windows Terminal and conhost: text, password, textarea (including multi-line entry, with Enter inserting newlines inside the box), select, suggest, search, multiselect, multisearch, confirm, number and autocomplete; plus the UI helpers (progress, spinner, note, pause).
- Byte-level capture transcripts show clean erase/redraw sequences (e.g. `ESC[1G ESC[15A ESC[J`) with correct adaptive cursor-up counts as frames grow and shrink.
- Captured submitted values match the keystrokes exactly, including multi-line textarea values.

## Stacking and process note

Branch `native-windows-input` is stacked on the branch from #270 and contains its commit; until that PR merges, the diff below shows both changes together, with the driver work concentrated in `src/WindowsConsole.php`, `Terminal.php` and `Prompt.php`. Please review #270 first, as this one relies on its normalized internal separators. **Both PRs open initially as drafts pending discussion in an issue with maintainers - feedback on the overall approach (FFI vs alternatives, the extension requirement, the mintty policy) is welcome before these are marked ready.**
